### PR TITLE
Surface AssistantStatus events as transient indicator (closes #9)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -86,6 +86,11 @@ pub struct App {
     /// When true, render tool/system/empty-assistant messages dimly inline
     /// instead of filtering them out. Persisted via `settings.json`.
     pub show_debug: bool,
+    /// Transient indicator from AssistantStatus events ("Searching knowledge
+    /// base…", tool-call progress). Cleared when streaming completes or
+    /// errors. Distinct from `status_message`, which is sticky user-facing
+    /// feedback.
+    pub assistant_status: Option<String>,
 }
 
 impl App {
@@ -107,6 +112,16 @@ impl App {
             rename_textarea: new_textarea(),
             renaming_id: None,
             show_debug: false,
+            assistant_status: None,
+        }
+    }
+
+    pub fn set_assistant_status(&mut self, message: impl Into<String>) {
+        let msg = message.into();
+        if msg.trim().is_empty() {
+            self.assistant_status = None;
+        } else {
+            self.assistant_status = Some(msg);
         }
     }
 
@@ -292,6 +307,7 @@ impl App {
         }
         self.streaming_buffer.clear();
         self.pending_request_id = None;
+        self.assistant_status = None;
     }
 
     pub fn streaming_error(&mut self, request_id: &str, error: &str) {
@@ -301,6 +317,7 @@ impl App {
         self.status_message = format!("Error: {error}");
         self.streaming_buffer.clear();
         self.pending_request_id = None;
+        self.assistant_status = None;
     }
 
     // --- Conversation management ---
@@ -708,6 +725,43 @@ mod tests {
         assert_eq!(app.status_message, "Error: LLM timeout");
         assert_eq!(app.pending_request_id, None);
         assert_eq!(app.streaming_buffer, "");
+    }
+
+    #[test]
+    fn assistant_status_set_and_cleared_on_complete() {
+        let mut app = App::new();
+        app.current_conversation = Some(ConversationDetail {
+            id: "c1".into(),
+            title: "Test".into(),
+            messages: vec![],
+            model_selection: None,
+        });
+        app.start_streaming("req1".into());
+        app.set_assistant_status("Searching knowledge base...");
+        assert_eq!(
+            app.assistant_status.as_deref(),
+            Some("Searching knowledge base...")
+        );
+
+        app.complete_streaming("req1", "done");
+        assert!(app.assistant_status.is_none());
+    }
+
+    #[test]
+    fn assistant_status_cleared_on_error() {
+        let mut app = App::new();
+        app.start_streaming("req1".into());
+        app.set_assistant_status("Calling tool...");
+        app.streaming_error("req1", "boom");
+        assert!(app.assistant_status.is_none());
+    }
+
+    #[test]
+    fn assistant_status_empty_string_clears() {
+        let mut app = App::new();
+        app.set_assistant_status("something");
+        app.set_assistant_status("");
+        assert!(app.assistant_status.is_none());
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -192,14 +192,13 @@ async fn run(
                     }
                     SignalEvent::Complete { request_id, full_response } => {
                         app.complete_streaming(&request_id, &full_response);
-                        app.status_message.clear();
                     }
                     SignalEvent::Error { request_id, error } => {
                         app.streaming_error(&request_id, &error);
                         app.status_message = format!("Error: {error}");
                     }
                     SignalEvent::Status { request_id: _, message } => {
-                        app.status_message = message;
+                        app.set_assistant_status(message);
                     }
                     SignalEvent::TitleChanged { conversation_id, title } => {
                         app.update_conversation_title(&conversation_id, &title);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -23,6 +23,7 @@ const COLOR_STATUS_DIM: Color = Color::Rgb(143, 153, 174);
 const COLOR_COUNT_DIM: Color = Color::Rgb(124, 132, 148);
 const COLOR_DEBUG_TOOL: Color = Color::Rgb(178, 138, 220);
 const COLOR_DEBUG_SYSTEM: Color = Color::Rgb(140, 156, 196);
+const COLOR_ASSISTANT_INDICATOR: Color = Color::Rgb(178, 220, 245);
 
 fn mode_chip_style(mode: &InputMode) -> Style {
     match mode {
@@ -154,18 +155,46 @@ fn draw_conversation_list(f: &mut Frame, app: &App, area: ratatui::layout::Rect)
 }
 
 fn draw_chat_panel(f: &mut Frame, app: &mut App, area: ratatui::layout::Rect) {
+    let show_status = app.assistant_status.is_some();
+    let status_height: u16 = if show_status { 1 } else { 0 };
+
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Min(1),
+            Constraint::Length(status_height),
             Constraint::Length(INPUT_TOTAL_HEIGHT),
             Constraint::Length(1),
         ])
         .split(area);
 
     draw_messages(f, app, chunks[0]);
-    draw_input(f, app, chunks[1]);
-    draw_status_bar(f, app, chunks[2]);
+    if show_status {
+        draw_assistant_status(f, app, chunks[1]);
+    }
+    draw_input(f, app, chunks[2]);
+    draw_status_bar(f, app, chunks[3]);
+}
+
+fn draw_assistant_status(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
+    let Some(message) = app.assistant_status.as_deref() else {
+        return;
+    };
+    let indicator = Paragraph::new(Line::from(vec![
+        Span::styled(
+            "● ",
+            Style::default()
+                .fg(COLOR_ASSISTANT_INDICATOR)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            message,
+            Style::default()
+                .fg(COLOR_ASSISTANT_INDICATOR)
+                .add_modifier(Modifier::ITALIC),
+        ),
+    ]));
+    f.render_widget(indicator, area);
 }
 
 fn draw_messages(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
@@ -502,5 +531,35 @@ mod tests {
         assert!(dump.contains("system:"));
         assert!(dump.contains("ran search"));
         assert!(dump.contains("context updated"));
+    }
+
+    #[test]
+    fn draw_with_assistant_status_renders_indicator() {
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut app = App::new();
+        app.current_conversation = Some(ConversationDetail {
+            id: "1".into(),
+            title: "Test".into(),
+            messages: vec![],
+            model_selection: None,
+        });
+        app.set_assistant_status("Searching knowledge base...");
+        terminal.draw(|f| draw(f, &mut app)).unwrap();
+        let buf = terminal.backend().buffer().clone();
+        let dump: String = buf.content.iter().map(|c| c.symbol()).collect();
+        assert!(dump.contains("Searching knowledge base"));
+    }
+
+    #[test]
+    fn draw_without_assistant_status_omits_indicator() {
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut app = App::new();
+        terminal.draw(|f| draw(f, &mut app)).unwrap();
+        let buf = terminal.backend().buffer().clone();
+        let dump: String = buf.content.iter().map(|c| c.symbol()).collect();
+        // The bullet glyph used by the indicator should not appear when no status.
+        assert!(!dump.contains("● "));
     }
 }


### PR DESCRIPTION
## Summary

- Adds `app.assistant_status: Option<String>`, populated from `SignalEvent::Status` and cleared on stream Complete or Error.
- Rendered as a single-line indicator (● + italic message) above the input only when active. Slot collapses to zero height otherwise.
- Splits transient assistant progress (was clobbering `status_message`) from sticky user notifications. Rename confirmations and other status messages no longer get wiped by tool-call status ticks.

## Test plan

- [x] `cargo test` — 80 passing (+5 new across `app.rs`, `ui.rs`)
- [x] `cargo build` clean
- [ ] Manual: send a prompt that triggers a tool/RAG call → indicator appears with "Searching knowledge base..." (or similar) and clears when the response completes
- [ ] Manual: verify rename confirmation persists in the status bar through a full streaming response

🤖 Generated with [Claude Code](https://claude.com/claude-code)