### PR TITLE
Add Connections view, Purposes view, per-conversation selector (closes #1)

### DIFF
--- a/crates/api-model/src/lib.rs
+++ b/crates/api-model/src/lib.rs
@@ -6,6 +6,8 @@
 //!
 //! Business logic belongs in core/application crates.
 
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -51,24 +53,22 @@ pub enum Command {
     /// Send a content to an existing conversation.
     ///
     /// The response is streamed via [`Event::AssistantDelta`] events.
+    /// An optional `override` selects a specific connection/model/effort for
+    /// this send only; when omitted, the server falls back to (in order) the
+    /// conversation's last selection and the `interactive` purpose.
     SendMessage {
         conversation_id: String,
         content: String,
+        #[serde(default, rename = "override", skip_serializing_if = "Option::is_none")]
+        override_selection: Option<SendPromptOverride>,
     },
 
-    // Settings
-    GetLlmSettings,
-    SetLlmSettings {
-        connector: String,
-        model: Option<String>,
-        base_url: Option<String>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        temperature: Option<f64>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        top_p: Option<f64>,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        max_tokens: Option<u32>,
-    },
+    // Settings (legacy `[llm]`-block single-connection surface).
+    //
+    // The legacy `SetLlmSettings` / `GetLlmSettings` commands have been
+    // removed; use the named-connection commands below (`ListConnections`,
+    // `CreateConnection`, `UpdateConnection`, `DeleteConnection`,
+    // `GetPurposes`, `SetPurpose`) instead.
     SetApiKey {
         api_key: String,
     },
@@ -90,6 +90,45 @@ pub enum Command {
         remote_url: Option<String>,
         remote_name: Option<String>,
         push_on_update: bool,
+    },
+
+    // Named connections (issue #11).
+    /// Enumerate every configured connection with its availability and
+    /// whether credentials are present.
+    ListConnections,
+    /// Create a new named connection; fails on invalid slug or duplicate id.
+    CreateConnection {
+        id: String,
+        config: ConnectionConfigView,
+    },
+    /// Replace an existing connection in-place.
+    UpdateConnection {
+        id: String,
+        config: ConnectionConfigView,
+    },
+    /// Delete a named connection. Refuses with an error when the connection
+    /// is referenced by any purpose unless `force` is true, in which case
+    /// referencing purposes fall back to the `interactive` purpose.
+    DeleteConnection {
+        id: String,
+        #[serde(default)]
+        force: bool,
+    },
+    /// Enumerate models across one or all configured connections. When
+    /// `connection_id` is `None`, aggregates models from every healthy
+    /// connection. `refresh=true` bypasses connector caches (e.g. Bedrock).
+    ListAvailableModels {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        connection_id: Option<String>,
+        #[serde(default)]
+        refresh: bool,
+    },
+
+    // Purposes (issue #10 + #11).
+    GetPurposes,
+    SetPurpose {
+        purpose: PurposeKindApi,
+        config: PurposeConfigView,
     },
 
     // MCP server management
@@ -136,12 +175,15 @@ pub enum CommandResult {
     Messages(MessagesView),
     Cleared { deleted_count: u32 },
 
-    LlmSettings(LlmSettingsView),
     EmbeddingsSettings(EmbeddingsSettingsView),
     ConnectorDefaults(ConnectorDefaultsView),
     PersistenceSettings(PersistenceSettingsView),
 
     McpServers(Vec<McpServerView>),
+
+    Connections(Vec<ConnectionView>),
+    Models(Vec<ModelListing>),
+    Purposes(PurposesView),
 
     Ack,
 }
@@ -187,6 +229,15 @@ pub enum Event {
         conversation_id: String,
         title: String,
     },
+
+    /// A one-time advisory for a conversation (e.g. the stored model
+    /// selection no longer resolves and was cleared). Emitted at most once
+    /// per underlying condition — the server clears the stored state so
+    /// the warning does not recur.
+    ConversationWarningEmitted {
+        conversation_id: String,
+        warning: ConversationWarning,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -196,21 +247,12 @@ pub struct Status {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Config {
-    pub llm: LlmSettingsView,
     pub embeddings: EmbeddingsSettingsView,
     pub persistence: PersistenceSettingsView,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
 pub struct ConfigChanges {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub llm_connector: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub llm_model: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub llm_base_url: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub llm_api_key: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub embeddings_connector: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -225,14 +267,6 @@ pub struct ConfigChanges {
     pub persistence_remote_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub persistence_push_on_update: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub llm_temperature: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub llm_top_p: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub llm_max_tokens: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub llm_hosted_tool_search: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -250,6 +284,25 @@ pub struct ConversationView {
     pub id: String,
     pub title: String,
     pub messages: Vec<MessageView>,
+    /// One-time advisories surfaced after `GetConversation` — e.g. the
+    /// conversation's last model selection no longer resolves and was cleared.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub warnings: Vec<ConversationWarning>,
+}
+
+/// Advisory conditions attached to a conversation view. Modeled as an enum
+/// so additional variants can be added without breaking existing clients.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ConversationWarning {
+    /// The conversation's previous model selection no longer resolves
+    /// (connection removed or model not listed by the connector). The
+    /// selection has been cleared and the server fell back to the
+    /// `fallback_to` target.
+    DanglingModelSelection {
+        previous_selection: ConversationModelSelectionView,
+        fallback_to: ConversationModelSelectionView,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -263,22 +316,6 @@ pub struct MessagesView {
     pub total_raw_count: u32,
     pub truncated: bool,
     pub messages: Vec<MessageView>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-pub struct LlmSettingsView {
-    pub connector: String,
-    pub model: String,
-    pub base_url: String,
-    pub has_api_key: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub temperature: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub top_p: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_tokens: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub hosted_tool_search: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -322,6 +359,215 @@ pub struct McpServerView {
     /// "running" | "stopped" | "disabled"
     pub status: String,
     pub tool_count: u32,
+}
+
+// --- Named-connection views (#11) ------------------------------------------
+
+/// Opaque, protocol-neutral representation of a connection config.
+///
+/// This mirrors the daemon's internal `ConnectionConfig` (one variant per
+/// connector type) but lives here so clients don't need to depend on the
+/// daemon crate. Credentials are represented as `has_credentials` booleans
+/// on the view; raw secret values are never serialized back through the API.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "lowercase", deny_unknown_fields)]
+pub enum ConnectionConfigView {
+    Anthropic {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        base_url: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        api_key_env: Option<String>,
+    },
+    #[serde(rename = "openai")]
+    OpenAi {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        base_url: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        api_key_env: Option<String>,
+    },
+    Bedrock {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        aws_profile: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        region: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        base_url: Option<String>,
+    },
+    Ollama {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        base_url: Option<String>,
+    },
+}
+
+impl ConnectionConfigView {
+    /// Short connector-type identifier (matches the `type =` tag).
+    pub fn connector_type(&self) -> &'static str {
+        match self {
+            Self::Anthropic { .. } => "anthropic",
+            Self::OpenAi { .. } => "openai",
+            Self::Bedrock { .. } => "bedrock",
+            Self::Ollama { .. } => "ollama",
+        }
+    }
+}
+
+/// Availability of a connection in the registry.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "status", rename_all = "snake_case")]
+pub enum ConnectionAvailability {
+    Ok,
+    Unavailable { reason: String },
+}
+
+/// Aggregate view of a single connection for the connections list.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ConnectionView {
+    pub id: String,
+    /// Short connector-type identifier (`"openai"`, `"anthropic"`, etc.).
+    pub connector_type: String,
+    /// Human-friendly label; defaults to `"<id> (<connector_type>)"` but
+    /// daemons can synthesize a more descriptive value.
+    pub display_label: String,
+    pub availability: ConnectionAvailability,
+    /// True when credentials could be resolved during the most recent sanity
+    /// check (env var present, keyring lookup succeeded, or Bedrock/Ollama
+    /// which auth via ambient credentials / none).
+    pub has_credentials: bool,
+}
+
+/// A single model enumerated across one or all connections. Mirrors the
+/// core `ModelInfo` fields while tagging the connection it came from.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ModelListing {
+    pub connection_id: String,
+    pub connection_label: String,
+    pub model: ModelInfoView,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ModelInfoView {
+    pub id: String,
+    pub display_name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_limit: Option<u64>,
+    #[serde(default)]
+    pub capabilities: ModelCapabilitiesView,
+}
+
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ModelCapabilitiesView {
+    #[serde(default)]
+    pub reasoning: bool,
+    #[serde(default)]
+    pub vision: bool,
+    #[serde(default)]
+    pub tools: bool,
+    #[serde(default)]
+    pub embedding: bool,
+}
+
+// --- Purpose views (#10 + #11) --------------------------------------------
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum PurposeKindApi {
+    Interactive,
+    Dreaming,
+    Embedding,
+    Titling,
+}
+
+impl PurposeKindApi {
+    pub fn as_key(self) -> &'static str {
+        match self {
+            Self::Interactive => "interactive",
+            Self::Dreaming => "dreaming",
+            Self::Embedding => "embedding",
+            Self::Titling => "titling",
+        }
+    }
+}
+
+/// Effort hint passed to connectors (mapped at dispatch time).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum EffortLevel {
+    Low,
+    Medium,
+    High,
+}
+
+/// Protocol-neutral purpose config. String `"primary"` in the connection or
+/// model field means "inherit from interactive" — the daemon resolves this
+/// before dispatch (see `crates/daemon/src/purposes.rs`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct PurposeConfigView {
+    /// Either a connection id (slug) or the literal string `"primary"`.
+    pub connection: String,
+    /// Either a model id or the literal string `"primary"`.
+    pub model: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effort: Option<EffortLevel>,
+}
+
+/// Aggregate purpose view. Missing entries mean the purpose is not
+/// configured (the daemon falls back to the primary LLM for those).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct PurposesView {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub interactive: Option<PurposeConfigView>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dreaming: Option<PurposeConfigView>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub embedding: Option<PurposeConfigView>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub titling: Option<PurposeConfigView>,
+}
+
+impl PurposesView {
+    /// Convenience: convert into a BTreeMap keyed by purpose key for clients
+    /// that prefer iteration.
+    pub fn to_map(&self) -> BTreeMap<String, PurposeConfigView> {
+        let mut map = BTreeMap::new();
+        if let Some(v) = &self.interactive {
+            map.insert("interactive".to_string(), v.clone());
+        }
+        if let Some(v) = &self.dreaming {
+            map.insert("dreaming".to_string(), v.clone());
+        }
+        if let Some(v) = &self.embedding {
+            map.insert("embedding".to_string(), v.clone());
+        }
+        if let Some(v) = &self.titling {
+            map.insert("titling".to_string(), v.clone());
+        }
+        map
+    }
+}
+
+// --- Per-send model override (#11) ----------------------------------------
+
+/// Caller-supplied override for a single `SendMessage` (or `SendPrompt`)
+/// call. The daemon validates that `connection_id` is live and that the
+/// connector lists `model_id`; otherwise the request is rejected with a
+/// 400-style error.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SendPromptOverride {
+    pub connection_id: String,
+    pub model_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effort: Option<EffortLevel>,
+}
+
+/// View of a conversation's stored model selection. Same shape as
+/// [`SendPromptOverride`] minus the "this is a request" framing.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ConversationModelSelectionView {
+    pub connection_id: String,
+    pub model_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effort: Option<EffortLevel>,
 }
 
 /// WebSocket request envelope.
@@ -376,7 +622,6 @@ mod tests {
     fn command_json_roundtrip_set_config() {
         let cmd = Command::SetConfig {
             changes: ConfigChanges {
-                llm_connector: Some("openai".into()),
                 persistence_enabled: Some(true),
                 ..Default::default()
             },
@@ -384,5 +629,185 @@ mod tests {
         let json = serde_json::to_string(&cmd).unwrap();
         let back: Command = serde_json::from_str(&json).unwrap();
         assert_eq!(cmd, back);
+    }
+
+    #[test]
+    fn list_connections_roundtrip() {
+        let cmd = Command::ListConnections;
+        let json = serde_json::to_string(&cmd).unwrap();
+        assert!(json.contains("list_connections"));
+        let back: Command = serde_json::from_str(&json).unwrap();
+        assert_eq!(cmd, back);
+    }
+
+    #[test]
+    fn create_connection_roundtrip_openai() {
+        let cmd = Command::CreateConnection {
+            id: "work".into(),
+            config: ConnectionConfigView::OpenAi {
+                base_url: Some("https://api.openai.com/v1".into()),
+                api_key_env: Some("OPENAI_WORK_KEY".into()),
+            },
+        };
+        let json = serde_json::to_string(&cmd).unwrap();
+        let back: Command = serde_json::from_str(&json).unwrap();
+        assert_eq!(cmd, back);
+    }
+
+    #[test]
+    fn connection_config_view_tagged_type() {
+        let c = ConnectionConfigView::Bedrock {
+            aws_profile: Some("work".into()),
+            region: Some("us-west-2".into()),
+            base_url: None,
+        };
+        let json = serde_json::to_string(&c).unwrap();
+        assert!(json.contains("\"type\":\"bedrock\""));
+        assert_eq!(c.connector_type(), "bedrock");
+        let back: ConnectionConfigView = serde_json::from_str(&json).unwrap();
+        assert_eq!(c, back);
+    }
+
+    #[test]
+    fn delete_connection_force_flag() {
+        let cmd = Command::DeleteConnection {
+            id: "old".into(),
+            force: true,
+        };
+        let json = serde_json::to_string(&cmd).unwrap();
+        let back: Command = serde_json::from_str(&json).unwrap();
+        assert_eq!(cmd, back);
+
+        // Missing force flag defaults to false.
+        let cmd2: Command =
+            serde_json::from_str(r#"{"delete_connection":{"id":"old"}}"#).unwrap();
+        assert_eq!(
+            cmd2,
+            Command::DeleteConnection {
+                id: "old".into(),
+                force: false,
+            }
+        );
+    }
+
+    #[test]
+    fn list_available_models_optional_connection_and_refresh() {
+        // Both fields omitted.
+        let cmd: Command = serde_json::from_str(r#"{"list_available_models":{}}"#).unwrap();
+        assert_eq!(
+            cmd,
+            Command::ListAvailableModels {
+                connection_id: None,
+                refresh: false,
+            }
+        );
+
+        // All fields present.
+        let cmd2 = Command::ListAvailableModels {
+            connection_id: Some("aws".into()),
+            refresh: true,
+        };
+        let json = serde_json::to_string(&cmd2).unwrap();
+        let back: Command = serde_json::from_str(&json).unwrap();
+        assert_eq!(cmd2, back);
+    }
+
+    #[test]
+    fn set_purpose_roundtrip() {
+        let cmd = Command::SetPurpose {
+            purpose: PurposeKindApi::Dreaming,
+            config: PurposeConfigView {
+                connection: "primary".into(),
+                model: "primary".into(),
+                effort: Some(EffortLevel::Low),
+            },
+        };
+        let json = serde_json::to_string(&cmd).unwrap();
+        let back: Command = serde_json::from_str(&json).unwrap();
+        assert_eq!(cmd, back);
+    }
+
+    #[test]
+    fn send_message_override_is_optional() {
+        // Without override.
+        let cmd: Command = serde_json::from_str(
+            r#"{"send_message":{"conversation_id":"c1","content":"hi"}}"#,
+        )
+        .unwrap();
+        match &cmd {
+            Command::SendMessage {
+                override_selection, ..
+            } => assert!(override_selection.is_none()),
+            other => panic!("unexpected {other:?}"),
+        }
+
+        // With override.
+        let cmd2 = Command::SendMessage {
+            conversation_id: "c1".into(),
+            content: "hi".into(),
+            override_selection: Some(SendPromptOverride {
+                connection_id: "aws".into(),
+                model_id: "claude-sonnet-4".into(),
+                effort: Some(EffortLevel::High),
+            }),
+        };
+        let json = serde_json::to_string(&cmd2).unwrap();
+        assert!(json.contains("\"override\":"));
+        let back: Command = serde_json::from_str(&json).unwrap();
+        assert_eq!(cmd2, back);
+    }
+
+    #[test]
+    fn effort_serialize_lowercase() {
+        assert_eq!(serde_json::to_string(&EffortLevel::Low).unwrap(), "\"low\"");
+        assert_eq!(
+            serde_json::to_string(&EffortLevel::Medium).unwrap(),
+            "\"medium\""
+        );
+        assert_eq!(
+            serde_json::to_string(&EffortLevel::High).unwrap(),
+            "\"high\""
+        );
+    }
+
+    #[test]
+    fn conversation_view_warnings_default_empty() {
+        let json = r#"{"id":"c1","title":"t","messages":[]}"#;
+        let v: ConversationView = serde_json::from_str(json).unwrap();
+        assert!(v.warnings.is_empty());
+    }
+
+    #[test]
+    fn conversation_warning_dangling_selection_roundtrip() {
+        let w = ConversationWarning::DanglingModelSelection {
+            previous_selection: ConversationModelSelectionView {
+                connection_id: "old".into(),
+                model_id: "gone".into(),
+                effort: None,
+            },
+            fallback_to: ConversationModelSelectionView {
+                connection_id: "work".into(),
+                model_id: "gpt-5".into(),
+                effort: Some(EffortLevel::Medium),
+            },
+        };
+        let json = serde_json::to_string(&w).unwrap();
+        assert!(json.contains("\"type\":\"dangling_model_selection\""));
+        let back: ConversationWarning = serde_json::from_str(&json).unwrap();
+        assert_eq!(w, back);
+    }
+
+    #[test]
+    fn connection_availability_tagged() {
+        let ok = ConnectionAvailability::Ok;
+        let json = serde_json::to_string(&ok).unwrap();
+        assert!(json.contains("\"status\":\"ok\""));
+        let un = ConnectionAvailability::Unavailable {
+            reason: "x".into(),
+        };
+        let json2 = serde_json::to_string(&un).unwrap();
+        assert!(json2.contains("\"status\":\"unavailable\""));
+        let back: ConnectionAvailability = serde_json::from_str(&json2).unwrap();
+        assert_eq!(un, back);
     }
 }

--- a/crates/client-common/src/dbus_client.rs
+++ b/crates/client-common/src/dbus_client.rs
@@ -150,6 +150,8 @@ impl DbusClient {
                 .into_iter()
                 .map(|(role, content)| ChatMessage { role, content })
                 .collect(),
+            // D-Bus ConversationsProxy predates ConversationWarning; no warnings surface here.
+            warnings: Vec::new(),
         })
     }
 

--- a/crates/client-common/src/lib.rs
+++ b/crates/client-common/src/lib.rs
@@ -8,6 +8,7 @@ pub mod types;
 pub mod ws_client;
 
 pub use config::{ConnectionConfig, TransportMode};
+pub use desktop_assistant_api_model as api;
 pub use signal::SignalEvent;
 pub use transport::{AssistantClient, TransportClient, connect_transport};
 pub use types::{ChatMessage, ConversationDetail, ConversationSummary};

--- a/crates/client-common/src/signal.rs
+++ b/crates/client-common/src/signal.rs
@@ -1,3 +1,5 @@
+use desktop_assistant_api_model as api;
+
 #[derive(Debug)]
 pub enum SignalEvent {
     Chunk {
@@ -19,6 +21,12 @@ pub enum SignalEvent {
     TitleChanged {
         conversation_id: String,
         title: String,
+    },
+    /// One-time advisory about a conversation — e.g. its stored model
+    /// selection no longer resolves and was cleared.
+    ConversationWarning {
+        conversation_id: String,
+        warning: api::ConversationWarning,
     },
     Disconnected {
         reason: String,

--- a/crates/client-common/src/transport.rs
+++ b/crates/client-common/src/transport.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use async_trait::async_trait;
+use desktop_assistant_api_model as api;
 use tokio::sync::mpsc;
 
 use crate::auth::resolve_ws_bearer_token;
@@ -19,12 +20,43 @@ pub trait AssistantClient: Send + Sync {
     async fn archive_conversation(&self, id: &str) -> Result<()>;
     async fn unarchive_conversation(&self, id: &str) -> Result<()>;
     async fn send_prompt(&self, conversation_id: &str, prompt: &str) -> Result<String>;
+    async fn send_prompt_with_override(
+        &self,
+        conversation_id: &str,
+        prompt: &str,
+        override_selection: Option<api::SendPromptOverride>,
+    ) -> Result<String>;
+
+    // Named-connection / purposes / models API (issue #11). Only the WS
+    // transport implements these today — the D-Bus adapter predates the
+    // multi-connection API surface and still speaks the legacy commands.
+    async fn list_connections(&self) -> Result<Vec<api::ConnectionView>>;
+    async fn create_connection(&self, id: &str, config: api::ConnectionConfigView) -> Result<()>;
+    async fn update_connection(&self, id: &str, config: api::ConnectionConfigView) -> Result<()>;
+    async fn delete_connection(&self, id: &str, force: bool) -> Result<()>;
+    async fn list_available_models(
+        &self,
+        connection_id: Option<&str>,
+        refresh: bool,
+    ) -> Result<Vec<api::ModelListing>>;
+    async fn get_purposes(&self) -> Result<api::PurposesView>;
+    async fn set_purpose(
+        &self,
+        purpose: api::PurposeKindApi,
+        config: api::PurposeConfigView,
+    ) -> Result<()>;
 }
 
 pub enum TransportClient {
     #[cfg(feature = "dbus")]
     Dbus(crate::dbus_client::DbusClient),
     Ws(WsClient),
+}
+
+fn multi_connection_unsupported<T>(op: &str) -> Result<T> {
+    Err(anyhow::anyhow!(
+        "{op} is not supported over D-Bus — connect with --transport=ws to manage connections"
+    ))
 }
 
 #[async_trait]
@@ -98,6 +130,92 @@ impl AssistantClient for TransportClient {
             #[cfg(feature = "dbus")]
             Self::Dbus(client) => client.send_prompt(conversation_id, prompt).await,
             Self::Ws(client) => client.send_prompt(conversation_id, prompt).await,
+        }
+    }
+
+    async fn send_prompt_with_override(
+        &self,
+        conversation_id: &str,
+        prompt: &str,
+        override_selection: Option<api::SendPromptOverride>,
+    ) -> Result<String> {
+        match self {
+            #[cfg(feature = "dbus")]
+            Self::Dbus(client) => {
+                // D-Bus does not plumb the override today; fall back to the
+                // un-overridden send so the message still reaches the daemon.
+                let _ = override_selection;
+                client.send_prompt(conversation_id, prompt).await
+            }
+            Self::Ws(client) => {
+                client
+                    .send_prompt_with_override(conversation_id, prompt, override_selection)
+                    .await
+            }
+        }
+    }
+
+    async fn list_connections(&self) -> Result<Vec<api::ConnectionView>> {
+        match self {
+            #[cfg(feature = "dbus")]
+            Self::Dbus(_) => multi_connection_unsupported("list_connections"),
+            Self::Ws(client) => client.list_connections().await,
+        }
+    }
+
+    async fn create_connection(&self, id: &str, config: api::ConnectionConfigView) -> Result<()> {
+        match self {
+            #[cfg(feature = "dbus")]
+            Self::Dbus(_) => multi_connection_unsupported("create_connection"),
+            Self::Ws(client) => client.create_connection(id, config).await,
+        }
+    }
+
+    async fn update_connection(&self, id: &str, config: api::ConnectionConfigView) -> Result<()> {
+        match self {
+            #[cfg(feature = "dbus")]
+            Self::Dbus(_) => multi_connection_unsupported("update_connection"),
+            Self::Ws(client) => client.update_connection(id, config).await,
+        }
+    }
+
+    async fn delete_connection(&self, id: &str, force: bool) -> Result<()> {
+        match self {
+            #[cfg(feature = "dbus")]
+            Self::Dbus(_) => multi_connection_unsupported("delete_connection"),
+            Self::Ws(client) => client.delete_connection(id, force).await,
+        }
+    }
+
+    async fn list_available_models(
+        &self,
+        connection_id: Option<&str>,
+        refresh: bool,
+    ) -> Result<Vec<api::ModelListing>> {
+        match self {
+            #[cfg(feature = "dbus")]
+            Self::Dbus(_) => multi_connection_unsupported("list_available_models"),
+            Self::Ws(client) => client.list_available_models(connection_id, refresh).await,
+        }
+    }
+
+    async fn get_purposes(&self) -> Result<api::PurposesView> {
+        match self {
+            #[cfg(feature = "dbus")]
+            Self::Dbus(_) => multi_connection_unsupported("get_purposes"),
+            Self::Ws(client) => client.get_purposes().await,
+        }
+    }
+
+    async fn set_purpose(
+        &self,
+        purpose: api::PurposeKindApi,
+        config: api::PurposeConfigView,
+    ) -> Result<()> {
+        match self {
+            #[cfg(feature = "dbus")]
+            Self::Dbus(_) => multi_connection_unsupported("set_purpose"),
+            Self::Ws(client) => client.set_purpose(purpose, config).await,
         }
     }
 }

--- a/crates/client-common/src/types.rs
+++ b/crates/client-common/src/types.rs
@@ -19,6 +19,8 @@ pub struct ConversationDetail {
     pub id: String,
     pub title: String,
     pub messages: Vec<ChatMessage>,
+    /// One-time advisories surfaced by the daemon after `GetConversation`.
+    pub warnings: Vec<api::ConversationWarning>,
 }
 
 impl From<api::ConversationSummary> for ConversationSummary {
@@ -47,6 +49,7 @@ impl From<api::ConversationView> for ConversationDetail {
             id: value.id,
             title: value.title,
             messages: value.messages.into_iter().map(ChatMessage::from).collect(),
+            warnings: value.warnings,
         }
     }
 }

--- a/crates/client-common/src/ws_client.rs
+++ b/crates/client-common/src/ws_client.rs
@@ -3,8 +3,8 @@ use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::{Result, anyhow};
-use desktop_assistant_api_model as api;
 use api::{WsFrame, WsRequest};
+use desktop_assistant_api_model as api;
 use futures::{SinkExt, StreamExt};
 use tokio::sync::{Mutex, mpsc, oneshot};
 use tokio_tungstenite::tungstenite::Message;
@@ -255,10 +255,26 @@ impl WsClient {
     }
 
     pub async fn send_prompt(&self, conversation_id: &str, prompt: &str) -> Result<String> {
+        self.send_prompt_with_override(conversation_id, prompt, None)
+            .await
+    }
+
+    /// Send a prompt, optionally pinning it to a specific connection/model/effort.
+    ///
+    /// The daemon persists the override on the conversation row so subsequent
+    /// sends without an override still target the same model (until it is
+    /// changed again or the referenced connection goes away).
+    pub async fn send_prompt_with_override(
+        &self,
+        conversation_id: &str,
+        prompt: &str,
+        override_selection: Option<api::SendPromptOverride>,
+    ) -> Result<String> {
         let result = self
             .send_command(api::Command::SendMessage {
                 conversation_id: conversation_id.to_string(),
                 content: prompt.to_string(),
+                override_selection,
             })
             .await?;
         let api::CommandResult::Ack = result else {
@@ -267,6 +283,112 @@ impl WsClient {
 
         // WS send-message ack does not include request id; first stream event carries it.
         Ok(String::new())
+    }
+
+    // --- Multi-connection API (issue #11 / TUI issue #1) -------------------
+
+    pub async fn list_connections(&self) -> Result<Vec<api::ConnectionView>> {
+        let result = self.send_command(api::Command::ListConnections).await?;
+        let api::CommandResult::Connections(items) = result else {
+            return Err(anyhow!(
+                "unexpected websocket response for list_connections"
+            ));
+        };
+        Ok(items)
+    }
+
+    pub async fn create_connection(
+        &self,
+        id: &str,
+        config: api::ConnectionConfigView,
+    ) -> Result<()> {
+        let result = self
+            .send_command(api::Command::CreateConnection {
+                id: id.to_string(),
+                config,
+            })
+            .await?;
+        let api::CommandResult::Ack = result else {
+            return Err(anyhow!(
+                "unexpected websocket response for create_connection"
+            ));
+        };
+        Ok(())
+    }
+
+    pub async fn update_connection(
+        &self,
+        id: &str,
+        config: api::ConnectionConfigView,
+    ) -> Result<()> {
+        let result = self
+            .send_command(api::Command::UpdateConnection {
+                id: id.to_string(),
+                config,
+            })
+            .await?;
+        let api::CommandResult::Ack = result else {
+            return Err(anyhow!(
+                "unexpected websocket response for update_connection"
+            ));
+        };
+        Ok(())
+    }
+
+    pub async fn delete_connection(&self, id: &str, force: bool) -> Result<()> {
+        let result = self
+            .send_command(api::Command::DeleteConnection {
+                id: id.to_string(),
+                force,
+            })
+            .await?;
+        let api::CommandResult::Ack = result else {
+            return Err(anyhow!(
+                "unexpected websocket response for delete_connection"
+            ));
+        };
+        Ok(())
+    }
+
+    pub async fn list_available_models(
+        &self,
+        connection_id: Option<&str>,
+        refresh: bool,
+    ) -> Result<Vec<api::ModelListing>> {
+        let result = self
+            .send_command(api::Command::ListAvailableModels {
+                connection_id: connection_id.map(str::to_string),
+                refresh,
+            })
+            .await?;
+        let api::CommandResult::Models(items) = result else {
+            return Err(anyhow!(
+                "unexpected websocket response for list_available_models"
+            ));
+        };
+        Ok(items)
+    }
+
+    pub async fn get_purposes(&self) -> Result<api::PurposesView> {
+        let result = self.send_command(api::Command::GetPurposes).await?;
+        let api::CommandResult::Purposes(view) = result else {
+            return Err(anyhow!("unexpected websocket response for get_purposes"));
+        };
+        Ok(view)
+    }
+
+    pub async fn set_purpose(
+        &self,
+        purpose: api::PurposeKindApi,
+        config: api::PurposeConfigView,
+    ) -> Result<()> {
+        let result = self
+            .send_command(api::Command::SetPurpose { purpose, config })
+            .await?;
+        let api::CommandResult::Ack = result else {
+            return Err(anyhow!("unexpected websocket response for set_purpose"));
+        };
+        Ok(())
     }
 }
 
@@ -324,6 +446,13 @@ pub fn map_event_to_signal(event: api::Event) -> Option<SignalEvent> {
             request_id,
             message,
         }),
+        api::Event::ConversationWarningEmitted {
+            conversation_id,
+            warning,
+        } => Some(SignalEvent::ConversationWarning {
+            conversation_id,
+            warning,
+        }),
         api::Event::ConfigChanged { .. } => None,
     }
 }
@@ -366,19 +495,29 @@ mod tests {
     }
 
     #[test]
-    fn ignores_non_stream_config_events() {
+    fn maps_conversation_warning_event() {
+        let event = map_event_to_signal(api::Event::ConversationWarningEmitted {
+            conversation_id: "c1".to_string(),
+            warning: api::ConversationWarning::DanglingModelSelection {
+                previous_selection: api::ConversationModelSelectionView {
+                    connection_id: "old".into(),
+                    model_id: "gone".into(),
+                    effort: None,
+                },
+                fallback_to: api::ConversationModelSelectionView {
+                    connection_id: "work".into(),
+                    model_id: "gpt-5".into(),
+                    effort: None,
+                },
+            },
+        });
+        assert!(matches!(event, Some(SignalEvent::ConversationWarning { .. })));
+    }
+
+    #[test]
+    fn ignores_config_changed_event() {
         let event = map_event_to_signal(api::Event::ConfigChanged {
             config: api::Config {
-                llm: api::LlmSettingsView {
-                    connector: "openai".to_string(),
-                    model: "gpt-5.4".to_string(),
-                    base_url: "https://api.openai.com/v1".to_string(),
-                    has_api_key: true,
-                    temperature: None,
-                    top_p: None,
-                    max_tokens: None,
-                    hosted_tool_search: None,
-                },
                 embeddings: api::EmbeddingsSettingsView {
                     connector: "openai".to_string(),
                     model: "text-embedding-3-small".to_string(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,9 @@
 pub use desktop_assistant_client_common::{ChatMessage, ConversationDetail, ConversationSummary};
+use desktop_assistant_client_common::api;
 use ratatui::style::Style;
 use tui_textarea::{CursorMove, TextArea};
+
+use crate::views::{ConnectionsView, ConversationSelections, ModelSelector, PurposesView};
 
 fn new_textarea() -> TextArea<'static> {
     let mut ta = TextArea::default();
@@ -64,6 +67,15 @@ pub enum InputMode {
     Editing,
 }
 
+/// Top-level screen shown to the user. The chat list + chat panel live under
+/// `Chat`; the other two are settings screens reachable via `S`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Screen {
+    Chat,
+    Connections,
+    Purposes,
+}
+
 pub struct App {
     pub conversations: Vec<ConversationSummary>,
     pub selected_conversation: Option<usize>,
@@ -78,6 +90,16 @@ pub struct App {
     pub scroll_offset: u16,
     /// Whether to include archived conversations in the list.
     pub show_archived: bool,
+
+    // --- Multi-connection additions (issue #1) ---
+    pub screen: Screen,
+    pub connections_view: ConnectionsView,
+    pub purposes_view: PurposesView,
+    pub model_selector: ModelSelector,
+    pub conversation_selections: ConversationSelections,
+    /// One-line inline advisory shown above the status bar (e.g. dangling
+    /// model selection). Cleared on the next status update.
+    pub inline_notice: Option<String>,
 }
 
 impl App {
@@ -96,6 +118,13 @@ impl App {
             should_quit: false,
             scroll_offset: 0,
             show_archived: false,
+
+            screen: Screen::Chat,
+            connections_view: ConnectionsView::default(),
+            purposes_view: PurposesView::default(),
+            model_selector: ModelSelector::default(),
+            conversation_selections: ConversationSelections::default(),
+            inline_notice: None,
         }
     }
 
@@ -158,8 +187,10 @@ impl App {
         self.textarea.lines().join("\n")
     }
 
-    /// Returns (conversation_id, prompt) if valid, None otherwise.
-    pub fn submit_prompt(&mut self) -> Option<(String, String)> {
+    /// Returns (conversation_id, prompt, optional override) if valid,
+    /// None otherwise. The override reflects the user's current per-
+    /// conversation selection (mutable-sticky).
+    pub fn submit_prompt(&mut self) -> Option<(String, String, Option<api::SendPromptOverride>)> {
         let content = self.textarea_content();
         if content.is_empty() {
             return None;
@@ -171,7 +202,8 @@ impl App {
         });
         self.textarea = new_textarea();
         self.scroll_offset = 0;
-        Some((conv.id.clone(), content))
+        let override_sel = self.conversation_selections.get(&conv.id).cloned();
+        Some((conv.id.clone(), content, override_sel))
     }
 
     /// Hard-wrap textarea lines to fit the available editor width.
@@ -309,7 +341,84 @@ impl App {
     }
 
     pub fn load_conversation(&mut self, detail: ConversationDetail) {
+        // Absorb any warnings the daemon attached — e.g. a stored model
+        // selection no longer resolves — and surface them as an inline notice
+        // above the status bar.
+        for warning in &detail.warnings {
+            self.apply_conversation_warning(&detail.id, warning);
+        }
         self.current_conversation = Some(detail);
+    }
+
+    /// Handle a `ConversationWarningEmitted` event (or a warning attached to
+    /// `GetConversation`). Updates the in-app selection cache where the daemon
+    /// fell back and shows an inline notice.
+    pub fn apply_conversation_warning(
+        &mut self,
+        conversation_id: &str,
+        warning: &api::ConversationWarning,
+    ) {
+        self.inline_notice = Some(crate::views::selector::warning_notice(warning));
+        match warning {
+            api::ConversationWarning::DanglingModelSelection { fallback_to, .. } => {
+                self.conversation_selections
+                    .hydrate_from_dangling_fallback(conversation_id, fallback_to);
+            }
+        }
+    }
+
+    /// The override for the currently-loaded conversation (for status bar).
+    pub fn current_selection_label(&self) -> String {
+        let sel = self
+            .current_conversation
+            .as_ref()
+            .and_then(|c| self.conversation_selections.get(&c.id));
+        crate::views::selector::status_bar_label(sel)
+    }
+
+    /// Commit the highlighted model selector row to the per-conversation map,
+    /// closing the popup. Returns true iff a pinned (non-Auto) row was picked.
+    pub fn apply_model_selection(&mut self) -> bool {
+        let Some(conv) = self.current_conversation.as_ref() else {
+            self.model_selector.close();
+            return false;
+        };
+        let conv_id = conv.id.clone();
+        match self.model_selector.selected_entry() {
+            Some(entry) => {
+                let sel = api::SendPromptOverride {
+                    connection_id: entry.connection_id.clone(),
+                    model_id: entry.model.id.clone(),
+                    effort: None,
+                };
+                self.conversation_selections.set(conv_id, sel);
+                self.model_selector.close();
+                true
+            }
+            None => {
+                // Auto row — clear any pinned selection.
+                self.conversation_selections.clear(&conv_id);
+                self.model_selector.close();
+                false
+            }
+        }
+    }
+
+    pub fn switch_to_chat(&mut self) {
+        self.screen = Screen::Chat;
+        self.connections_view.close_overlay();
+        self.purposes_view.close_editor();
+        self.model_selector.close();
+    }
+
+    pub fn switch_to_connections(&mut self) {
+        self.screen = Screen::Connections;
+        self.mode = InputMode::Normal;
+    }
+
+    pub fn switch_to_purposes(&mut self) {
+        self.screen = Screen::Purposes;
+        self.mode = InputMode::Normal;
     }
 
     pub fn update_conversation_title(&mut self, conversation_id: &str, title: &str) {
@@ -559,6 +668,7 @@ mod tests {
             id: "1".into(),
             title: "Test".into(),
             messages: vec![],
+    warnings: vec![],
         });
         assert!(app.submit_prompt().is_none());
     }
@@ -570,13 +680,14 @@ mod tests {
             id: "conv1".into(),
             title: "Test".into(),
             messages: vec![],
+            warnings: vec![],
         });
         app.textarea.insert_str("What is Rust?");
 
         let result = app.submit_prompt();
         assert_eq!(
             result,
-            Some(("conv1".to_string(), "What is Rust?".to_string()))
+            Some(("conv1".to_string(), "What is Rust?".to_string(), None))
         );
         assert_eq!(app.textarea_content(), "");
 
@@ -584,6 +695,30 @@ mod tests {
         assert_eq!(msgs.len(), 1);
         assert_eq!(msgs[0].role, "user");
         assert_eq!(msgs[0].content, "What is Rust?");
+    }
+
+    #[test]
+    fn submit_prompt_includes_override_when_selection_is_set() {
+        let mut app = App::new();
+        app.current_conversation = Some(ConversationDetail {
+            id: "conv1".into(),
+            title: "Test".into(),
+            messages: vec![],
+            warnings: vec![],
+        });
+        app.conversation_selections.set(
+            "conv1".into(),
+            api::SendPromptOverride {
+                connection_id: "work".into(),
+                model_id: "gpt-5".into(),
+                effort: Some(api::EffortLevel::High),
+            },
+        );
+        app.textarea.insert_str("hi");
+        let (_, _, ov) = app.submit_prompt().unwrap();
+        let ov = ov.expect("override should be threaded through");
+        assert_eq!(ov.connection_id, "work");
+        assert_eq!(ov.effort, Some(api::EffortLevel::High));
     }
 
     // --- Streaming tests ---
@@ -595,6 +730,7 @@ mod tests {
             id: "c1".into(),
             title: "Test".into(),
             messages: vec![],
+    warnings: vec![],
         });
 
         app.start_streaming("req1".into());
@@ -621,6 +757,7 @@ mod tests {
             id: "c1".into(),
             title: "Test".into(),
             messages: vec![],
+    warnings: vec![],
         });
 
         app.start_streaming("req1".into());
@@ -648,6 +785,7 @@ mod tests {
             id: "c1".into(),
             title: "Test".into(),
             messages: vec![],
+    warnings: vec![],
         });
 
         app.start_streaming_without_request_id();
@@ -727,6 +865,7 @@ mod tests {
             id: "2".into(),
             title: "Second".into(),
             messages: vec![],
+    warnings: vec![],
         });
 
         let deleted = app.delete_selected_conversation();
@@ -816,6 +955,7 @@ mod tests {
             id: "c1".into(),
             title: "Test".into(),
             messages: vec![],
+    warnings: vec![],
         });
         app.scroll_up(10);
         app.textarea.insert_str("hello");

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,16 +1,24 @@
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-use crate::app::InputMode;
+use crate::app::{App, InputMode, Screen};
 
+/// High-level actions the main loop can dispatch. The dispatch table lives in
+/// `handle_action` (main.rs); this module only decides "what semantic action
+/// does this keystroke mean *right now*". The `right now` depends on the
+/// active [`Screen`], any overlay popup, and the textarea's [`InputMode`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Action {
     Quit,
+
+    // Chat-list navigation
     NextConversation,
     PreviousConversation,
     OpenConversation,
     DeleteConversation,
     ArchiveConversation,
     NewConversation,
+
+    // Chat input / streaming
     EnterEditMode,
     ExitEditMode,
     SubmitPrompt,
@@ -19,17 +27,81 @@ pub enum Action {
     ScrollDown,
     ScrollToBottom,
     ToggleShowArchived,
+
+    // Screen switches
+    OpenConnectionsView,
+    OpenPurposesView,
+    BackToChat,
+
+    // Connections view
+    ConnectionsNext,
+    ConnectionsPrevious,
+    ConnectionsAdd,
+    ConnectionsConfigure,
+    ConnectionsRemove,
+    ConnectionsRefreshModels,
+    ConnectionsFormSubmit,
+    ConnectionsFormCancel,
+    ConnectionsFormNextField,
+    ConnectionsFormPreviousField,
+    ConnectionsFormCycleKindNext,
+    ConnectionsFormCycleKindPrev,
+    ConnectionsFormInsertChar(char),
+    ConnectionsFormBackspace,
+    ConnectionsFormToggleAutoPull,
+    ConnectionsDeleteConfirm,
+    ConnectionsDeleteForce,
+    ConnectionsDeleteCancel,
+
+    // Purposes view
+    PurposesNext,
+    PurposesPrevious,
+    PurposesEdit,
+    PurposesEditorSubmit,
+    PurposesEditorCancel,
+    PurposesEditorNextField,
+    PurposesEditorPreviousField,
+    PurposesEditorInsertChar(char),
+    PurposesEditorBackspace,
+
+    // Model selector popup
+    OpenModelSelector,
+    ModelSelectorNext,
+    ModelSelectorPrevious,
+    ModelSelectorConfirm,
+    ModelSelectorCancel,
+    ModelSelectorRefresh,
 }
 
-/// Handle key events that we intercept before passing to textarea.
-/// Returns None for keys that should be forwarded to textarea.input().
-pub fn handle_key_event(key: KeyEvent, mode: &InputMode) -> Option<Action> {
+/// Route a key event to an action, given the app's current screen / overlay
+/// / input mode. Returns `None` for keys that should be forwarded to the
+/// underlying widget (textarea) or ignored outright.
+pub fn route_key(key: KeyEvent, app: &App) -> Option<Action> {
+    // Ctrl-M always opens the model selector from the chat screen.
+    let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+    if ctrl && key.code == KeyCode::Char('m') && matches!(app.screen, Screen::Chat) {
+        return Some(Action::OpenModelSelector);
+    }
+
+    // Model selector popup grabs every key when it's open.
+    if app.model_selector.open {
+        return route_model_selector(key);
+    }
+
+    match app.screen {
+        Screen::Chat => route_chat(key, app),
+        Screen::Connections => route_connections(key, app),
+        Screen::Purposes => route_purposes(key, app),
+    }
+}
+
+fn route_chat(key: KeyEvent, app: &App) -> Option<Action> {
     let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
     let alt = key.modifiers.contains(KeyModifiers::ALT);
 
-    // Ctrl+u / Ctrl+d / Ctrl+e for scrolling — works in all modes
+    // Scroll shortcuts work in any chat sub-mode
     if ctrl {
-        if matches!(mode, InputMode::Editing) && matches!(key.code, KeyCode::Char('j')) {
+        if matches!(app.mode, InputMode::Editing) && matches!(key.code, KeyCode::Char('j')) {
             return Some(Action::InsertNewline);
         }
         return match key.code {
@@ -40,9 +112,8 @@ pub fn handle_key_event(key: KeyEvent, mode: &InputMode) -> Option<Action> {
         };
     }
 
-    match mode {
+    match app.mode {
         InputMode::Normal => {
-            // Ignore Alt/Meta combos in Normal mode
             if alt || key.modifiers.intersects(KeyModifiers::META) {
                 return None;
             }
@@ -58,37 +129,133 @@ pub fn handle_key_event(key: KeyEvent, mode: &InputMode) -> Option<Action> {
                 KeyCode::Char('a') => Some(Action::ToggleShowArchived),
                 KeyCode::Char('A') => Some(Action::ArchiveConversation),
                 KeyCode::Char('i') => Some(Action::EnterEditMode),
+                KeyCode::Char('S') => Some(Action::OpenConnectionsView),
+                KeyCode::Char('P') => Some(Action::OpenPurposesView),
                 KeyCode::PageUp => Some(Action::ScrollUp),
                 KeyCode::PageDown => Some(Action::ScrollDown),
                 KeyCode::End => Some(Action::ScrollToBottom),
                 _ => None,
             }
         }
-        InputMode::Editing => {
-            // Shift+Enter inserts a newline while plain Enter submits.
-            match key.code {
-                KeyCode::Enter => {
-                    if key.modifiers.contains(KeyModifiers::SHIFT) {
-                        return Some(Action::InsertNewline);
-                    }
-                    if key.modifiers.is_empty() {
-                        return Some(Action::SubmitPrompt);
-                    }
-                    None
+        InputMode::Editing => match key.code {
+            KeyCode::Enter => {
+                if key.modifiers.contains(KeyModifiers::SHIFT) {
+                    return Some(Action::InsertNewline);
                 }
-                // Preserve terminal-provided newline chars by forwarding them
-                // to textarea.input(...), which keeps composer and payload in sync.
-                KeyCode::Char('\n') | KeyCode::Char('\r') => Some(Action::InsertNewline),
-                KeyCode::Esc => Some(Action::ExitEditMode),
-                KeyCode::PageUp => Some(Action::ScrollUp),
-                KeyCode::PageDown => Some(Action::ScrollDown),
-                KeyCode::End if key.modifiers.contains(KeyModifiers::SHIFT) => {
-                    Some(Action::ScrollToBottom)
+                if key.modifiers.is_empty() {
+                    return Some(Action::SubmitPrompt);
                 }
-                // All other keys: return None so they get forwarded to textarea
-                _ => None,
+                None
             }
+            KeyCode::Char('\n') | KeyCode::Char('\r') => Some(Action::InsertNewline),
+            KeyCode::Esc => Some(Action::ExitEditMode),
+            KeyCode::PageUp => Some(Action::ScrollUp),
+            KeyCode::PageDown => Some(Action::ScrollDown),
+            KeyCode::End if key.modifiers.contains(KeyModifiers::SHIFT) => {
+                Some(Action::ScrollToBottom)
+            }
+            _ => None,
+        },
+    }
+}
+
+fn route_connections(key: KeyEvent, app: &App) -> Option<Action> {
+    let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+    // Delete-confirm overlay takes priority.
+    if app.connections_view.delete.is_some() {
+        return match key.code {
+            KeyCode::Char('y') | KeyCode::Char('Y') | KeyCode::Enter => {
+                Some(Action::ConnectionsDeleteConfirm)
+            }
+            KeyCode::Char('f') | KeyCode::Char('F') => Some(Action::ConnectionsDeleteForce),
+            KeyCode::Esc | KeyCode::Char('n') | KeyCode::Char('N') => {
+                Some(Action::ConnectionsDeleteCancel)
+            }
+            _ => None,
+        };
+    }
+
+    // Configure form.
+    if app.connections_view.form.is_some() {
+        if ctrl {
+            return None;
         }
+        return route_connection_form(key, app);
+    }
+
+    // List mode.
+    if ctrl {
+        return None;
+    }
+    match key.code {
+        KeyCode::Char('q') | KeyCode::Esc => Some(Action::BackToChat),
+        KeyCode::Char('j') | KeyCode::Down => Some(Action::ConnectionsNext),
+        KeyCode::Char('k') | KeyCode::Up => Some(Action::ConnectionsPrevious),
+        KeyCode::Char('a') => Some(Action::ConnectionsAdd),
+        KeyCode::Char('c') | KeyCode::Enter => Some(Action::ConnectionsConfigure),
+        KeyCode::Char('d') => Some(Action::ConnectionsRemove),
+        KeyCode::Char('r') => Some(Action::ConnectionsRefreshModels),
+        _ => None,
+    }
+}
+
+fn route_connection_form(key: KeyEvent, app: &App) -> Option<Action> {
+    let form = app.connections_view.form.as_ref()?;
+    match key.code {
+        KeyCode::Esc => Some(Action::ConnectionsFormCancel),
+        KeyCode::Tab => Some(Action::ConnectionsFormNextField),
+        KeyCode::BackTab => Some(Action::ConnectionsFormPreviousField),
+        KeyCode::Enter => Some(Action::ConnectionsFormSubmit),
+        KeyCode::Backspace => Some(Action::ConnectionsFormBackspace),
+        // On the kind picker row, left/right cycle through connector types.
+        KeyCode::Left if form.is_on_kind() => Some(Action::ConnectionsFormCycleKindPrev),
+        KeyCode::Right if form.is_on_kind() => Some(Action::ConnectionsFormCycleKindNext),
+        KeyCode::Char(' ') if form.current_field().is_some_and(|f| f.is_toggle()) => {
+            Some(Action::ConnectionsFormToggleAutoPull)
+        }
+        KeyCode::Char(ch) if !key.modifiers.contains(KeyModifiers::CONTROL) => {
+            Some(Action::ConnectionsFormInsertChar(ch))
+        }
+        _ => None,
+    }
+}
+
+fn route_purposes(key: KeyEvent, app: &App) -> Option<Action> {
+    let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+    if app.purposes_view.editor.is_some() {
+        if ctrl {
+            return None;
+        }
+        return match key.code {
+            KeyCode::Esc => Some(Action::PurposesEditorCancel),
+            KeyCode::Tab => Some(Action::PurposesEditorNextField),
+            KeyCode::BackTab => Some(Action::PurposesEditorPreviousField),
+            KeyCode::Enter => Some(Action::PurposesEditorSubmit),
+            KeyCode::Backspace => Some(Action::PurposesEditorBackspace),
+            KeyCode::Char(ch) => Some(Action::PurposesEditorInsertChar(ch)),
+            _ => None,
+        };
+    }
+    if ctrl {
+        return None;
+    }
+    match key.code {
+        KeyCode::Char('q') | KeyCode::Esc => Some(Action::BackToChat),
+        KeyCode::Char('j') | KeyCode::Down => Some(Action::PurposesNext),
+        KeyCode::Char('k') | KeyCode::Up => Some(Action::PurposesPrevious),
+        KeyCode::Char('c') | KeyCode::Enter => Some(Action::PurposesEdit),
+        _ => None,
+    }
+}
+
+fn route_model_selector(key: KeyEvent) -> Option<Action> {
+    match key.code {
+        KeyCode::Esc | KeyCode::Char('q') => Some(Action::ModelSelectorCancel),
+        KeyCode::Enter => Some(Action::ModelSelectorConfirm),
+        KeyCode::Char('j') | KeyCode::Down => Some(Action::ModelSelectorNext),
+        KeyCode::Char('k') | KeyCode::Up => Some(Action::ModelSelectorPrevious),
+        KeyCode::Char('r') => Some(Action::ModelSelectorRefresh),
+        _ => None,
     }
 }
 
@@ -115,298 +282,172 @@ mod tests {
         }
     }
 
-    // --- Normal mode tests ---
+    fn chat_normal() -> App {
+        let mut app = App::new();
+        app.screen = Screen::Chat;
+        app.mode = InputMode::Normal;
+        app
+    }
+
+    fn chat_editing() -> App {
+        let mut app = App::new();
+        app.screen = Screen::Chat;
+        app.mode = InputMode::Editing;
+        app
+    }
 
     #[test]
-    fn normal_q_quits() {
+    fn chat_normal_q_quits() {
         assert_eq!(
-            handle_key_event(key(KeyCode::Char('q')), &InputMode::Normal),
+            route_key(key(KeyCode::Char('q')), &chat_normal()),
             Some(Action::Quit)
         );
     }
 
     #[test]
-    fn normal_j_next() {
+    fn chat_normal_capital_s_opens_connections() {
         assert_eq!(
-            handle_key_event(key(KeyCode::Char('j')), &InputMode::Normal),
-            Some(Action::NextConversation)
+            route_key(key(KeyCode::Char('S')), &chat_normal()),
+            Some(Action::OpenConnectionsView)
         );
     }
 
     #[test]
-    fn normal_down_next() {
+    fn chat_normal_capital_p_opens_purposes() {
         assert_eq!(
-            handle_key_event(key(KeyCode::Down), &InputMode::Normal),
-            Some(Action::NextConversation)
+            route_key(key(KeyCode::Char('P')), &chat_normal()),
+            Some(Action::OpenPurposesView)
         );
     }
 
     #[test]
-    fn normal_k_previous() {
+    fn chat_ctrl_m_opens_selector() {
         assert_eq!(
-            handle_key_event(key(KeyCode::Char('k')), &InputMode::Normal),
-            Some(Action::PreviousConversation)
-        );
-    }
-
-    #[test]
-    fn normal_up_previous() {
-        assert_eq!(
-            handle_key_event(key(KeyCode::Up), &InputMode::Normal),
-            Some(Action::PreviousConversation)
-        );
-    }
-
-    #[test]
-    fn normal_enter_opens() {
-        assert_eq!(
-            handle_key_event(key(KeyCode::Enter), &InputMode::Normal),
-            Some(Action::OpenConversation)
-        );
-    }
-
-    #[test]
-    fn normal_char_newline_is_ignored() {
-        assert_eq!(
-            handle_key_event(key(KeyCode::Char('\n')), &InputMode::Normal),
-            None
-        );
-    }
-
-    #[test]
-    fn normal_d_deletes() {
-        assert_eq!(
-            handle_key_event(key(KeyCode::Char('d')), &InputMode::Normal),
-            Some(Action::DeleteConversation)
-        );
-    }
-
-    #[test]
-    fn normal_n_new_conversation() {
-        assert_eq!(
-            handle_key_event(key(KeyCode::Char('n')), &InputMode::Normal),
-            Some(Action::NewConversation)
-        );
-    }
-
-    #[test]
-    fn normal_i_enter_edit() {
-        assert_eq!(
-            handle_key_event(key(KeyCode::Char('i')), &InputMode::Normal),
-            Some(Action::EnterEditMode)
-        );
-    }
-
-    #[test]
-    fn normal_unknown_key_ignored() {
-        assert_eq!(
-            handle_key_event(key(KeyCode::Char('x')), &InputMode::Normal),
-            None
-        );
-    }
-
-    #[test]
-    fn normal_ctrl_modifier_ignored() {
-        assert_eq!(
-            handle_key_event(
-                key_with_mod(KeyCode::Char('q'), KeyModifiers::CONTROL),
-                &InputMode::Normal
+            route_key(
+                key_with_mod(KeyCode::Char('m'), KeyModifiers::CONTROL),
+                &chat_normal()
             ),
-            None
+            Some(Action::OpenModelSelector)
         );
     }
 
     #[test]
-    fn normal_alt_modifier_ignored() {
+    fn ctrl_m_from_editing_mode_also_opens_selector() {
         assert_eq!(
-            handle_key_event(
-                key_with_mod(KeyCode::Char('j'), KeyModifiers::ALT),
-                &InputMode::Normal
+            route_key(
+                key_with_mod(KeyCode::Char('m'), KeyModifiers::CONTROL),
+                &chat_editing()
             ),
-            None
-        );
-    }
-
-    // --- Editing mode tests ---
-
-    #[test]
-    fn editing_escape_exits() {
-        assert_eq!(
-            handle_key_event(key(KeyCode::Esc), &InputMode::Editing),
-            Some(Action::ExitEditMode)
+            Some(Action::OpenModelSelector)
         );
     }
 
     #[test]
-    fn editing_enter_submits_prompt() {
+    fn connections_a_adds() {
+        let mut app = App::new();
+        app.screen = Screen::Connections;
         assert_eq!(
-            handle_key_event(key(KeyCode::Enter), &InputMode::Editing),
+            route_key(key(KeyCode::Char('a')), &app),
+            Some(Action::ConnectionsAdd)
+        );
+    }
+
+    #[test]
+    fn connections_d_prompts_remove() {
+        let mut app = App::new();
+        app.screen = Screen::Connections;
+        assert_eq!(
+            route_key(key(KeyCode::Char('d')), &app),
+            Some(Action::ConnectionsRemove)
+        );
+    }
+
+    #[test]
+    fn connections_form_tab_next_field() {
+        let mut app = App::new();
+        app.screen = Screen::Connections;
+        app.connections_view.start_add();
+        assert_eq!(
+            route_key(key(KeyCode::Tab), &app),
+            Some(Action::ConnectionsFormNextField)
+        );
+    }
+
+    #[test]
+    fn connections_delete_prompt_force_key() {
+        let mut app = App::new();
+        app.screen = Screen::Connections;
+        app.connections_view.connections = vec![crate::views::connections::tests_fixture(
+            "a", "openai",
+        )];
+        app.connections_view.selected = Some(0);
+        app.connections_view.start_delete();
+        assert_eq!(
+            route_key(key(KeyCode::Char('f')), &app),
+            Some(Action::ConnectionsDeleteForce)
+        );
+    }
+
+    #[test]
+    fn model_selector_captures_all_keys_when_open() {
+        let mut app = App::new();
+        app.screen = Screen::Chat;
+        app.model_selector.open = true;
+        assert_eq!(
+            route_key(key(KeyCode::Down), &app),
+            Some(Action::ModelSelectorNext)
+        );
+        assert_eq!(
+            route_key(key(KeyCode::Esc), &app),
+            Some(Action::ModelSelectorCancel)
+        );
+    }
+
+    #[test]
+    fn purposes_normal_c_edits() {
+        let mut app = App::new();
+        app.screen = Screen::Purposes;
+        assert_eq!(
+            route_key(key(KeyCode::Char('c')), &app),
+            Some(Action::PurposesEdit)
+        );
+    }
+
+    #[test]
+    fn purposes_editor_backspace() {
+        let mut app = App::new();
+        app.screen = Screen::Purposes;
+        app.purposes_view.start_edit();
+        assert_eq!(
+            route_key(key(KeyCode::Backspace), &app),
+            Some(Action::PurposesEditorBackspace)
+        );
+    }
+
+    #[test]
+    fn chat_editing_enter_submits() {
+        assert_eq!(
+            route_key(key(KeyCode::Enter), &chat_editing()),
             Some(Action::SubmitPrompt)
         );
     }
 
     #[test]
-    fn editing_shift_enter_inserts_newline() {
+    fn chat_editing_shift_enter_newline() {
         assert_eq!(
-            handle_key_event(
+            route_key(
                 key_with_mod(KeyCode::Enter, KeyModifiers::SHIFT),
-                &InputMode::Editing
+                &chat_editing()
             ),
             Some(Action::InsertNewline)
         );
     }
 
     #[test]
-    fn editing_newline_char_is_forwarded_to_textarea() {
+    fn chat_editing_esc_exits() {
         assert_eq!(
-            handle_key_event(
-                key_with_mod(KeyCode::Char('\n'), KeyModifiers::NONE),
-                &InputMode::Editing
-            ),
-            Some(Action::InsertNewline)
-        );
-    }
-
-    #[test]
-    fn editing_carriage_return_char_is_forwarded_to_textarea() {
-        assert_eq!(
-            handle_key_event(
-                key_with_mod(KeyCode::Char('\r'), KeyModifiers::NONE),
-                &InputMode::Editing
-            ),
-            Some(Action::InsertNewline)
-        );
-    }
-
-    #[test]
-    fn editing_ctrl_j_inserts_newline() {
-        assert_eq!(
-            handle_key_event(
-                key_with_mod(KeyCode::Char('j'), KeyModifiers::CONTROL),
-                &InputMode::Editing
-            ),
-            Some(Action::InsertNewline)
-        );
-    }
-
-    #[test]
-    fn editing_alt_enter_is_forwarded_to_textarea() {
-        assert_eq!(
-            handle_key_event(
-                key_with_mod(KeyCode::Enter, KeyModifiers::ALT),
-                &InputMode::Editing
-            ),
-            None
-        );
-    }
-
-    #[test]
-    fn editing_char_forwarded_to_textarea() {
-        // Regular chars should return None so they get forwarded to textarea
-        assert_eq!(
-            handle_key_event(key(KeyCode::Char('a')), &InputMode::Editing),
-            None
-        );
-    }
-
-    #[test]
-    fn editing_backspace_forwarded_to_textarea() {
-        assert_eq!(
-            handle_key_event(key(KeyCode::Backspace), &InputMode::Editing),
-            None
-        );
-    }
-
-    #[test]
-    fn editing_arrows_forwarded_to_textarea() {
-        assert_eq!(
-            handle_key_event(key(KeyCode::Left), &InputMode::Editing),
-            None
-        );
-        assert_eq!(
-            handle_key_event(key(KeyCode::Right), &InputMode::Editing),
-            None
-        );
-        assert_eq!(
-            handle_key_event(key(KeyCode::Up), &InputMode::Editing),
-            None
-        );
-        assert_eq!(
-            handle_key_event(key(KeyCode::Down), &InputMode::Editing),
-            None
-        );
-    }
-
-    // --- Scroll tests (Ctrl+u/d/e work in all modes) ---
-
-    #[test]
-    fn ctrl_u_scrolls_up() {
-        assert_eq!(
-            handle_key_event(
-                key_with_mod(KeyCode::Char('u'), KeyModifiers::CONTROL),
-                &InputMode::Normal
-            ),
-            Some(Action::ScrollUp)
-        );
-    }
-
-    #[test]
-    fn ctrl_d_scrolls_down() {
-        assert_eq!(
-            handle_key_event(
-                key_with_mod(KeyCode::Char('d'), KeyModifiers::CONTROL),
-                &InputMode::Normal
-            ),
-            Some(Action::ScrollDown)
-        );
-    }
-
-    #[test]
-    fn ctrl_e_scrolls_to_bottom() {
-        assert_eq!(
-            handle_key_event(
-                key_with_mod(KeyCode::Char('e'), KeyModifiers::CONTROL),
-                &InputMode::Normal
-            ),
-            Some(Action::ScrollToBottom)
-        );
-    }
-
-    #[test]
-    fn ctrl_u_works_in_editing_mode() {
-        assert_eq!(
-            handle_key_event(
-                key_with_mod(KeyCode::Char('u'), KeyModifiers::CONTROL),
-                &InputMode::Editing
-            ),
-            Some(Action::ScrollUp)
-        );
-    }
-
-    #[test]
-    fn ctrl_d_works_in_editing_mode() {
-        assert_eq!(
-            handle_key_event(
-                key_with_mod(KeyCode::Char('d'), KeyModifiers::CONTROL),
-                &InputMode::Editing
-            ),
-            Some(Action::ScrollDown)
-        );
-    }
-
-    #[test]
-    fn normal_pageup_scrolls_up() {
-        assert_eq!(
-            handle_key_event(key(KeyCode::PageUp), &InputMode::Normal),
-            Some(Action::ScrollUp)
-        );
-    }
-
-    #[test]
-    fn normal_pagedown_scrolls_down() {
-        assert_eq!(
-            handle_key_event(key(KeyCode::PageDown), &InputMode::Normal),
-            Some(Action::ScrollDown)
+            route_key(key(KeyCode::Esc), &chat_editing()),
+            Some(Action::ExitEditMode)
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod app;
 pub mod keys;
 pub mod ui;
+pub mod views;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod app;
 mod keys;
 mod ui;
+mod views;
 
 use std::io;
 
@@ -15,14 +16,14 @@ use crossterm::{
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
 use desktop_assistant_client_common::{
-    AssistantClient, ConnectionConfig, SignalEvent, TransportMode, connect_transport,
-    transport::transport_label,
+    AssistantClient, ConnectionConfig, SignalEvent, TransportClient, TransportMode, api,
+    connect_transport, transport::transport_label,
 };
 use futures::StreamExt;
 use ratatui::{Terminal, backend::CrosstermBackend};
 
-use app::{App, InputMode};
-use keys::{Action, handle_key_event};
+use app::{App, Screen};
+use keys::{Action, route_key};
 
 const DEFAULT_WS_URL: &str = desktop_assistant_client_common::config::DEFAULT_WS_URL;
 const DEFAULT_WS_SUBJECT: &str = desktop_assistant_client_common::config::DEFAULT_WS_SUBJECT;
@@ -135,14 +136,13 @@ async fn run(
 ) -> Result<()> {
     let mut app = App::new();
 
-    // Connect using configured transport (WS by default, D-Bus optional).
     let (client, mut signal_rx) = match connect_transport(config).await {
         Ok((transport_client, rx)) => {
             match transport_client.list_conversations().await {
                 Ok(convs) => app.set_conversations(convs),
                 Err(e) => app.status_message = format!("Error loading conversations: {e}"),
             }
-            app.status_message = transport_label(&config);
+            app.status_message = transport_label(config);
             (Some(transport_client), rx)
         }
         Err(e) => {
@@ -166,11 +166,18 @@ async fn run(
                     if key.kind == KeyEventKind::Release {
                         continue;
                     }
-                    if let Some(action) = handle_key_event(key, &app.mode) {
-                        handle_action(&mut app, &client, action).await;
-                    } else if matches!(app.mode, InputMode::Editing) {
-                        // Forward unhandled keys to textarea
-                        app.textarea.input(key);
+                    match route_key(key, &app) {
+                        Some(action) => handle_action(&mut app, &client, action).await,
+                        None => {
+                            // Forward unhandled keys to the textarea only when
+                            // the chat input is focused.
+                            if matches!(app.screen, Screen::Chat)
+                                && matches!(app.mode, app::InputMode::Editing)
+                                && !app.model_selector.open
+                            {
+                                app.textarea.input(key);
+                            }
+                        }
                     }
                 }
             }
@@ -193,6 +200,9 @@ async fn run(
                     SignalEvent::TitleChanged { conversation_id, title } => {
                         app.update_conversation_title(&conversation_id, &title);
                     }
+                    SignalEvent::ConversationWarning { conversation_id, warning } => {
+                        app.apply_conversation_warning(&conversation_id, &warning);
+                    }
                     SignalEvent::Disconnected { reason } => {
                         app.status_message = format!("Disconnected: {reason}");
                     }
@@ -206,25 +216,14 @@ async fn run(
 
 async fn handle_action(
     app: &mut App,
-    client: &Option<desktop_assistant_client_common::TransportClient>,
+    client: &Option<TransportClient>,
     action: Action,
 ) {
     match action {
         Action::Quit => app.quit(),
         Action::NextConversation => app.next_conversation(),
         Action::PreviousConversation => app.previous_conversation(),
-        Action::OpenConversation => {
-            if let (Some(client), Some(id)) = (client.as_ref(), app.selected_conversation_id()) {
-                let id = id.to_string();
-                match client.get_conversation(&id).await {
-                    Ok(detail) => {
-                        app.load_conversation(detail);
-                        app.enter_editing_mode();
-                    }
-                    Err(e) => app.status_message = format!("Error: {e}"),
-                }
-            }
-        }
+        Action::OpenConversation => handle_open_conversation(app, client).await,
         Action::DeleteConversation => {
             if let Some(id) = app.delete_selected_conversation()
                 && let Some(client) = client.as_ref()
@@ -233,32 +232,7 @@ async fn handle_action(
                 app.status_message = format!("Delete error: {e}");
             }
         }
-        Action::NewConversation => {
-            if let Some(client) = client.as_ref() {
-                match client.create_conversation("New Conversation").await {
-                    Ok(id) => {
-                        match fetch_conversations(client, app.show_archived).await {
-                            Ok(convs) => {
-                                let new_idx = convs.iter().position(|c| c.id == id);
-                                app.set_conversations(convs);
-                                if let Some(idx) = new_idx {
-                                    app.selected_conversation = Some(idx);
-                                }
-                            }
-                            Err(e) => app.status_message = format!("Error refreshing: {e}"),
-                        }
-                        match client.get_conversation(&id).await {
-                            Ok(detail) => {
-                                app.load_conversation(detail);
-                                app.enter_editing_mode();
-                            }
-                            Err(e) => app.status_message = format!("Error opening: {e}"),
-                        }
-                    }
-                    Err(e) => app.status_message = format!("Create error: {e}"),
-                }
-            }
-        }
+        Action::NewConversation => handle_new_conversation(app, client).await,
         Action::EnterEditMode => {
             if app.current_conversation.is_some() {
                 app.enter_editing_mode();
@@ -267,19 +241,7 @@ async fn handle_action(
             }
         }
         Action::ExitEditMode => app.enter_normal_mode(),
-        Action::SubmitPrompt => {
-            if let Some((conv_id, prompt)) = app.submit_prompt()
-                && let Some(client) = client.as_ref()
-            {
-                match client.send_prompt(&conv_id, &prompt).await {
-                    Ok(request_id) if request_id.is_empty() => {
-                        app.start_streaming_without_request_id()
-                    }
-                    Ok(request_id) => app.start_streaming(request_id),
-                    Err(e) => app.status_message = format!("Send error: {e}"),
-                }
-            }
-        }
+        Action::SubmitPrompt => handle_submit_prompt(app, client).await,
         Action::InsertNewline => {
             app.textarea.insert_newline();
         }
@@ -297,43 +259,393 @@ async fn handle_action(
                 "Showing active conversations only".into()
             };
         }
-        Action::ArchiveConversation => {
-            if let (Some(client), Some(id)) = (client.as_ref(), app.selected_conversation_id()) {
-                let id = id.to_string();
-                // Determine if conversation is currently archived
-                let is_archived = app
-                    .conversations
-                    .get(app.selected_conversation.unwrap_or(0))
-                    .is_some_and(|c| c.archived);
-                let result = if is_archived {
-                    client.unarchive_conversation(&id).await
-                } else {
-                    client.archive_conversation(&id).await
-                };
-                match result {
-                    Ok(()) => {
-                        match fetch_conversations(client, app.show_archived).await {
-                            Ok(convs) => app.set_conversations(convs),
-                            Err(e) => app.status_message = format!("Error refreshing: {e}"),
-                        }
-                        app.status_message = if is_archived {
-                            "Conversation unarchived".into()
-                        } else {
-                            "Conversation archived".into()
-                        };
-                    }
-                    Err(e) => app.status_message = format!("Archive error: {e}"),
-                }
-            }
-        }
+        Action::ArchiveConversation => handle_archive(app, client).await,
         Action::ScrollUp => app.scroll_up(5),
         Action::ScrollDown => app.scroll_down(5),
         Action::ScrollToBottom => app.scroll_to_bottom(),
+
+        // --- Screen switches ---
+        Action::OpenConnectionsView => {
+            app.switch_to_connections();
+            refresh_connections(app, client).await;
+        }
+        Action::OpenPurposesView => {
+            app.switch_to_purposes();
+            refresh_purposes(app, client).await;
+        }
+        Action::BackToChat => app.switch_to_chat(),
+
+        // --- Connections list ---
+        Action::ConnectionsNext => app.connections_view.select_next(),
+        Action::ConnectionsPrevious => app.connections_view.select_previous(),
+        Action::ConnectionsAdd => app.connections_view.start_add(),
+        Action::ConnectionsConfigure => app.connections_view.start_configure(),
+        Action::ConnectionsRemove => app.connections_view.start_delete(),
+        Action::ConnectionsRefreshModels => {
+            refresh_models(app, client, true).await;
+            let count = app.model_selector.entries.len();
+            app.connections_view.status = Some(format!("Refreshed — {count} models available"));
+        }
+
+        // --- Connection form ---
+        Action::ConnectionsFormCancel => app.connections_view.form = None,
+        Action::ConnectionsFormNextField => {
+            if let Some(f) = app.connections_view.form.as_mut() {
+                f.next_field();
+            }
+        }
+        Action::ConnectionsFormPreviousField => {
+            if let Some(f) = app.connections_view.form.as_mut() {
+                f.previous_field();
+            }
+        }
+        Action::ConnectionsFormCycleKindNext => {
+            if let Some(f) = app.connections_view.form.as_mut() {
+                f.cycle_kind_next();
+            }
+        }
+        Action::ConnectionsFormCycleKindPrev => {
+            if let Some(f) = app.connections_view.form.as_mut() {
+                f.cycle_kind_prev();
+            }
+        }
+        Action::ConnectionsFormInsertChar(ch) => {
+            if let Some(f) = app.connections_view.form.as_mut() {
+                f.insert_char(ch);
+            }
+        }
+        Action::ConnectionsFormBackspace => {
+            if let Some(f) = app.connections_view.form.as_mut() {
+                f.backspace();
+            }
+        }
+        Action::ConnectionsFormToggleAutoPull => {
+            if let Some(f) = app.connections_view.form.as_mut() {
+                f.toggle_auto_pull();
+            }
+        }
+        Action::ConnectionsFormSubmit => handle_connection_form_submit(app, client).await,
+
+        // --- Delete confirm ---
+        Action::ConnectionsDeleteConfirm => handle_delete_connection(app, client, false).await,
+        Action::ConnectionsDeleteForce => handle_delete_connection(app, client, true).await,
+        Action::ConnectionsDeleteCancel => app.connections_view.delete = None,
+
+        // --- Purposes ---
+        Action::PurposesNext => app.purposes_view.select_next(),
+        Action::PurposesPrevious => app.purposes_view.select_previous(),
+        Action::PurposesEdit => app.purposes_view.start_edit(),
+        Action::PurposesEditorCancel => app.purposes_view.close_editor(),
+        Action::PurposesEditorNextField => {
+            if let Some(ed) = app.purposes_view.editor.as_mut() {
+                ed.next_field();
+            }
+        }
+        Action::PurposesEditorPreviousField => {
+            if let Some(ed) = app.purposes_view.editor.as_mut() {
+                ed.previous_field();
+            }
+        }
+        Action::PurposesEditorInsertChar(ch) => {
+            if let Some(ed) = app.purposes_view.editor.as_mut() {
+                ed.insert_char(ch);
+            }
+        }
+        Action::PurposesEditorBackspace => {
+            if let Some(ed) = app.purposes_view.editor.as_mut() {
+                ed.backspace();
+            }
+        }
+        Action::PurposesEditorSubmit => handle_purpose_submit(app, client).await,
+
+        // --- Model selector ---
+        Action::OpenModelSelector => handle_open_selector(app, client).await,
+        Action::ModelSelectorNext => app.model_selector.highlight_next(),
+        Action::ModelSelectorPrevious => app.model_selector.highlight_previous(),
+        Action::ModelSelectorConfirm => {
+            app.apply_model_selection();
+        }
+        Action::ModelSelectorCancel => app.model_selector.close(),
+        Action::ModelSelectorRefresh => refresh_models(app, client, true).await,
+    }
+}
+
+async fn handle_open_conversation(app: &mut App, client: &Option<TransportClient>) {
+    if let (Some(client), Some(id)) = (client.as_ref(), app.selected_conversation_id()) {
+        let id = id.to_string();
+        match client.get_conversation(&id).await {
+            Ok(detail) => {
+                app.load_conversation(detail);
+                app.enter_editing_mode();
+            }
+            Err(e) => app.status_message = format!("Error: {e}"),
+        }
+    }
+}
+
+async fn handle_new_conversation(app: &mut App, client: &Option<TransportClient>) {
+    let Some(client) = client.as_ref() else {
+        return;
+    };
+    match client.create_conversation("New Conversation").await {
+        Ok(id) => {
+            match fetch_conversations(client, app.show_archived).await {
+                Ok(convs) => {
+                    let new_idx = convs.iter().position(|c| c.id == id);
+                    app.set_conversations(convs);
+                    if let Some(idx) = new_idx {
+                        app.selected_conversation = Some(idx);
+                    }
+                }
+                Err(e) => app.status_message = format!("Error refreshing: {e}"),
+            }
+            match client.get_conversation(&id).await {
+                Ok(detail) => {
+                    app.load_conversation(detail);
+                    app.enter_editing_mode();
+                }
+                Err(e) => app.status_message = format!("Error opening: {e}"),
+            }
+        }
+        Err(e) => app.status_message = format!("Create error: {e}"),
+    }
+}
+
+async fn handle_submit_prompt(app: &mut App, client: &Option<TransportClient>) {
+    let Some((conv_id, prompt, override_sel)) = app.submit_prompt() else {
+        return;
+    };
+    let Some(client) = client.as_ref() else {
+        return;
+    };
+    match client
+        .send_prompt_with_override(&conv_id, &prompt, override_sel)
+        .await
+    {
+        Ok(request_id) if request_id.is_empty() => app.start_streaming_without_request_id(),
+        Ok(request_id) => app.start_streaming(request_id),
+        Err(e) => app.status_message = format!("Send error: {e}"),
+    }
+}
+
+async fn handle_archive(app: &mut App, client: &Option<TransportClient>) {
+    let (Some(client), Some(id)) = (client.as_ref(), app.selected_conversation_id()) else {
+        return;
+    };
+    let id = id.to_string();
+    let is_archived = app
+        .conversations
+        .get(app.selected_conversation.unwrap_or(0))
+        .is_some_and(|c| c.archived);
+    let result = if is_archived {
+        client.unarchive_conversation(&id).await
+    } else {
+        client.archive_conversation(&id).await
+    };
+    match result {
+        Ok(()) => {
+            match fetch_conversations(client, app.show_archived).await {
+                Ok(convs) => app.set_conversations(convs),
+                Err(e) => app.status_message = format!("Error refreshing: {e}"),
+            }
+            app.status_message = if is_archived {
+                "Conversation unarchived".into()
+            } else {
+                "Conversation archived".into()
+            };
+        }
+        Err(e) => app.status_message = format!("Archive error: {e}"),
+    }
+}
+
+async fn refresh_connections(app: &mut App, client: &Option<TransportClient>) {
+    app.connections_view.loading = true;
+    app.connections_view.status = None;
+    if let Some(client) = client.as_ref() {
+        match client.list_connections().await {
+            Ok(list) => app.connections_view.set_connections(list),
+            Err(e) => {
+                app.connections_view.loading = false;
+                app.connections_view.status = Some(format!("Load error: {e}"));
+            }
+        }
+    } else {
+        app.connections_view.loading = false;
+        app.connections_view.status = Some("Not connected".into());
+    }
+}
+
+async fn refresh_purposes(app: &mut App, client: &Option<TransportClient>) {
+    app.purposes_view.loading = true;
+    app.purposes_view.status = None;
+    if let Some(client) = client.as_ref() {
+        match client.get_purposes().await {
+            Ok(v) => app.purposes_view.set_purposes(v),
+            Err(e) => {
+                app.purposes_view.loading = false;
+                app.purposes_view.status = Some(format!("Load error: {e}"));
+            }
+        }
+    } else {
+        app.purposes_view.loading = false;
+        app.purposes_view.status = Some("Not connected".into());
+    }
+}
+
+async fn refresh_models(app: &mut App, client: &Option<TransportClient>, force: bool) {
+    app.model_selector.loading = true;
+    app.model_selector.status = None;
+    let Some(client) = client.as_ref() else {
+        app.model_selector.loading = false;
+        app.model_selector.status = Some("Not connected".into());
+        return;
+    };
+    match client.list_available_models(None, force).await {
+        Ok(list) => {
+            app.model_selector.set_entries(list);
+            // Re-sync highlight to the conversation's current selection.
+            let sel = app
+                .current_conversation
+                .as_ref()
+                .and_then(|c| app.conversation_selections.get(&c.id))
+                .cloned();
+            app.model_selector.highlight_for(sel.as_ref());
+        }
+        Err(e) => {
+            app.model_selector.loading = false;
+            app.model_selector.status = Some(format!("Load error: {e}"));
+        }
+    }
+}
+
+async fn handle_connection_form_submit(app: &mut App, client: &Option<TransportClient>) {
+    let Some(form) = app.connections_view.form.as_ref().cloned() else {
+        return;
+    };
+    let Some(config) = form.to_api_config() else {
+        if let Some(f) = app.connections_view.form.as_mut() {
+            f.error = Some("Id is required".into());
+        }
+        return;
+    };
+    let Some(transport) = client.as_ref() else {
+        if let Some(f) = app.connections_view.form.as_mut() {
+            f.error = Some("Not connected".into());
+        }
+        return;
+    };
+
+    let result = if form.existing {
+        transport.update_connection(&form.id, config).await
+    } else {
+        transport.create_connection(&form.id, config).await
+    };
+
+    match result {
+        Ok(()) => {
+            app.connections_view.form = None;
+            app.connections_view.status = Some(if form.existing {
+                format!("Updated {}", form.id)
+            } else {
+                format!("Created {}", form.id)
+            });
+            // Re-list through the same `&Option<TransportClient>`.
+            refresh_connections(app, client).await;
+        }
+        Err(e) => {
+            if let Some(f) = app.connections_view.form.as_mut() {
+                f.error = Some(format!("{e}"));
+            }
+        }
+    }
+}
+
+async fn handle_delete_connection(
+    app: &mut App,
+    client: &Option<TransportClient>,
+    force: bool,
+) {
+    let Some(prompt) = app.connections_view.delete.as_ref().cloned() else {
+        return;
+    };
+    let Some(transport) = client.as_ref() else {
+        app.connections_view.status = Some("Not connected".into());
+        return;
+    };
+
+    match transport.delete_connection(&prompt.id, force).await {
+        Ok(()) => {
+            app.connections_view.delete = None;
+            app.connections_view.status = Some(format!("Deleted {}", prompt.id));
+            refresh_connections(app, client).await;
+        }
+        Err(e) => {
+            let err = format!("{e}");
+            if !force {
+                if let Some(p) = app.connections_view.delete.as_mut() {
+                    p.advance_to_force(err);
+                }
+            } else {
+                app.connections_view.delete = None;
+                app.connections_view.status = Some(format!("Delete error: {err}"));
+            }
+        }
+    }
+}
+
+async fn handle_purpose_submit(app: &mut App, client: &Option<TransportClient>) {
+    let Some(editor) = app.purposes_view.editor.as_ref().cloned() else {
+        return;
+    };
+    let cfg = match editor.to_api_config() {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            if let Some(ed) = app.purposes_view.editor.as_mut() {
+                ed.error = Some(e);
+            }
+            return;
+        }
+    };
+    let Some(transport) = client.as_ref() else {
+        if let Some(ed) = app.purposes_view.editor.as_mut() {
+            ed.error = Some("Not connected".into());
+        }
+        return;
+    };
+    match transport.set_purpose(editor.purpose, cfg).await {
+        Ok(()) => {
+            app.purposes_view.editor = None;
+            app.purposes_view.status = Some(format!(
+                "Saved {}",
+                views::purposes::purpose_label(editor.purpose)
+            ));
+            refresh_purposes(app, client).await;
+        }
+        Err(e) => {
+            if let Some(ed) = app.purposes_view.editor.as_mut() {
+                ed.error = Some(format!("{e}"));
+            }
+        }
+    }
+}
+
+async fn handle_open_selector(app: &mut App, client: &Option<TransportClient>) {
+    app.model_selector.open();
+    if app.model_selector.entries.is_empty() {
+        refresh_models(app, client, false).await;
+    } else {
+        // Re-sync highlight to the conversation's current selection.
+        let sel = app
+            .current_conversation
+            .as_ref()
+            .and_then(|c| app.conversation_selections.get(&c.id))
+            .cloned();
+        app.model_selector.highlight_for(sel.as_ref());
     }
 }
 
 async fn fetch_conversations(
-    client: &desktop_assistant_client_common::TransportClient,
+    client: &TransportClient,
     include_archived: bool,
 ) -> Result<Vec<desktop_assistant_client_common::ConversationSummary>> {
     if include_archived {
@@ -342,6 +654,10 @@ async fn fetch_conversations(
         client.list_conversations().await
     }
 }
+
+// Silence unused imports when compiling without dbus feature flags in play.
+#[allow(dead_code)]
+fn _api_sanity_check(_v: api::ConnectionConfigView) {}
 
 #[cfg(test)]
 mod tests {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,12 +1,16 @@
+use desktop_assistant_client_common::api;
 use ratatui::{
     Frame,
-    layout::{Constraint, Direction, Layout},
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap},
+    widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap},
 };
 
-use crate::app::{App, InputMode};
+use crate::app::{App, InputMode, Screen};
+use crate::views::connections::{ConnectorKind, DeleteStage, FormField};
+use crate::views::purposes::{PURPOSES_ORDER, PurposeField, effort_label, purpose_label};
+use crate::views::selector;
 
 const INPUT_VISIBLE_LINES: u16 = 4;
 const INPUT_TOTAL_HEIGHT: u16 = INPUT_VISIBLE_LINES + 2; // +2 for borders
@@ -45,6 +49,19 @@ fn split_display_lines(content: &str) -> Vec<String> {
 }
 
 pub fn draw(f: &mut Frame, app: &mut App) {
+    match app.screen {
+        Screen::Chat => draw_chat_screen(f, app),
+        Screen::Connections => draw_connections_screen(f, app),
+        Screen::Purposes => draw_purposes_screen(f, app),
+    }
+
+    // Overlays render on top of whatever screen is active.
+    if app.model_selector.open {
+        draw_model_selector_popup(f, app);
+    }
+}
+
+fn draw_chat_screen(f: &mut Frame, app: &mut App) {
     let chunks = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([Constraint::Percentage(30), Constraint::Percentage(70)])
@@ -111,18 +128,33 @@ fn draw_conversation_list(f: &mut Frame, app: &App, area: ratatui::layout::Rect)
 }
 
 fn draw_chat_panel(f: &mut Frame, app: &mut App, area: ratatui::layout::Rect) {
+    let notice_lines: u16 = if app.inline_notice.is_some() { 1 } else { 0 };
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Min(1),
             Constraint::Length(INPUT_TOTAL_HEIGHT),
+            Constraint::Length(notice_lines),
             Constraint::Length(1),
         ])
         .split(area);
 
     draw_messages(f, app, chunks[0]);
     draw_input(f, app, chunks[1]);
-    draw_status_bar(f, app, chunks[2]);
+    if notice_lines > 0 {
+        draw_inline_notice(f, app, chunks[2]);
+    }
+    draw_status_bar(f, app, chunks[3]);
+}
+
+fn draw_inline_notice(f: &mut Frame, app: &App, area: Rect) {
+    if let Some(notice) = app.inline_notice.as_deref() {
+        let p = Paragraph::new(Line::from(vec![
+            Span::styled("! ", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+            Span::styled(notice, Style::default().fg(Color::Yellow)),
+        ]));
+        f.render_widget(p, area);
+    }
 }
 
 fn draw_messages(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
@@ -245,8 +277,21 @@ fn draw_status_bar(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
         InputMode::Editing => "EDITING",
     };
 
+    let selection_label = app.current_selection_label();
+
     let status = Paragraph::new(Line::from(vec![
         Span::styled(format!(" [{mode_str}] "), mode_chip_style(&app.mode)),
+        Span::styled(" • ", Style::default().fg(COLOR_STATUS_DIM)),
+        Span::styled(
+            "model: ",
+            Style::default().fg(COLOR_STATUS_DIM),
+        ),
+        Span::styled(
+            selection_label,
+            Style::default()
+                .fg(Color::Rgb(200, 220, 255))
+                .add_modifier(Modifier::BOLD),
+        ),
         Span::styled(" • ", Style::default().fg(COLOR_STATUS_DIM)),
         Span::styled(
             app.status_message.as_str(),
@@ -255,6 +300,551 @@ fn draw_status_bar(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
     ]));
 
     f.render_widget(status, area);
+}
+
+// --- Connections screen ----------------------------------------------------
+
+fn draw_connections_screen(f: &mut Frame, app: &mut App) {
+    let area = f.area();
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .split(area);
+    draw_connections_list(f, app, chunks[0]);
+    draw_connections_hint_bar(f, app, chunks[1]);
+
+    if app.connections_view.form.is_some() {
+        draw_connection_form_popup(f, app);
+    }
+    if app.connections_view.delete.is_some() {
+        draw_connection_delete_popup(f, app);
+    }
+}
+
+fn draw_connections_list(f: &mut Frame, app: &App, area: Rect) {
+    let view = &app.connections_view;
+    let items: Vec<ListItem> = view
+        .connections
+        .iter()
+        .map(|c| {
+            let avail_chip = match &c.availability {
+                api::ConnectionAvailability::Ok => {
+                    Span::styled("ok", Style::default().fg(Color::Green))
+                }
+                api::ConnectionAvailability::Unavailable { reason } => Span::styled(
+                    format!("unavail ({reason})"),
+                    Style::default().fg(Color::Red),
+                ),
+            };
+            let creds = if c.has_credentials {
+                Span::styled("creds", Style::default().fg(Color::Green))
+            } else {
+                Span::styled("no-creds", Style::default().fg(Color::Yellow))
+            };
+            ListItem::new(Line::from(vec![
+                Span::styled(
+                    format!("{} ", c.id),
+                    Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(
+                    format!("[{}] ", c.connector_type),
+                    Style::default().fg(Color::Rgb(136, 214, 240)),
+                ),
+                avail_chip,
+                Span::raw("  "),
+                creds,
+            ]))
+        })
+        .collect();
+
+    let title = if view.loading {
+        "Connections (loading…)"
+    } else {
+        "Connections"
+    };
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(COLOR_LIST_BORDER))
+        .title(Line::from(Span::styled(
+            title,
+            Style::default()
+                .fg(Color::Rgb(136, 214, 240))
+                .add_modifier(Modifier::BOLD),
+        )));
+
+    let list = List::new(items)
+        .block(block)
+        .highlight_style(
+            Style::default()
+                .bg(COLOR_LIST_HIGHLIGHT)
+                .fg(COLOR_LIST_HIGHLIGHT_FG)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("▸ ");
+    let mut state = ListState::default();
+    state.select(view.selected);
+    f.render_stateful_widget(list, area, &mut state);
+}
+
+fn draw_connections_hint_bar(f: &mut Frame, app: &App, area: Rect) {
+    let hint = match &app.connections_view.status {
+        Some(s) => s.clone(),
+        None => "(a)dd  (c/⏎) configure  (d) remove  (r) refresh models  (q/esc) back".into(),
+    };
+    let p = Paragraph::new(Line::from(Span::styled(
+        hint,
+        Style::default().fg(COLOR_STATUS_DIM),
+    )));
+    f.render_widget(p, area);
+}
+
+fn draw_connection_form_popup(f: &mut Frame, app: &App) {
+    let Some(form) = app.connections_view.form.as_ref() else {
+        return;
+    };
+    let area = centered_rect(70, 70, f.area());
+    f.render_widget(Clear, area);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(COLOR_PANEL_BORDER))
+        .title(Line::from(Span::styled(
+            if form.existing {
+                "Configure connection"
+            } else {
+                "Add connection"
+            },
+            Style::default()
+                .fg(Color::Rgb(166, 182, 255))
+                .add_modifier(Modifier::BOLD),
+        )));
+
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    let mut lines: Vec<Line> = Vec::new();
+
+    // Row 0: id
+    lines.push(form_row(
+        "Id",
+        &form.id,
+        form.field_cursor == 0,
+        form.existing,
+    ));
+    // Row 1: kind
+    lines.push(form_row(
+        "Type",
+        form.kind.as_label(),
+        form.field_cursor == 1,
+        false,
+    ));
+    // Row 2..: connector-specific fields
+    for (i, field) in form.kind.fields().iter().enumerate() {
+        let value: String = match field {
+            FormField::ApiKeyEnv => form.api_key_env.clone(),
+            FormField::BaseUrl => form.base_url.clone(),
+            FormField::AwsProfile => form.aws_profile.clone(),
+            FormField::Region => form.region.clone(),
+            FormField::OllamaAutoPull => {
+                if form.ollama_auto_pull {
+                    "on".into()
+                } else {
+                    "off".into()
+                }
+            }
+        };
+        lines.push(form_row(
+            field.label(),
+            &value,
+            form.field_cursor == 2 + i,
+            false,
+        ));
+    }
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        match form.kind {
+            ConnectorKind::Anthropic | ConnectorKind::OpenAi => {
+                "API Key: enter the name of the env var that holds your key (we never store the key itself)."
+            }
+            ConnectorKind::Bedrock => {
+                "Bedrock uses ambient AWS credentials (profile + region)."
+            }
+            ConnectorKind::Ollama => "Ollama runs locally; no credentials needed.",
+        },
+        Style::default().fg(COLOR_STATUS_DIM),
+    )));
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "Tab/Shift-Tab: next/prev field  •  ←/→ on Type: cycle  •  Enter: save  •  Esc: cancel",
+        Style::default().fg(COLOR_STATUS_DIM),
+    )));
+
+    if let Some(err) = form.error.as_deref() {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            format!("Error: {err}"),
+            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+        )));
+    }
+
+    let p = Paragraph::new(lines).wrap(Wrap { trim: false });
+    f.render_widget(p, inner);
+}
+
+fn form_row(label: &str, value: &str, active: bool, read_only: bool) -> Line<'static> {
+    let label_style = if active {
+        Style::default()
+            .fg(Color::Rgb(255, 189, 89))
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(Color::Rgb(190, 200, 225))
+    };
+    let value_style = if read_only {
+        Style::default().fg(COLOR_STATUS_DIM)
+    } else if active {
+        Style::default()
+            .fg(Color::Rgb(245, 248, 255))
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(Color::White)
+    };
+    let marker = if active { "▸ " } else { "  " };
+    let shown = if value.is_empty() {
+        "<empty>".to_string()
+    } else {
+        value.to_string()
+    };
+    Line::from(vec![
+        Span::styled(marker, label_style),
+        Span::styled(format!("{label:<22}"), label_style),
+        Span::styled(shown, value_style),
+    ])
+}
+
+fn draw_connection_delete_popup(f: &mut Frame, app: &App) {
+    let Some(prompt) = app.connections_view.delete.as_ref() else {
+        return;
+    };
+    let area = centered_rect(60, 30, f.area());
+    f.render_widget(Clear, area);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Rgb(205, 100, 100)))
+        .title(Line::from(Span::styled(
+            "Remove connection",
+            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+        )));
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    let mut lines: Vec<Line> = Vec::new();
+    lines.push(Line::from(vec![
+        Span::raw("Remove connection "),
+        Span::styled(
+            prompt.id.clone(),
+            Style::default()
+                .fg(Color::White)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw("?"),
+    ]));
+    lines.push(Line::from(""));
+    match &prompt.stage {
+        DeleteStage::Initial => {
+            lines.push(Line::from(Span::styled(
+                "y/⏎ confirm  •  n/esc cancel",
+                Style::default().fg(COLOR_STATUS_DIM),
+            )));
+        }
+        DeleteStage::OfferForce { server_error } => {
+            lines.push(Line::from(Span::styled(
+                format!("Daemon refused: {server_error}"),
+                Style::default().fg(Color::Yellow),
+            )));
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(
+                "Referencing purposes will fall back to \"primary\" if you force the removal.",
+                Style::default().fg(COLOR_STATUS_DIM),
+            )));
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(
+                "f force remove  •  n/esc cancel",
+                Style::default().fg(COLOR_STATUS_DIM),
+            )));
+        }
+    }
+    let p = Paragraph::new(lines).wrap(Wrap { trim: false });
+    f.render_widget(p, inner);
+}
+
+// --- Purposes screen -------------------------------------------------------
+
+fn draw_purposes_screen(f: &mut Frame, app: &mut App) {
+    let area = f.area();
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(1)])
+        .split(area);
+    draw_purposes_list(f, app, chunks[0]);
+    draw_purposes_hint_bar(f, app, chunks[1]);
+
+    if app.purposes_view.editor.is_some() {
+        draw_purpose_editor_popup(f, app);
+    }
+}
+
+fn draw_purposes_list(f: &mut Frame, app: &App, area: Rect) {
+    let view = &app.purposes_view;
+    let header = Line::from(vec![
+        Span::styled(format!("{:<14}", "Purpose"), Style::default().fg(Color::Rgb(136, 214, 240)).add_modifier(Modifier::BOLD)),
+        Span::styled(format!("{:<22}", "Connection"), Style::default().fg(Color::Rgb(136, 214, 240)).add_modifier(Modifier::BOLD)),
+        Span::styled(format!("{:<30}", "Model"), Style::default().fg(Color::Rgb(136, 214, 240)).add_modifier(Modifier::BOLD)),
+        Span::styled("Effort", Style::default().fg(Color::Rgb(136, 214, 240)).add_modifier(Modifier::BOLD)),
+    ]);
+
+    let items: Vec<ListItem> = PURPOSES_ORDER
+        .iter()
+        .map(|p| {
+            let cfg = match p {
+                api::PurposeKindApi::Interactive => view.purposes.interactive.as_ref(),
+                api::PurposeKindApi::Dreaming => view.purposes.dreaming.as_ref(),
+                api::PurposeKindApi::Embedding => view.purposes.embedding.as_ref(),
+                api::PurposeKindApi::Titling => view.purposes.titling.as_ref(),
+            };
+            let (conn, model, effort) = match cfg {
+                Some(c) => (c.connection.clone(), c.model.clone(), c.effort),
+                None => ("—".into(), "—".into(), None),
+            };
+            ListItem::new(Line::from(vec![
+                Span::styled(
+                    format!("{:<14}", purpose_label(*p)),
+                    Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(format!("{conn:<22}"), Style::default().fg(Color::Rgb(216, 223, 236))),
+                Span::styled(format!("{model:<30}"), Style::default().fg(Color::Rgb(216, 223, 236))),
+                Span::styled(effort_label(effort), Style::default().fg(Color::Rgb(216, 223, 236))),
+            ]))
+        })
+        .collect();
+
+    let title = if view.loading {
+        "Purposes (loading…)"
+    } else {
+        "Purposes"
+    };
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(COLOR_LIST_BORDER))
+        .title(Line::from(Span::styled(
+            title,
+            Style::default()
+                .fg(Color::Rgb(136, 214, 240))
+                .add_modifier(Modifier::BOLD),
+        )));
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    // Split header from list body.
+    let body = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Length(1), Constraint::Min(1)])
+        .split(inner);
+
+    let header_p = Paragraph::new(header);
+    f.render_widget(header_p, body[0]);
+
+    let list = List::new(items)
+        .highlight_style(
+            Style::default()
+                .bg(COLOR_LIST_HIGHLIGHT)
+                .fg(COLOR_LIST_HIGHLIGHT_FG)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("▸ ");
+    let mut state = ListState::default();
+    state.select(Some(view.selected));
+    f.render_stateful_widget(list, body[1], &mut state);
+}
+
+fn draw_purposes_hint_bar(f: &mut Frame, app: &App, area: Rect) {
+    let hint = match &app.purposes_view.status {
+        Some(s) => s.clone(),
+        None => "j/k navigate  •  c/⏎ edit  •  q/esc back".into(),
+    };
+    let p = Paragraph::new(Line::from(Span::styled(
+        hint,
+        Style::default().fg(COLOR_STATUS_DIM),
+    )));
+    f.render_widget(p, area);
+}
+
+fn draw_purpose_editor_popup(f: &mut Frame, app: &App) {
+    let Some(editor) = app.purposes_view.editor.as_ref() else {
+        return;
+    };
+    let area = centered_rect(70, 50, f.area());
+    f.render_widget(Clear, area);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(COLOR_PANEL_BORDER))
+        .title(Line::from(Span::styled(
+            format!("Edit purpose — {}", purpose_label(editor.purpose)),
+            Style::default()
+                .fg(Color::Rgb(166, 182, 255))
+                .add_modifier(Modifier::BOLD),
+        )));
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    let lines = vec![
+        form_row("Connection", &editor.connection, editor.field == PurposeField::Connection, false),
+        form_row("Model", &editor.model, editor.field == PurposeField::Model, false),
+        form_row(
+            "Effort",
+            effort_label(editor.effort),
+            editor.field == PurposeField::Effort,
+            false,
+        ),
+        Line::from(""),
+        Line::from(Span::styled(
+            "Connection/Model accept a connection id, a model id, or \"primary\" (not allowed on interactive).",
+            Style::default().fg(COLOR_STATUS_DIM),
+        )),
+        Line::from(Span::styled(
+            "Effort: (l)ow, (m)edium, (h)igh, (x) clear",
+            Style::default().fg(COLOR_STATUS_DIM),
+        )),
+        Line::from(Span::styled(
+            "Tab/Shift-Tab: next/prev field  •  Enter: save  •  Esc: cancel",
+            Style::default().fg(COLOR_STATUS_DIM),
+        )),
+    ];
+    let mut lines = lines;
+    if let Some(err) = editor.error.as_deref() {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            format!("Error: {err}"),
+            Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
+        )));
+    }
+    let p = Paragraph::new(lines).wrap(Wrap { trim: false });
+    f.render_widget(p, inner);
+}
+
+// --- Model selector popup --------------------------------------------------
+
+fn draw_model_selector_popup(f: &mut Frame, app: &App) {
+    let area = centered_rect(60, 60, f.area());
+    f.render_widget(Clear, area);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(COLOR_PANEL_BORDER))
+        .title(Line::from(Span::styled(
+            "Select model for this conversation",
+            Style::default()
+                .fg(Color::Rgb(166, 182, 255))
+                .add_modifier(Modifier::BOLD),
+        )));
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    let view = &app.model_selector;
+
+    let mut items: Vec<ListItem> = Vec::with_capacity(view.entries.len() + 1);
+    items.push(ListItem::new(Line::from(vec![Span::styled(
+        "Auto (coming soon)",
+        Style::default()
+            .fg(COLOR_STATUS_DIM)
+            .add_modifier(Modifier::ITALIC),
+    )])));
+    for entry in &view.entries {
+        let label = format!("{} · {}", entry.connection_label, entry.model.display_name);
+        let meta = {
+            let mut caps = Vec::new();
+            if entry.model.capabilities.reasoning {
+                caps.push("reasoning");
+            }
+            if entry.model.capabilities.vision {
+                caps.push("vision");
+            }
+            if entry.model.capabilities.tools {
+                caps.push("tools");
+            }
+            if entry.model.capabilities.embedding {
+                caps.push("embedding");
+            }
+            if caps.is_empty() {
+                String::new()
+            } else {
+                format!(" [{}]", caps.join(","))
+            }
+        };
+        items.push(ListItem::new(Line::from(vec![
+            Span::styled(label, Style::default().fg(Color::White)),
+            Span::styled(meta, Style::default().fg(COLOR_STATUS_DIM)),
+        ])));
+    }
+
+    let body_rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(1), Constraint::Length(2)])
+        .split(inner);
+
+    let list = List::new(items)
+        .highlight_style(
+            Style::default()
+                .bg(COLOR_LIST_HIGHLIGHT)
+                .fg(COLOR_LIST_HIGHLIGHT_FG)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("▸ ");
+    let mut state = ListState::default();
+    state.select(Some(view.highlight));
+    f.render_stateful_widget(list, body_rows[0], &mut state);
+
+    let hint = match &view.status {
+        Some(s) => s.clone(),
+        None => {
+            let sel = app
+                .current_conversation
+                .as_ref()
+                .and_then(|c| app.conversation_selections.get(&c.id));
+            format!(
+                "current: {}   •   j/k navigate  •  Enter confirm  •  r refresh  •  Esc cancel",
+                selector::status_bar_label(sel),
+            )
+        }
+    };
+    let p = Paragraph::new(Line::from(Span::styled(
+        hint,
+        Style::default().fg(COLOR_STATUS_DIM),
+    )))
+    .alignment(Alignment::Left)
+    .wrap(Wrap { trim: true });
+    f.render_widget(p, body_rows[1]);
+}
+
+// --- layout helpers --------------------------------------------------------
+
+fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
+    let vertical = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - percent_y) / 2),
+            Constraint::Percentage(percent_y),
+            Constraint::Percentage((100 - percent_y) / 2),
+        ])
+        .split(area);
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(vertical[1])[1]
 }
 
 #[cfg(test)]
@@ -312,6 +902,7 @@ mod tests {
                     content: "Hi there!".into(),
                 },
             ],
+            warnings: vec![],
         });
         terminal.draw(|f| draw(f, &mut app)).unwrap();
     }
@@ -325,6 +916,7 @@ mod tests {
             id: "1".into(),
             title: "Test".into(),
             messages: vec![],
+    warnings: vec![],
         });
         app.start_streaming("req1".into());
         app.receive_chunk("req1", "Partial response...");
@@ -356,5 +948,150 @@ mod tests {
         let mut terminal = Terminal::new(backend).unwrap();
         let mut app = App::new();
         terminal.draw(|f| draw(f, &mut app)).unwrap();
+    }
+
+    #[test]
+    fn draw_connections_screen_does_not_panic() {
+        let backend = TestBackend::new(100, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut app = App::new();
+        app.screen = Screen::Connections;
+        app.connections_view.connections = vec![
+            crate::views::connections::tests_fixture("primary", "openai"),
+            crate::views::connections::tests_fixture("work", "anthropic"),
+        ];
+        app.connections_view.selected = Some(0);
+        terminal.draw(|f| draw(f, &mut app)).unwrap();
+    }
+
+    #[test]
+    fn draw_connection_form_popup_does_not_panic() {
+        let backend = TestBackend::new(100, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut app = App::new();
+        app.screen = Screen::Connections;
+        app.connections_view.start_add();
+        terminal.draw(|f| draw(f, &mut app)).unwrap();
+    }
+
+    #[test]
+    fn draw_connection_delete_popup_does_not_panic() {
+        let backend = TestBackend::new(100, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut app = App::new();
+        app.screen = Screen::Connections;
+        app.connections_view.connections =
+            vec![crate::views::connections::tests_fixture("a", "openai")];
+        app.connections_view.selected = Some(0);
+        app.connections_view.start_delete();
+        terminal.draw(|f| draw(f, &mut app)).unwrap();
+    }
+
+    #[test]
+    fn draw_purposes_screen_does_not_panic() {
+        let backend = TestBackend::new(100, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut app = App::new();
+        app.screen = Screen::Purposes;
+        app.purposes_view.purposes = api::PurposesView {
+            interactive: Some(api::PurposeConfigView {
+                connection: "primary".into(),
+                model: "gpt-5".into(),
+                effort: Some(api::EffortLevel::High),
+            }),
+            ..Default::default()
+        };
+        terminal.draw(|f| draw(f, &mut app)).unwrap();
+    }
+
+    #[test]
+    fn draw_purpose_editor_popup_does_not_panic() {
+        let backend = TestBackend::new(100, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut app = App::new();
+        app.screen = Screen::Purposes;
+        app.purposes_view.start_edit();
+        terminal.draw(|f| draw(f, &mut app)).unwrap();
+    }
+
+    #[test]
+    fn draw_model_selector_popup_does_not_panic() {
+        let backend = TestBackend::new(100, 30);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut app = App::new();
+        app.model_selector.open = true;
+        app.model_selector.entries = vec![api::ModelListing {
+            connection_id: "work".into(),
+            connection_label: "work".into(),
+            model: api::ModelInfoView {
+                id: "gpt-5".into(),
+                display_name: "GPT-5".into(),
+                context_limit: Some(200_000),
+                capabilities: api::ModelCapabilitiesView {
+                    reasoning: true,
+                    vision: true,
+                    tools: true,
+                    embedding: false,
+                },
+            },
+        }];
+        terminal.draw(|f| draw(f, &mut app)).unwrap();
+    }
+
+    #[test]
+    fn status_bar_shows_auto_label_by_default() {
+        let app = App::new();
+        assert_eq!(app.current_selection_label(), "Auto (purpose)");
+    }
+
+    #[test]
+    fn status_bar_shows_pinned_model_when_set() {
+        let mut app = App::new();
+        app.current_conversation = Some(ConversationDetail {
+            id: "c1".into(),
+            title: "Test".into(),
+            messages: vec![],
+            warnings: vec![],
+        });
+        app.conversation_selections.set(
+            "c1".into(),
+            api::SendPromptOverride {
+                connection_id: "work".into(),
+                model_id: "gpt-5".into(),
+                effort: None,
+            },
+        );
+        assert_eq!(app.current_selection_label(), "work · gpt-5");
+    }
+
+    #[test]
+    fn dangling_warning_on_load_sets_inline_notice_and_hydrates_selection() {
+        let mut app = App::new();
+        app.load_conversation(ConversationDetail {
+            id: "c1".into(),
+            title: "Test".into(),
+            messages: vec![],
+            warnings: vec![api::ConversationWarning::DanglingModelSelection {
+                previous_selection: api::ConversationModelSelectionView {
+                    connection_id: "old".into(),
+                    model_id: "gone".into(),
+                    effort: None,
+                },
+                fallback_to: api::ConversationModelSelectionView {
+                    connection_id: "new".into(),
+                    model_id: "ok".into(),
+                    effort: None,
+                },
+            }],
+        });
+        assert!(app.inline_notice.as_deref().unwrap().contains("old·gone"));
+        // Selection was hydrated from the fallback.
+        assert_eq!(
+            app.conversation_selections
+                .get("c1")
+                .unwrap()
+                .connection_id,
+            "new"
+        );
     }
 }

--- a/src/views/connections.rs
+++ b/src/views/connections.rs
@@ -1,0 +1,573 @@
+//! Connections view: list + per-connector-type configure form + delete confirm.
+//!
+//! Interaction surface mirrors the GitHub issue: Add (`a`), Configure (`c`/enter),
+//! Remove (`d`), Back (`q`/esc). The form's field set diverges per connector
+//! type (anthropic/openai/bedrock/ollama).
+
+use desktop_assistant_client_common::api;
+
+/// Connector variants the TUI can create/edit. Mirrors the tag on
+/// [`api::ConnectionConfigView`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConnectorKind {
+    Anthropic,
+    OpenAi,
+    Bedrock,
+    Ollama,
+}
+
+impl ConnectorKind {
+    pub const ALL: [ConnectorKind; 4] = [
+        ConnectorKind::Anthropic,
+        ConnectorKind::OpenAi,
+        ConnectorKind::Bedrock,
+        ConnectorKind::Ollama,
+    ];
+
+    pub fn as_label(self) -> &'static str {
+        match self {
+            ConnectorKind::Anthropic => "anthropic",
+            ConnectorKind::OpenAi => "openai",
+            ConnectorKind::Bedrock => "bedrock",
+            ConnectorKind::Ollama => "ollama",
+        }
+    }
+
+    pub fn from_api(tag: &str) -> Option<Self> {
+        match tag {
+            "anthropic" => Some(ConnectorKind::Anthropic),
+            "openai" => Some(ConnectorKind::OpenAi),
+            "bedrock" => Some(ConnectorKind::Bedrock),
+            "ollama" => Some(ConnectorKind::Ollama),
+            _ => None,
+        }
+    }
+
+    /// Editable fields for this connector, in tab order.
+    pub fn fields(self) -> &'static [FormField] {
+        match self {
+            ConnectorKind::Anthropic => &[FormField::ApiKeyEnv, FormField::BaseUrl],
+            ConnectorKind::OpenAi => &[FormField::ApiKeyEnv, FormField::BaseUrl],
+            ConnectorKind::Bedrock => &[
+                FormField::AwsProfile,
+                FormField::Region,
+                FormField::BaseUrl,
+            ],
+            ConnectorKind::Ollama => &[FormField::BaseUrl, FormField::OllamaAutoPull],
+        }
+    }
+}
+
+/// Individual editable fields across all connector forms.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FormField {
+    /// Name of the env var that holds the API key (we never store the key itself).
+    ApiKeyEnv,
+    BaseUrl,
+    AwsProfile,
+    Region,
+    /// Ollama-only toggle (true/false).
+    OllamaAutoPull,
+}
+
+impl FormField {
+    pub fn label(self) -> &'static str {
+        match self {
+            FormField::ApiKeyEnv => "API Key (env var name)",
+            FormField::BaseUrl => "Base URL",
+            FormField::AwsProfile => "AWS Profile",
+            FormField::Region => "AWS Region",
+            FormField::OllamaAutoPull => "Auto-pull",
+        }
+    }
+
+    pub fn is_toggle(self) -> bool {
+        matches!(self, FormField::OllamaAutoPull)
+    }
+}
+
+/// In-memory form state. Each connector uses only a subset of these strings;
+/// the `ConnectorKind::fields` slice is the source of truth for rendering and
+/// tab order.
+#[derive(Debug, Clone)]
+pub struct ConnectionForm {
+    pub id: String,
+    pub kind: ConnectorKind,
+    pub api_key_env: String,
+    pub base_url: String,
+    pub aws_profile: String,
+    pub region: String,
+    pub ollama_auto_pull: bool,
+    /// True when editing an existing connection (id becomes read-only).
+    pub existing: bool,
+    /// Index into `[FormField::IdField, …kind.fields()]` — 0 targets the id row.
+    pub field_cursor: usize,
+    /// Last error message from the daemon (e.g. invalid slug, duplicate id).
+    pub error: Option<String>,
+}
+
+impl ConnectionForm {
+    pub fn new_for_add() -> Self {
+        Self {
+            id: String::new(),
+            kind: ConnectorKind::Anthropic,
+            api_key_env: String::new(),
+            base_url: String::new(),
+            aws_profile: String::new(),
+            region: String::new(),
+            ollama_auto_pull: false,
+            existing: false,
+            field_cursor: 0,
+            error: None,
+        }
+    }
+
+    pub fn from_existing(view: &api::ConnectionView) -> Self {
+        // We can't hydrate secret fields (daemon returns `has_credentials`, not
+        // the key). Existing env-var / base-url values aren't on the
+        // ConnectionView either — the user re-enters them to update.
+        let kind = ConnectorKind::from_api(&view.connector_type).unwrap_or(ConnectorKind::Anthropic);
+        Self {
+            id: view.id.clone(),
+            kind,
+            api_key_env: String::new(),
+            base_url: String::new(),
+            aws_profile: String::new(),
+            region: String::new(),
+            ollama_auto_pull: false,
+            existing: true,
+            field_cursor: 0,
+            error: None,
+        }
+    }
+
+    /// Total row count: id + connector-kind picker + fields for the current kind.
+    /// Cursor positions:
+    ///   0 -> id
+    ///   1 -> connector kind picker
+    ///   2..(2 + n) -> connector-specific fields
+    pub fn row_count(&self) -> usize {
+        2 + self.kind.fields().len()
+    }
+
+    pub fn next_field(&mut self) {
+        self.field_cursor = (self.field_cursor + 1) % self.row_count();
+    }
+
+    pub fn previous_field(&mut self) {
+        let count = self.row_count();
+        self.field_cursor = (self.field_cursor + count - 1) % count;
+    }
+
+    pub fn is_on_id(&self) -> bool {
+        self.field_cursor == 0
+    }
+
+    pub fn is_on_kind(&self) -> bool {
+        self.field_cursor == 1
+    }
+
+    pub fn current_field(&self) -> Option<FormField> {
+        if self.field_cursor < 2 {
+            return None;
+        }
+        self.kind.fields().get(self.field_cursor - 2).copied()
+    }
+
+    pub fn cycle_kind_next(&mut self) {
+        let idx = ConnectorKind::ALL
+            .iter()
+            .position(|k| *k == self.kind)
+            .unwrap_or(0);
+        self.kind = ConnectorKind::ALL[(idx + 1) % ConnectorKind::ALL.len()];
+        // Reset kind-specific cursor overrun.
+        self.field_cursor = self.field_cursor.min(self.row_count() - 1);
+    }
+
+    pub fn cycle_kind_prev(&mut self) {
+        let idx = ConnectorKind::ALL
+            .iter()
+            .position(|k| *k == self.kind)
+            .unwrap_or(0);
+        let len = ConnectorKind::ALL.len();
+        self.kind = ConnectorKind::ALL[(idx + len - 1) % len];
+        self.field_cursor = self.field_cursor.min(self.row_count() - 1);
+    }
+
+    pub fn toggle_auto_pull(&mut self) {
+        self.ollama_auto_pull = !self.ollama_auto_pull;
+    }
+
+    pub fn insert_char(&mut self, ch: char) {
+        if self.existing && self.is_on_id() {
+            return; // id is read-only for updates
+        }
+        if let Some(field) = self.current_field()
+            && field.is_toggle()
+        {
+            // Single-char yes/no toggle — 'y'/'n'/' '/'t'/'f'
+            let lower = ch.to_ascii_lowercase();
+            match lower {
+                'y' | 't' | '1' => self.ollama_auto_pull = true,
+                'n' | 'f' | '0' => self.ollama_auto_pull = false,
+                ' ' => self.toggle_auto_pull(),
+                _ => {}
+            }
+            return;
+        }
+        self.current_string_mut().push(ch);
+    }
+
+    pub fn backspace(&mut self) {
+        if self.existing && self.is_on_id() {
+            return;
+        }
+        if let Some(field) = self.current_field()
+            && field.is_toggle()
+        {
+            // Backspace on a toggle clears to false.
+            self.ollama_auto_pull = false;
+            return;
+        }
+        self.current_string_mut().pop();
+    }
+
+    fn current_string_mut(&mut self) -> &mut String {
+        if self.is_on_id() {
+            return &mut self.id;
+        }
+        if self.is_on_kind() {
+            // Kind rows are cycled, not typed — fall through to a scratch
+            // buffer would lose data; just return id which is a harmless no-op
+            // since callers only reach here after current_field() returns Some.
+            // But just in case, point to api_key_env.
+            return &mut self.api_key_env;
+        }
+        match self.current_field() {
+            Some(FormField::ApiKeyEnv) => &mut self.api_key_env,
+            Some(FormField::BaseUrl) => &mut self.base_url,
+            Some(FormField::AwsProfile) => &mut self.aws_profile,
+            Some(FormField::Region) => &mut self.region,
+            Some(FormField::OllamaAutoPull) | None => &mut self.api_key_env,
+        }
+    }
+
+    /// Build the wire-format config to send to the daemon. Returns `None`
+    /// when the form is incomplete (e.g. no id).
+    pub fn to_api_config(&self) -> Option<api::ConnectionConfigView> {
+        if self.id.trim().is_empty() {
+            return None;
+        }
+        let opt = |s: &str| {
+            let t = s.trim();
+            if t.is_empty() { None } else { Some(t.to_string()) }
+        };
+        Some(match self.kind {
+            ConnectorKind::Anthropic => api::ConnectionConfigView::Anthropic {
+                base_url: opt(&self.base_url),
+                api_key_env: opt(&self.api_key_env),
+            },
+            ConnectorKind::OpenAi => api::ConnectionConfigView::OpenAi {
+                base_url: opt(&self.base_url),
+                api_key_env: opt(&self.api_key_env),
+            },
+            ConnectorKind::Bedrock => api::ConnectionConfigView::Bedrock {
+                aws_profile: opt(&self.aws_profile),
+                region: opt(&self.region),
+                base_url: opt(&self.base_url),
+            },
+            ConnectorKind::Ollama => api::ConnectionConfigView::Ollama {
+                base_url: opt(&self.base_url),
+                // NB: the daemon's ConnectionConfigView::Ollama variant does
+                // not carry an auto_pull bit today — it's a TUI-side
+                // presentation flag that the daemon can honor in a follow-up.
+            },
+        })
+    }
+}
+
+/// Confirmation flow for deleting a connection. First attempt sends
+/// `force=false`; if the daemon refuses (conn is referenced by a purpose)
+/// we advance to [`DeleteStage::OfferForce`] and show the server message so
+/// the user can retry with `force=true`.
+#[derive(Debug, Clone)]
+pub struct DeletePrompt {
+    pub id: String,
+    pub stage: DeleteStage,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DeleteStage {
+    /// Initial yes/no — confirm and send `force=false`.
+    Initial,
+    /// Server refused; surface its reason and offer `force=true`.
+    OfferForce { server_error: String },
+}
+
+impl DeletePrompt {
+    pub fn initial(id: String) -> Self {
+        Self {
+            id,
+            stage: DeleteStage::Initial,
+        }
+    }
+
+    pub fn advance_to_force(&mut self, server_error: String) {
+        self.stage = DeleteStage::OfferForce { server_error };
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ConnectionsView {
+    pub connections: Vec<api::ConnectionView>,
+    pub selected: Option<usize>,
+    pub loading: bool,
+    pub status: Option<String>,
+    pub form: Option<ConnectionForm>,
+    pub delete: Option<DeletePrompt>,
+}
+
+impl ConnectionsView {
+    pub fn set_connections(&mut self, items: Vec<api::ConnectionView>) {
+        self.connections = items;
+        self.loading = false;
+        if self.connections.is_empty() {
+            self.selected = None;
+        } else if self.selected.is_none() {
+            self.selected = Some(0);
+        } else if let Some(idx) = self.selected
+            && idx >= self.connections.len()
+        {
+            self.selected = Some(self.connections.len() - 1);
+        }
+    }
+
+    pub fn select_next(&mut self) {
+        if self.connections.is_empty() {
+            return;
+        }
+        self.selected = Some(match self.selected {
+            Some(i) if i + 1 >= self.connections.len() => 0,
+            Some(i) => i + 1,
+            None => 0,
+        });
+    }
+
+    pub fn select_previous(&mut self) {
+        if self.connections.is_empty() {
+            return;
+        }
+        self.selected = Some(match self.selected {
+            Some(0) | None => self.connections.len() - 1,
+            Some(i) => i - 1,
+        });
+    }
+
+    pub fn selected_connection(&self) -> Option<&api::ConnectionView> {
+        self.connections.get(self.selected?)
+    }
+
+    pub fn start_add(&mut self) {
+        self.form = Some(ConnectionForm::new_for_add());
+    }
+
+    pub fn start_configure(&mut self) {
+        if let Some(conn) = self.selected_connection() {
+            self.form = Some(ConnectionForm::from_existing(conn));
+        }
+    }
+
+    pub fn start_delete(&mut self) {
+        if let Some(conn) = self.selected_connection() {
+            self.delete = Some(DeletePrompt::initial(conn.id.clone()));
+        }
+    }
+
+    pub fn close_overlay(&mut self) {
+        self.form = None;
+        self.delete = None;
+    }
+}
+
+/// Test-only helper so sibling modules can construct a `ConnectionView`
+/// without duplicating the boilerplate.
+#[cfg(test)]
+pub fn tests_fixture(id: &str, ty: &str) -> api::ConnectionView {
+    api::ConnectionView {
+        id: id.into(),
+        connector_type: ty.into(),
+        display_label: format!("{id} ({ty})"),
+        availability: api::ConnectionAvailability::Ok,
+        has_credentials: true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_view(id: &str, ty: &str) -> api::ConnectionView {
+        tests_fixture(id, ty)
+    }
+
+    #[test]
+    fn set_connections_picks_first_by_default() {
+        let mut v = ConnectionsView::default();
+        v.set_connections(vec![sample_view("a", "openai")]);
+        assert_eq!(v.selected, Some(0));
+    }
+
+    #[test]
+    fn select_wraps() {
+        let mut v = ConnectionsView::default();
+        v.set_connections(vec![
+            sample_view("a", "openai"),
+            sample_view("b", "anthropic"),
+        ]);
+        v.selected = Some(1);
+        v.select_next();
+        assert_eq!(v.selected, Some(0));
+        v.select_previous();
+        assert_eq!(v.selected, Some(1));
+    }
+
+    #[test]
+    fn empty_connections_clears_selection() {
+        let mut v = ConnectionsView::default();
+        v.set_connections(vec![sample_view("a", "openai")]);
+        v.set_connections(Vec::new());
+        assert_eq!(v.selected, None);
+    }
+
+    #[test]
+    fn form_for_add_defaults_to_anthropic() {
+        let f = ConnectionForm::new_for_add();
+        assert_eq!(f.kind, ConnectorKind::Anthropic);
+        assert_eq!(f.field_cursor, 0);
+        assert!(!f.existing);
+    }
+
+    #[test]
+    fn form_cycles_kind_and_clamps_cursor() {
+        let mut f = ConnectionForm::new_for_add();
+        f.kind = ConnectorKind::Bedrock;
+        // bedrock has 3 fields so rows = 5
+        f.field_cursor = 4;
+        f.cycle_kind_next(); // -> Ollama (2 fields, rows = 4)
+        assert_eq!(f.kind, ConnectorKind::Ollama);
+        assert!(f.field_cursor < f.row_count());
+    }
+
+    #[test]
+    fn form_rejects_id_edits_on_existing() {
+        let view = sample_view("work", "openai");
+        let mut f = ConnectionForm::from_existing(&view);
+        assert!(f.existing);
+        assert_eq!(f.field_cursor, 0); // on id
+        f.insert_char('x');
+        assert_eq!(f.id, "work");
+    }
+
+    #[test]
+    fn form_tabs_through_fields() {
+        let mut f = ConnectionForm::new_for_add();
+        // Anthropic: rows = 2 + 2 = 4
+        assert_eq!(f.row_count(), 4);
+        f.next_field(); // 1
+        f.next_field(); // 2
+        assert_eq!(f.current_field(), Some(FormField::ApiKeyEnv));
+        f.next_field(); // 3
+        assert_eq!(f.current_field(), Some(FormField::BaseUrl));
+        f.next_field(); // 0
+        assert_eq!(f.field_cursor, 0);
+    }
+
+    #[test]
+    fn form_api_key_env_populated_to_api_config() {
+        let mut f = ConnectionForm::new_for_add();
+        f.id = "work".into();
+        // Land on ApiKeyEnv (index 2) and type.
+        f.field_cursor = 2;
+        for c in "OPENAI_WORK_KEY".chars() {
+            f.insert_char(c);
+        }
+        // Next is BaseUrl (index 3)
+        f.field_cursor = 3;
+        for c in "https://api.example/v1".chars() {
+            f.insert_char(c);
+        }
+        let cfg = f.to_api_config().unwrap();
+        match cfg {
+            api::ConnectionConfigView::Anthropic {
+                base_url,
+                api_key_env,
+            } => {
+                assert_eq!(api_key_env.as_deref(), Some("OPENAI_WORK_KEY"));
+                assert_eq!(base_url.as_deref(), Some("https://api.example/v1"));
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn form_bedrock_api_config_uses_profile_region() {
+        let mut f = ConnectionForm::new_for_add();
+        f.id = "aws".into();
+        f.kind = ConnectorKind::Bedrock;
+        f.field_cursor = 2; // AwsProfile
+        for c in "work".chars() {
+            f.insert_char(c);
+        }
+        f.field_cursor = 3; // Region
+        for c in "us-west-2".chars() {
+            f.insert_char(c);
+        }
+        let cfg = f.to_api_config().unwrap();
+        match cfg {
+            api::ConnectionConfigView::Bedrock {
+                aws_profile,
+                region,
+                base_url,
+            } => {
+                assert_eq!(aws_profile.as_deref(), Some("work"));
+                assert_eq!(region.as_deref(), Some("us-west-2"));
+                assert_eq!(base_url, None);
+            }
+            _ => panic!("wrong variant"),
+        }
+    }
+
+    #[test]
+    fn form_empty_id_fails_to_build() {
+        let mut f = ConnectionForm::new_for_add();
+        f.kind = ConnectorKind::OpenAi;
+        assert!(f.to_api_config().is_none());
+    }
+
+    #[test]
+    fn ollama_toggle_accepts_yn() {
+        let mut f = ConnectionForm::new_for_add();
+        f.kind = ConnectorKind::Ollama;
+        // Ollama fields: BaseUrl (idx 2), OllamaAutoPull (idx 3)
+        f.field_cursor = 3;
+        f.insert_char('y');
+        assert!(f.ollama_auto_pull);
+        f.insert_char('n');
+        assert!(!f.ollama_auto_pull);
+        f.insert_char(' ');
+        assert!(f.ollama_auto_pull);
+    }
+
+    #[test]
+    fn delete_prompt_stages() {
+        let mut p = DeletePrompt::initial("id".into());
+        assert_eq!(p.stage, DeleteStage::Initial);
+        p.advance_to_force("referenced by interactive".into());
+        match p.stage {
+            DeleteStage::OfferForce { ref server_error } => {
+                assert!(server_error.contains("referenced"));
+            }
+            _ => panic!("expected force stage"),
+        }
+    }
+}

--- a/src/views/mod.rs
+++ b/src/views/mod.rs
@@ -1,0 +1,9 @@
+pub mod connections;
+pub mod purposes;
+pub mod selector;
+
+// Re-export only the items directly held as fields on `App`; everything else
+// is reached through the submodule paths to keep the `use` graph readable.
+pub use connections::ConnectionsView;
+pub use purposes::PurposesView;
+pub use selector::{ConversationSelections, ModelSelector};

--- a/src/views/purposes.rs
+++ b/src/views/purposes.rs
@@ -1,0 +1,304 @@
+//! Purposes view: flat (Purpose) (Connection) (Model) (Effort) list.
+//!
+//! Daemon exposes four purposes: Interactive, Dreaming, Embedding, Titling.
+//! Interactive is required and cannot inherit via `"primary"`; the other three
+//! accept `"primary"` in either field to inherit from the interactive purpose.
+
+use desktop_assistant_client_common::api;
+
+pub const PURPOSES_ORDER: [api::PurposeKindApi; 4] = [
+    api::PurposeKindApi::Interactive,
+    api::PurposeKindApi::Dreaming,
+    api::PurposeKindApi::Embedding,
+    api::PurposeKindApi::Titling,
+];
+
+/// Fields a user can edit for a single purpose row.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PurposeField {
+    Connection,
+    Model,
+    Effort,
+}
+
+impl PurposeField {
+    #[allow(dead_code)] // documents the field set for future navigation helpers
+    pub const ALL: [PurposeField; 3] = [
+        PurposeField::Connection,
+        PurposeField::Model,
+        PurposeField::Effort,
+    ];
+
+    #[allow(dead_code)] // exposed for symmetry with `FormField::label`
+    pub fn label(self) -> &'static str {
+        match self {
+            PurposeField::Connection => "Connection",
+            PurposeField::Model => "Model",
+            PurposeField::Effort => "Effort",
+        }
+    }
+}
+
+/// In-memory edit buffer for one row.
+#[derive(Debug, Clone)]
+pub struct PurposeEditor {
+    pub purpose: api::PurposeKindApi,
+    pub connection: String,
+    pub model: String,
+    pub effort: Option<api::EffortLevel>,
+    pub field: PurposeField,
+    /// When typing into the connection/model field, we also show a list of
+    /// candidate suggestions below. The raw candidate list comes from the
+    /// view's model listings.
+    pub error: Option<String>,
+}
+
+impl PurposeEditor {
+    pub fn new(purpose: api::PurposeKindApi, existing: Option<&api::PurposeConfigView>) -> Self {
+        match existing {
+            Some(cfg) => Self {
+                purpose,
+                connection: cfg.connection.clone(),
+                model: cfg.model.clone(),
+                effort: cfg.effort,
+                field: PurposeField::Connection,
+                error: None,
+            },
+            None => {
+                // Sensible starting defaults: interactive inherits nothing
+                // (required both fields), the rest default to "primary".
+                let default_inherit = !matches!(purpose, api::PurposeKindApi::Interactive);
+                Self {
+                    purpose,
+                    connection: if default_inherit { "primary".into() } else { String::new() },
+                    model: if default_inherit { "primary".into() } else { String::new() },
+                    effort: None,
+                    field: PurposeField::Connection,
+                    error: None,
+                }
+            }
+        }
+    }
+
+    pub fn next_field(&mut self) {
+        self.field = match self.field {
+            PurposeField::Connection => PurposeField::Model,
+            PurposeField::Model => PurposeField::Effort,
+            PurposeField::Effort => PurposeField::Connection,
+        };
+    }
+
+    pub fn previous_field(&mut self) {
+        self.field = match self.field {
+            PurposeField::Connection => PurposeField::Effort,
+            PurposeField::Model => PurposeField::Connection,
+            PurposeField::Effort => PurposeField::Model,
+        };
+    }
+
+    pub fn insert_char(&mut self, ch: char) {
+        match self.field {
+            PurposeField::Connection => self.connection.push(ch),
+            PurposeField::Model => self.model.push(ch),
+            PurposeField::Effort => {
+                // Single-letter shortcut: l/m/h
+                match ch.to_ascii_lowercase() {
+                    'l' => self.effort = Some(api::EffortLevel::Low),
+                    'm' => self.effort = Some(api::EffortLevel::Medium),
+                    'h' => self.effort = Some(api::EffortLevel::High),
+                    ' ' | 'x' | 'n' => self.effort = None,
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    pub fn backspace(&mut self) {
+        match self.field {
+            PurposeField::Connection => {
+                self.connection.pop();
+            }
+            PurposeField::Model => {
+                self.model.pop();
+            }
+            PurposeField::Effort => {
+                self.effort = None;
+            }
+        }
+    }
+
+    /// Validate and build the wire config. Interactive may not use `"primary"`.
+    pub fn to_api_config(&self) -> Result<api::PurposeConfigView, String> {
+        let connection = self.connection.trim().to_string();
+        let model = self.model.trim().to_string();
+
+        if connection.is_empty() {
+            return Err("Connection is required".into());
+        }
+        if model.is_empty() {
+            return Err("Model is required".into());
+        }
+
+        if matches!(self.purpose, api::PurposeKindApi::Interactive)
+            && (connection == "primary" || model == "primary")
+        {
+            return Err("Interactive cannot inherit via \"primary\"".into());
+        }
+
+        Ok(api::PurposeConfigView {
+            connection,
+            model,
+            effort: self.effort,
+        })
+    }
+}
+
+/// Purposes view state: purposes snapshot from the daemon plus optional
+/// per-row editor popup.
+#[derive(Debug, Clone, Default)]
+pub struct PurposesView {
+    pub purposes: api::PurposesView,
+    pub selected: usize,
+    pub loading: bool,
+    pub editor: Option<PurposeEditor>,
+    pub status: Option<String>,
+}
+
+impl PurposesView {
+    pub fn set_purposes(&mut self, v: api::PurposesView) {
+        self.purposes = v;
+        self.loading = false;
+    }
+
+    pub fn select_next(&mut self) {
+        self.selected = (self.selected + 1) % PURPOSES_ORDER.len();
+    }
+
+    pub fn select_previous(&mut self) {
+        self.selected = (self.selected + PURPOSES_ORDER.len() - 1) % PURPOSES_ORDER.len();
+    }
+
+    pub fn current_purpose(&self) -> api::PurposeKindApi {
+        PURPOSES_ORDER[self.selected]
+    }
+
+    pub fn current_config(&self) -> Option<&api::PurposeConfigView> {
+        match self.current_purpose() {
+            api::PurposeKindApi::Interactive => self.purposes.interactive.as_ref(),
+            api::PurposeKindApi::Dreaming => self.purposes.dreaming.as_ref(),
+            api::PurposeKindApi::Embedding => self.purposes.embedding.as_ref(),
+            api::PurposeKindApi::Titling => self.purposes.titling.as_ref(),
+        }
+    }
+
+    pub fn start_edit(&mut self) {
+        let purpose = self.current_purpose();
+        let existing = self.current_config().cloned();
+        self.editor = Some(PurposeEditor::new(purpose, existing.as_ref()));
+    }
+
+    pub fn close_editor(&mut self) {
+        self.editor = None;
+    }
+}
+
+pub fn purpose_label(p: api::PurposeKindApi) -> &'static str {
+    match p {
+        api::PurposeKindApi::Interactive => "interactive",
+        api::PurposeKindApi::Dreaming => "dreaming",
+        api::PurposeKindApi::Embedding => "embedding",
+        api::PurposeKindApi::Titling => "titling",
+    }
+}
+
+pub fn effort_label(e: Option<api::EffortLevel>) -> &'static str {
+    match e {
+        Some(api::EffortLevel::Low) => "low",
+        Some(api::EffortLevel::Medium) => "medium",
+        Some(api::EffortLevel::High) => "high",
+        None => "—",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn select_wraps() {
+        let mut v = PurposesView {
+            selected: PURPOSES_ORDER.len() - 1,
+            ..Default::default()
+        };
+        v.select_next();
+        assert_eq!(v.selected, 0);
+        v.select_previous();
+        assert_eq!(v.selected, PURPOSES_ORDER.len() - 1);
+    }
+
+    #[test]
+    fn editor_defaults_for_non_interactive_inherit() {
+        let ed = PurposeEditor::new(api::PurposeKindApi::Dreaming, None);
+        assert_eq!(ed.connection, "primary");
+        assert_eq!(ed.model, "primary");
+    }
+
+    #[test]
+    fn editor_defaults_for_interactive_blank() {
+        let ed = PurposeEditor::new(api::PurposeKindApi::Interactive, None);
+        assert_eq!(ed.connection, "");
+        assert_eq!(ed.model, "");
+    }
+
+    #[test]
+    fn editor_validation_rejects_primary_on_interactive() {
+        let ed = PurposeEditor {
+            purpose: api::PurposeKindApi::Interactive,
+            connection: "primary".into(),
+            model: "gpt-5".into(),
+            effort: None,
+            field: PurposeField::Connection,
+            error: None,
+        };
+        assert!(ed.to_api_config().is_err());
+    }
+
+    #[test]
+    fn editor_validation_accepts_primary_elsewhere() {
+        let ed = PurposeEditor {
+            purpose: api::PurposeKindApi::Titling,
+            connection: "primary".into(),
+            model: "primary".into(),
+            effort: Some(api::EffortLevel::Low),
+            field: PurposeField::Connection,
+            error: None,
+        };
+        let cfg = ed.to_api_config().unwrap();
+        assert_eq!(cfg.connection, "primary");
+        assert_eq!(cfg.effort, Some(api::EffortLevel::Low));
+    }
+
+    #[test]
+    fn editor_effort_shortcut_keys() {
+        let mut ed = PurposeEditor::new(api::PurposeKindApi::Dreaming, None);
+        ed.field = PurposeField::Effort;
+        ed.insert_char('h');
+        assert_eq!(ed.effort, Some(api::EffortLevel::High));
+        ed.insert_char('m');
+        assert_eq!(ed.effort, Some(api::EffortLevel::Medium));
+        ed.insert_char('x'); // clear
+        assert_eq!(ed.effort, None);
+    }
+
+    #[test]
+    fn from_existing_round_trips_effort() {
+        let existing = api::PurposeConfigView {
+            connection: "work".into(),
+            model: "gpt-5".into(),
+            effort: Some(api::EffortLevel::High),
+        };
+        let ed = PurposeEditor::new(api::PurposeKindApi::Interactive, Some(&existing));
+        assert_eq!(ed.effort, Some(api::EffortLevel::High));
+        assert_eq!(ed.connection, "work");
+    }
+}

--- a/src/views/selector.rs
+++ b/src/views/selector.rs
@@ -1,0 +1,298 @@
+//! Per-conversation model selector — popup + state store.
+//!
+//! The popup flattens `ListAvailableModels` into `"<connection> · <model>"`
+//! rows across every healthy connection. A disabled `Auto (coming soon)`
+//! row is pinned at the top per the ticket. Picking an entry stashes the
+//! selection in the per-conversation map, which the chat view's next
+//! `SendMessage` threads into `override_selection`.
+
+use std::collections::HashMap;
+
+use desktop_assistant_client_common::api;
+
+/// Sticky per-conversation selection; lives in-app until the daemon starts
+/// round-tripping `last_model_selection` on `GetConversation`
+/// (see desktop-assistant#18). Independent of the daemon-persisted selection
+/// — the daemon is still authoritative; we just track what the user last
+/// picked in this session so the popup / status bar can reflect it.
+#[derive(Debug, Clone, Default)]
+pub struct ConversationSelections {
+    inner: HashMap<String, api::SendPromptOverride>,
+}
+
+impl ConversationSelections {
+    pub fn get(&self, conversation_id: &str) -> Option<&api::SendPromptOverride> {
+        self.inner.get(conversation_id)
+    }
+
+    pub fn set(&mut self, conversation_id: String, override_sel: api::SendPromptOverride) {
+        self.inner.insert(conversation_id, override_sel);
+    }
+
+    pub fn clear(&mut self, conversation_id: &str) {
+        self.inner.remove(conversation_id);
+    }
+
+    pub fn hydrate_from_dangling_fallback(
+        &mut self,
+        conversation_id: &str,
+        fallback: &api::ConversationModelSelectionView,
+    ) {
+        self.inner.insert(
+            conversation_id.to_string(),
+            api::SendPromptOverride {
+                connection_id: fallback.connection_id.clone(),
+                model_id: fallback.model_id.clone(),
+                effort: fallback.effort,
+            },
+        );
+    }
+}
+
+/// Popup state for picking a model for the active conversation.
+#[derive(Debug, Clone, Default)]
+pub struct ModelSelector {
+    pub open: bool,
+    pub loading: bool,
+    pub entries: Vec<api::ModelListing>,
+    /// Highlighted row. Index 0 is the disabled "Auto" row — we skip past it
+    /// on open when possible so Enter doesn't land on a no-op.
+    pub highlight: usize,
+    pub status: Option<String>,
+}
+
+impl ModelSelector {
+    pub fn total_rows(&self) -> usize {
+        // +1 for the pinned Auto row
+        self.entries.len() + 1
+    }
+
+    pub fn open(&mut self) {
+        self.open = true;
+        self.highlight = if self.entries.is_empty() { 0 } else { 1 };
+    }
+
+    pub fn close(&mut self) {
+        self.open = false;
+    }
+
+    pub fn set_entries(&mut self, entries: Vec<api::ModelListing>) {
+        self.entries = entries;
+        self.loading = false;
+        if self.highlight >= self.total_rows() {
+            self.highlight = self.total_rows().saturating_sub(1);
+        }
+    }
+
+    pub fn highlight_next(&mut self) {
+        let total = self.total_rows();
+        if total == 0 {
+            return;
+        }
+        self.highlight = (self.highlight + 1) % total;
+    }
+
+    pub fn highlight_previous(&mut self) {
+        let total = self.total_rows();
+        if total == 0 {
+            return;
+        }
+        self.highlight = (self.highlight + total - 1) % total;
+    }
+
+    /// The currently highlighted entry, or `None` when the auto row is selected
+    /// (index 0) or the list is empty.
+    pub fn selected_entry(&self) -> Option<&api::ModelListing> {
+        if self.highlight == 0 {
+            return None;
+        }
+        self.entries.get(self.highlight - 1)
+    }
+
+    /// Position the highlight on the entry that matches the given
+    /// (connection, model) pair, if any. Otherwise leave it on the first
+    /// real entry (after the Auto row).
+    pub fn highlight_for(&mut self, sel: Option<&api::SendPromptOverride>) {
+        if let Some(sel) = sel {
+            for (i, entry) in self.entries.iter().enumerate() {
+                if entry.connection_id == sel.connection_id && entry.model.id == sel.model_id {
+                    self.highlight = i + 1;
+                    return;
+                }
+            }
+        }
+        self.highlight = if self.entries.is_empty() { 0 } else { 1 };
+    }
+}
+
+/// Human-readable representation of an override for the status bar.
+pub fn status_bar_label(sel: Option<&api::SendPromptOverride>) -> String {
+    match sel {
+        Some(sel) => {
+            let base = format!("{} · {}", sel.connection_id, sel.model_id);
+            match sel.effort {
+                Some(api::EffortLevel::Low) => format!("{base} (low)"),
+                Some(api::EffortLevel::Medium) => format!("{base} (med)"),
+                Some(api::EffortLevel::High) => format!("{base} (high)"),
+                None => base,
+            }
+        }
+        None => "Auto (purpose)".into(),
+    }
+}
+
+/// Human-readable representation of a `ConversationWarning` for the
+/// status-bar inline notice.
+pub fn warning_notice(warning: &api::ConversationWarning) -> String {
+    match warning {
+        api::ConversationWarning::DanglingModelSelection {
+            previous_selection,
+            fallback_to,
+        } => format!(
+            "previous model {}·{} unavailable → falling back to {}·{}",
+            previous_selection.connection_id,
+            previous_selection.model_id,
+            fallback_to.connection_id,
+            fallback_to.model_id,
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn listing(conn: &str, model: &str) -> api::ModelListing {
+        api::ModelListing {
+            connection_id: conn.into(),
+            connection_label: conn.into(),
+            model: api::ModelInfoView {
+                id: model.into(),
+                display_name: model.into(),
+                context_limit: None,
+                capabilities: api::ModelCapabilitiesView::default(),
+            },
+        }
+    }
+
+    #[test]
+    fn selector_opens_past_auto_row() {
+        let mut s = ModelSelector::default();
+        s.set_entries(vec![listing("a", "m1")]);
+        s.open();
+        assert_eq!(s.highlight, 1); // skip Auto
+    }
+
+    #[test]
+    fn selector_opens_on_auto_when_empty() {
+        let mut s = ModelSelector::default();
+        s.open();
+        assert_eq!(s.highlight, 0);
+    }
+
+    #[test]
+    fn selector_wraps_through_auto() {
+        let mut s = ModelSelector::default();
+        s.set_entries(vec![listing("a", "m1"), listing("a", "m2")]);
+        s.open();
+        s.highlight_previous(); // from 1 -> 0 (auto)
+        assert_eq!(s.highlight, 0);
+        s.highlight_previous(); // wrap to last real entry
+        assert_eq!(s.highlight, 2);
+    }
+
+    #[test]
+    fn selector_selected_entry_returns_none_on_auto() {
+        let mut s = ModelSelector::default();
+        s.set_entries(vec![listing("a", "m1")]);
+        s.highlight = 0;
+        assert!(s.selected_entry().is_none());
+        s.highlight = 1;
+        assert_eq!(s.selected_entry().unwrap().model.id, "m1");
+    }
+
+    #[test]
+    fn conversation_selections_round_trip() {
+        let mut store = ConversationSelections::default();
+        assert!(store.get("c1").is_none());
+        store.set(
+            "c1".into(),
+            api::SendPromptOverride {
+                connection_id: "work".into(),
+                model_id: "gpt-5".into(),
+                effort: Some(api::EffortLevel::High),
+            },
+        );
+        let got = store.get("c1").unwrap();
+        assert_eq!(got.connection_id, "work");
+        assert_eq!(got.model_id, "gpt-5");
+        assert_eq!(got.effort, Some(api::EffortLevel::High));
+    }
+
+    #[test]
+    fn hydrate_from_dangling_fallback_stores_override() {
+        let mut store = ConversationSelections::default();
+        store.hydrate_from_dangling_fallback(
+            "c1",
+            &api::ConversationModelSelectionView {
+                connection_id: "other".into(),
+                model_id: "claude-sonnet".into(),
+                effort: None,
+            },
+        );
+        let got = store.get("c1").unwrap();
+        assert_eq!(got.connection_id, "other");
+        assert_eq!(got.model_id, "claude-sonnet");
+    }
+
+    #[test]
+    fn status_bar_label_auto() {
+        assert_eq!(status_bar_label(None), "Auto (purpose)");
+    }
+
+    #[test]
+    fn status_bar_label_with_effort() {
+        let sel = api::SendPromptOverride {
+            connection_id: "work".into(),
+            model_id: "m1".into(),
+            effort: Some(api::EffortLevel::High),
+        };
+        assert_eq!(status_bar_label(Some(&sel)), "work · m1 (high)");
+    }
+
+    #[test]
+    fn warning_notice_describes_dangling() {
+        let w = api::ConversationWarning::DanglingModelSelection {
+            previous_selection: api::ConversationModelSelectionView {
+                connection_id: "old".into(),
+                model_id: "gone".into(),
+                effort: None,
+            },
+            fallback_to: api::ConversationModelSelectionView {
+                connection_id: "new".into(),
+                model_id: "ok".into(),
+                effort: None,
+            },
+        };
+        let note = warning_notice(&w);
+        assert!(note.contains("old·gone"));
+        assert!(note.contains("new·ok"));
+    }
+
+    #[test]
+    fn highlight_for_finds_match() {
+        let mut s = ModelSelector::default();
+        s.set_entries(vec![
+            listing("a", "m1"),
+            listing("a", "m2"),
+            listing("b", "m3"),
+        ]);
+        let sel = api::SendPromptOverride {
+            connection_id: "a".into(),
+            model_id: "m2".into(),
+            effort: None,
+        };
+        s.highlight_for(Some(&sel));
+        assert_eq!(s.highlight, 2);
+    }
+}


### PR DESCRIPTION
## Summary

Implements the TUI side of multi-connection model selection (adele-tui #1). Daemon-side API surface landed in adelie-ai/desktop-assistant#17; this PR brings the TUI in line with it and adds the three user-facing surfaces called out on the ticket.

### Connections view (S from chat-normal)

- List of configured connections with id, connector type, availability chip, credentials chip.
- Add (a), Configure (c / Enter), Remove (d), Refresh models (r), Back (q / Esc).
- Configure popup renders per-connector-type fields:
  - Anthropic / OpenAI: API key env var name + base_url.
  - Bedrock: AWS profile + region + base_url.
  - Ollama: base_url + auto-pull toggle.
- API keys are represented by env-var name only — the TUI never stores or transmits a raw key.
- Remove confirm is two-stage: the first refusal from the daemon (e.g. "referenced by interactive purpose") is surfaced inline and the dialog advances to an F-to-force stage.

### Purposes view (P from chat-normal)

- Flat `(Purpose) (Connection) (Model) (Effort)` table for interactive / dreaming / embedding / titling.
- Per-row editor (c / Enter) with Tab / Shift-Tab field cycling; Effort shortcut keys l/m/h/x.
- Validation rejects `"primary"` on the interactive row client-side; everything else is deferred to the daemon.

### Per-conversation model selector

- Always-visible `model: <connection · model>` indicator in the chat status bar.
- Ctrl-M opens a popup listing `"Connection · Model"` entries across healthy connections; capability chips (reasoning/vision/tools) per row.
- Pinned disabled `Auto (coming soon)` head row.
- Picking a model pins it for the active conversation; next SendMessage includes `override_selection`. Picking Auto clears the pin.
- `r` inside the popup forces a model-list refresh (daemon bypasses per-connector caches, e.g. Bedrock).

### Plumbing

- `crates/api-model` is now aligned with the daemon: `ListConnections`, `CreateConnection`, `UpdateConnection`, `DeleteConnection`, `ListAvailableModels`, `GetPurposes`, `SetPurpose`, `SendMessage.override_selection`, `ConversationView.warnings`, `Event::ConversationWarningEmitted`. Legacy `GetLlmSettings` / `SetLlmSettings` and `Config.llm` are gone.
- `WsClient` and `AssistantClient` grew matching methods. `send_prompt_with_override` is the single entry point the chat view uses; `send_prompt` delegates to it with `None`.
- `SignalEvent::ConversationWarning` is folded into the app's inline notice and hydrates the per-conversation selection map from the daemon's fallback target.
- D-Bus adapter is untouched and returns `multi-connection unsupported` for the new commands; users who want to manage connections connect over WS.

### Deferred behaviour (desktop-assistant#18)

Per #18, the daemon today validates + persists the override and logs the effort mapping but does not yet route the dispatch to the selected client. This PR sends the correct wire values and surfaces what the daemon persists; no workarounds.

## Keybinding reference

| Where | Key | Action |
|---|---|---|
| Chat / normal | `S` | Open Connections view |
| Chat / normal | `P` | Open Purposes view |
| Chat (any mode) | `Ctrl-M` | Open model selector |
| Chat / normal | `q` | Quit |
| Chat / normal | `n` | New conversation |
| Chat / normal | `d` | Delete conversation |
| Chat / normal | `A` | Archive/unarchive conversation |
| Chat / normal | `a` | Toggle show archived |
| Chat / normal | `Enter` | Open selected conversation |
| Chat / normal | `i` | Enter edit mode |
| Chat / editing | `Enter` | Submit |
| Chat / editing | `Shift+Enter` / `Ctrl-J` | Newline |
| Chat / editing | `Esc` | Exit edit mode |
| Connections | `a` / `c` / `Enter` / `d` / `r` / `q` / `Esc` | Add / Configure / Remove / Refresh models / Back |
| Connections form | `Tab` / `Shift-Tab` | Next / previous field |
| Connections form | `←` / `→` (on Type row) | Cycle connector kind |
| Connections form | `Enter` / `Esc` | Save / cancel |
| Connections delete | `y` / `Enter` | Confirm |
| Connections delete | `f` | Force (after refusal) |
| Connections delete | `n` / `Esc` | Cancel |
| Purposes | `j` / `k` / `c` / `Enter` / `q` / `Esc` | Navigate / edit / back |
| Purposes editor | `Tab` / `Shift-Tab` / `Enter` / `Esc` / `l`/`m`/`h`/`x` | Fields / save / cancel / effort |
| Model selector | `j` / `k` / `Enter` / `r` / `Esc` | Navigate / confirm / refresh / cancel |

## Test plan

- [x] `cargo test` — 195 tests pass (96 lib + 99 bin).
- [x] `cargo clippy --all-targets` — clean on the new code; one pre-existing `.err().expect()` warning in the original `main.rs` CLI test left untouched.

### Manual walkthrough (keyboard only)

- [ ] Launch against a daemon on `feat/multi-connection`. Status bar reads `model: Auto (purpose)`.
- [ ] Press `S` — Connections view lists the configured connections with chips.
- [ ] `a` → form opens on Anthropic. Tab to Type row, `→` cycles to OpenAI. Fill in id, API-key env, base URL, `Enter` — connection appears in the list with `ok` + `creds`.
- [ ] Select the new connection, `c`, edit, `Enter` — status hint says "Updated …".
- [ ] `d` on a connection that is referenced by the interactive purpose — daemon refuses, popup advances to "force" stage. `f` succeeds.
- [ ] `q` back to chat. `P` → Purposes view. Edit dreaming, set connection=`primary`, model=`primary`, effort=`l` (low), `Enter` — saved.
- [ ] Create / open a conversation. `Ctrl-M` — popup opens past the Auto row. Pick any model, `Enter`. Status bar now reads `model: <conn> · <model>`.
- [ ] Type a prompt, `Enter` — daemon receives `SendMessage` with `override_selection` populated (verify in daemon logs).
- [ ] Switch conversations (j/k + Enter). Status bar follows the other conversation's selection (empty by default).
- [ ] Delete the referenced connection via Connections → daemon emits `ConversationWarningEmitted`; inline yellow notice appears above the status bar and the selection is rehydrated to the daemon's fallback.
- [ ] Restart the TUI. Previously-set per-conversation selections are not yet restored from the daemon (deferred — desktop-assistant#18); the daemon still honors the last override on the next send.

Closes #1