### PR TITLE
Security: bump rustls-webpki + rand for advisories (Refs #3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1482,9 +1482,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -1717,9 +1717,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
Refs #3. Issue stays open — some advisories require upstream/migration work.

Lockfile-only `cargo update --precise`:
- `rustls-webpki` 0.103.10 → **0.103.13** (RUSTSEC-2026-0098/0099/0104)
- `rand` 0.9.2 → **0.9.3** (RUSTSEC-2026-0097)

Not in this PR (deferred):
- `lru 0.12.5` — transitive, blocked by major-version constraint
- `paste`, `rustls-pemfile` — unmaintained, no fixed version exists. `rustls-pemfile` is a direct dep; future migration to `rustls-pki-types` advised.

`Cargo.toml` unchanged. `cargo build` and `cargo test` clean locally.