### PR TITLE
Rename conversation with `r` keybind (closes #11)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -62,6 +62,7 @@ fn map_cursor_col_to_wrapped_segments(segments: &[String], cursor_col: usize) ->
 pub enum InputMode {
     Normal,
     Editing,
+    Renaming,
 }
 
 pub struct App {
@@ -78,6 +79,10 @@ pub struct App {
     pub scroll_offset: u16,
     /// Whether to include archived conversations in the list.
     pub show_archived: bool,
+    /// Single-line input used during InputMode::Renaming.
+    pub rename_textarea: TextArea<'static>,
+    /// Conversation id being renamed; `None` outside InputMode::Renaming.
+    pub renaming_id: Option<String>,
 }
 
 impl App {
@@ -96,6 +101,8 @@ impl App {
             should_quit: false,
             scroll_offset: 0,
             show_archived: false,
+            rename_textarea: new_textarea(),
+            renaming_id: None,
         }
     }
 
@@ -328,6 +335,60 @@ impl App {
     pub fn selected_conversation_id(&self) -> Option<&str> {
         let idx = self.selected_conversation?;
         self.conversations.get(idx).map(|c| c.id.as_str())
+    }
+
+    // --- Rename ---
+
+    /// Enter rename mode for the selected conversation, prepopulating the
+    /// rename buffer with its current title. No-op if nothing is selected.
+    pub fn begin_rename(&mut self) {
+        let Some(idx) = self.selected_conversation else {
+            return;
+        };
+        let Some(conv) = self.conversations.get(idx) else {
+            return;
+        };
+        let mut ta = new_textarea();
+        ta.insert_str(&conv.title);
+        ta.move_cursor(CursorMove::End);
+        self.rename_textarea = ta;
+        self.renaming_id = Some(conv.id.clone());
+        self.mode = InputMode::Renaming;
+    }
+
+    /// Trim the rename buffer and return `(id, new_title)` if the title is
+    /// non-empty and differs from the current one. Always exits rename mode.
+    pub fn submit_rename(&mut self) -> Option<(String, String)> {
+        let new_title = self.rename_textarea.lines().join(" ").trim().to_string();
+        let id = self.renaming_id.take();
+        self.rename_textarea = new_textarea();
+        self.mode = InputMode::Normal;
+
+        let id = id?;
+        if new_title.is_empty() {
+            return None;
+        }
+        let unchanged = self
+            .conversations
+            .iter()
+            .find(|c| c.id == id)
+            .map(|c| c.title == new_title)
+            .unwrap_or(false);
+        if unchanged {
+            return None;
+        }
+        Some((id, new_title))
+    }
+
+    pub fn cancel_rename(&mut self) {
+        self.renaming_id = None;
+        self.rename_textarea = new_textarea();
+        self.mode = InputMode::Normal;
+    }
+
+    /// Apply a renamed title locally (call after the daemon confirms).
+    pub fn apply_rename(&mut self, conversation_id: &str, title: &str) {
+        self.update_conversation_title(conversation_id, title);
     }
 
     pub fn delete_selected_conversation(&mut self) -> Option<String> {
@@ -780,6 +841,93 @@ mod tests {
         assert!(!app.should_quit);
         app.quit();
         assert!(app.should_quit);
+    }
+
+    // --- Rename tests ---
+
+    #[test]
+    fn begin_rename_without_selection_is_noop() {
+        let mut app = app_with_conversations();
+        assert!(app.selected_conversation.is_none());
+        app.begin_rename();
+        assert_eq!(app.mode, InputMode::Normal);
+        assert!(app.renaming_id.is_none());
+    }
+
+    #[test]
+    fn begin_rename_prepopulates_buffer_and_enters_mode() {
+        let mut app = app_with_conversations();
+        app.selected_conversation = Some(1); // "Second"
+        app.begin_rename();
+        assert_eq!(app.mode, InputMode::Renaming);
+        assert_eq!(app.renaming_id.as_deref(), Some("2"));
+        assert_eq!(app.rename_textarea.lines(), ["Second"]);
+    }
+
+    #[test]
+    fn submit_rename_returns_id_and_trimmed_title() {
+        let mut app = app_with_conversations();
+        app.selected_conversation = Some(0);
+        app.begin_rename();
+        // Replace contents
+        app.rename_textarea = TextArea::from(vec!["  Renamed Chat  ".to_string()]);
+
+        let result = app.submit_rename();
+        assert_eq!(result, Some(("1".to_string(), "Renamed Chat".to_string())));
+        assert_eq!(app.mode, InputMode::Normal);
+        assert!(app.renaming_id.is_none());
+    }
+
+    #[test]
+    fn submit_rename_with_unchanged_title_returns_none() {
+        let mut app = app_with_conversations();
+        app.selected_conversation = Some(0); // "First"
+        app.begin_rename();
+        // Buffer still equals current title
+        let result = app.submit_rename();
+        assert_eq!(result, None);
+        assert_eq!(app.mode, InputMode::Normal);
+    }
+
+    #[test]
+    fn submit_rename_with_empty_title_returns_none() {
+        let mut app = app_with_conversations();
+        app.selected_conversation = Some(0);
+        app.begin_rename();
+        app.rename_textarea = TextArea::from(vec!["   ".to_string()]);
+
+        let result = app.submit_rename();
+        assert_eq!(result, None);
+        assert_eq!(app.mode, InputMode::Normal);
+    }
+
+    #[test]
+    fn cancel_rename_clears_state() {
+        let mut app = app_with_conversations();
+        app.selected_conversation = Some(0);
+        app.begin_rename();
+        app.rename_textarea = TextArea::from(vec!["scratch".to_string()]);
+
+        app.cancel_rename();
+        assert_eq!(app.mode, InputMode::Normal);
+        assert!(app.renaming_id.is_none());
+    }
+
+    #[test]
+    fn apply_rename_updates_sidebar_and_current() {
+        let mut app = app_with_conversations();
+        app.current_conversation = Some(ConversationDetail {
+            id: "2".into(),
+            title: "Second".into(),
+            messages: vec![],
+            model_selection: None,
+        });
+        app.apply_rename("2", "Renamed");
+        assert_eq!(app.conversations[1].title, "Renamed");
+        assert_eq!(
+            app.current_conversation.as_ref().unwrap().title,
+            "Renamed"
+        );
     }
 
     // --- Scroll tests ---

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -19,6 +19,9 @@ pub enum Action {
     ScrollDown,
     ScrollToBottom,
     ToggleShowArchived,
+    BeginRename,
+    SubmitRename,
+    CancelRename,
 }
 
 /// Handle key events that we intercept before passing to textarea.
@@ -27,8 +30,10 @@ pub fn handle_key_event(key: KeyEvent, mode: &InputMode) -> Option<Action> {
     let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
     let alt = key.modifiers.contains(KeyModifiers::ALT);
 
-    // Ctrl+u / Ctrl+d / Ctrl+e for scrolling — works in all modes
-    if ctrl {
+    // Ctrl+u / Ctrl+d / Ctrl+e for scrolling — works in Normal/Editing only.
+    // In Renaming mode we forward all Ctrl combos to the rename textarea
+    // (Ctrl+a/e/u/k word/line edits).
+    if ctrl && !matches!(mode, InputMode::Renaming) {
         if matches!(mode, InputMode::Editing) && matches!(key.code, KeyCode::Char('j')) {
             return Some(Action::InsertNewline);
         }
@@ -57,6 +62,7 @@ pub fn handle_key_event(key: KeyEvent, mode: &InputMode) -> Option<Action> {
                 KeyCode::Char('n') => Some(Action::NewConversation),
                 KeyCode::Char('a') => Some(Action::ToggleShowArchived),
                 KeyCode::Char('A') => Some(Action::ArchiveConversation),
+                KeyCode::Char('r') => Some(Action::BeginRename),
                 KeyCode::Char('i') => Some(Action::EnterEditMode),
                 KeyCode::PageUp => Some(Action::ScrollUp),
                 KeyCode::PageDown => Some(Action::ScrollDown),
@@ -64,6 +70,13 @@ pub fn handle_key_event(key: KeyEvent, mode: &InputMode) -> Option<Action> {
                 _ => None,
             }
         }
+        InputMode::Renaming => match key.code {
+            KeyCode::Enter => Some(Action::SubmitRename),
+            KeyCode::Esc => Some(Action::CancelRename),
+            // All other keys (chars, backspace, arrows, home/end, ctrl-a/e/u/k)
+            // forward to the rename textarea.
+            _ => None,
+        },
         InputMode::Editing => {
             // Shift+Enter inserts a newline while plain Enter submits.
             match key.code {
@@ -407,6 +420,65 @@ mod tests {
         assert_eq!(
             handle_key_event(key(KeyCode::PageDown), &InputMode::Normal),
             Some(Action::ScrollDown)
+        );
+    }
+
+    // --- Renaming mode tests ---
+
+    #[test]
+    fn normal_r_begins_rename() {
+        assert_eq!(
+            handle_key_event(key(KeyCode::Char('r')), &InputMode::Normal),
+            Some(Action::BeginRename)
+        );
+    }
+
+    #[test]
+    fn renaming_enter_submits() {
+        assert_eq!(
+            handle_key_event(key(KeyCode::Enter), &InputMode::Renaming),
+            Some(Action::SubmitRename)
+        );
+    }
+
+    #[test]
+    fn renaming_esc_cancels() {
+        assert_eq!(
+            handle_key_event(key(KeyCode::Esc), &InputMode::Renaming),
+            Some(Action::CancelRename)
+        );
+    }
+
+    #[test]
+    fn renaming_chars_forwarded_to_textarea() {
+        // Regular chars and editing keys must reach the rename textarea.
+        assert_eq!(
+            handle_key_event(key(KeyCode::Char('a')), &InputMode::Renaming),
+            None
+        );
+        assert_eq!(
+            handle_key_event(key(KeyCode::Backspace), &InputMode::Renaming),
+            None
+        );
+    }
+
+    #[test]
+    fn renaming_ctrl_combos_forwarded_to_textarea() {
+        // Ctrl+a/e/u/k are textarea editing shortcuts in rename mode and
+        // must NOT be intercepted as scroll commands.
+        assert_eq!(
+            handle_key_event(
+                key_with_mod(KeyCode::Char('u'), KeyModifiers::CONTROL),
+                &InputMode::Renaming
+            ),
+            None
+        );
+        assert_eq!(
+            handle_key_event(
+                key_with_mod(KeyCode::Char('a'), KeyModifiers::CONTROL),
+                &InputMode::Renaming
+            ),
+            None
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -168,9 +168,16 @@ async fn run(
                     }
                     if let Some(action) = handle_key_event(key, &app.mode) {
                         handle_action(&mut app, &client, action).await;
-                    } else if matches!(app.mode, InputMode::Editing) {
-                        // Forward unhandled keys to textarea
-                        app.textarea.input(key);
+                    } else {
+                        match app.mode {
+                            InputMode::Editing => {
+                                app.textarea.input(key);
+                            }
+                            InputMode::Renaming => {
+                                app.rename_textarea.input(key);
+                            }
+                            InputMode::Normal => {}
+                        }
                     }
                 }
             }
@@ -336,6 +343,27 @@ async fn handle_action(
         Action::ScrollUp => app.scroll_up(5),
         Action::ScrollDown => app.scroll_down(5),
         Action::ScrollToBottom => app.scroll_to_bottom(),
+        Action::BeginRename => {
+            if app.selected_conversation_id().is_some() {
+                app.begin_rename();
+            } else {
+                app.status_message = "Select a conversation to rename".into();
+            }
+        }
+        Action::SubmitRename => {
+            if let Some((id, title)) = app.submit_rename()
+                && let Some(client) = client.as_ref()
+            {
+                match client.rename_conversation(&id, &title).await {
+                    Ok(()) => {
+                        app.apply_rename(&id, &title);
+                        app.status_message = format!("Renamed to \"{title}\"");
+                    }
+                    Err(e) => app.status_message = format!("Rename error: {e}"),
+                }
+            }
+        }
+        Action::CancelRename => app.cancel_rename(),
     }
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -1,9 +1,9 @@
 use ratatui::{
     Frame,
-    layout::{Constraint, Direction, Layout},
+    layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap},
+    widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap},
 };
 
 use crate::app::{App, InputMode};
@@ -32,6 +32,10 @@ fn mode_chip_style(mode: &InputMode) -> Style {
             .fg(Color::Black)
             .bg(Color::Rgb(120, 214, 118))
             .add_modifier(Modifier::BOLD),
+        InputMode::Renaming => Style::default()
+            .fg(Color::Black)
+            .bg(Color::Rgb(255, 189, 89))
+            .add_modifier(Modifier::BOLD),
     }
 }
 
@@ -52,6 +56,43 @@ pub fn draw(f: &mut Frame, app: &mut App) {
 
     draw_conversation_list(f, app, chunks[0]);
     draw_chat_panel(f, app, chunks[1]);
+
+    if matches!(app.mode, InputMode::Renaming) {
+        draw_rename_popup(f, app, f.area());
+    }
+}
+
+fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {
+    let w = width.min(area.width);
+    let h = height.min(area.height);
+    let x = area.x + (area.width.saturating_sub(w)) / 2;
+    let y = area.y + (area.height.saturating_sub(h)) / 2;
+    Rect {
+        x,
+        y,
+        width: w,
+        height: h,
+    }
+}
+
+fn draw_rename_popup(f: &mut Frame, app: &mut App, area: Rect) {
+    let popup_width = area.width.saturating_sub(8).clamp(20, 72);
+    let popup = centered_rect(popup_width, 3, area);
+
+    f.render_widget(Clear, popup);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Rgb(255, 189, 89)))
+        .title(Line::from(Span::styled(
+            "Rename (Enter save, Esc cancel)",
+            Style::default()
+                .fg(Color::Rgb(255, 220, 160))
+                .add_modifier(Modifier::BOLD),
+        )));
+
+    app.rename_textarea.set_block(block);
+    f.render_widget(&app.rename_textarea, popup);
 }
 
 fn draw_conversation_list(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
@@ -224,6 +265,7 @@ fn draw_input(f: &mut Frame, app: &mut App, area: ratatui::layout::Rect) {
             "Input (Esc cancel, Enter send, Shift+Enter/Ctrl+J newline)",
             COLOR_INPUT_BORDER_EDIT,
         ),
+        InputMode::Renaming => ("Input", COLOR_INPUT_BORDER_IDLE),
     };
 
     app.textarea.set_block(
@@ -243,6 +285,7 @@ fn draw_status_bar(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
     let mode_str = match app.mode {
         InputMode::Normal => "NORMAL",
         InputMode::Editing => "EDITING",
+        InputMode::Renaming => "RENAME",
     };
 
     let status = Paragraph::new(Line::from(vec![
@@ -357,6 +400,22 @@ mod tests {
         let backend = TestBackend::new(20, 8);
         let mut terminal = Terminal::new(backend).unwrap();
         let mut app = App::new();
+        terminal.draw(|f| draw(f, &mut app)).unwrap();
+    }
+
+    #[test]
+    fn draw_rename_popup_does_not_panic() {
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut app = App::new();
+        app.set_conversations(vec![ConversationSummary {
+            id: "1".into(),
+            title: "Chat 1".into(),
+            message_count: 0,
+            archived: false,
+        }]);
+        app.selected_conversation = Some(0);
+        app.begin_rename();
         terminal.draw(|f| draw(f, &mut app)).unwrap();
     }
 }


### PR DESCRIPTION
## Summary

- Press `r` in normal mode on a selected conversation to open a centered rename popup prepopulated with the current title.
- Enter submits via `RenameConversation`; Esc cancels. Sidebar updates locally on success.
- New `InputMode::Renaming` with its own `TextArea`, three actions (`BeginRename` / `SubmitRename` / `CancelRename`), and a status-bar `[RENAME]` chip.
- Ctrl combos are forwarded to the rename textarea inside the popup so `Ctrl+a/e/u/k` work for line editing instead of being intercepted as scroll commands.

## Test plan

- [x] `cargo test` — 88 passing (+13 new tests across `app.rs`, `keys.rs`, `ui.rs`)
- [x] `cargo build` clean
- [ ] Manual: pick a conversation, press `r`, edit, Enter → title updates in sidebar
- [ ] Manual: press `r`, Esc → popup closes, no daemon call
- [ ] Manual: press `r`, clear field, Enter → no-op (empty title rejected client-side)
- [ ] Manual: press `r`, leave unchanged, Enter → no-op (no needless RPC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)