### PR TITLE
Syntax-highlight fenced code blocks (closes #8)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,11 +14,18 @@ dependencies = [
  "pulldown-cmark",
  "ratatui",
  "serde_json",
+ "syntect",
  "tokio",
  "tracing",
  "tracing-subscriber",
  "tui-textarea",
 ]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
@@ -164,6 +171,30 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -361,6 +392,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -441,6 +481,15 @@ name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "desktop-assistant-api-model"
@@ -576,6 +625,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -586,6 +646,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -1184,6 +1254,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1262,6 +1338,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1281,6 +1367,12 @@ checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "once_cell"
@@ -1358,6 +1450,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "plist"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
+dependencies = [
+ "base64",
+ "indexmap",
+ "quick-xml",
+ "serde",
+ "time",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1365,6 +1470,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1412,6 +1523,15 @@ dependencies = [
  "bitflags",
  "memchr",
  "unicase",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1915,6 +2035,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2014,6 +2140,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "syntect"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
+dependencies = [
+ "bincode",
+ "fancy-regex",
+ "flate2",
+ "fnv",
+ "once_cell",
+ "plist",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror 2.0.18",
+ "walkdir",
+ "yaml-rust",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2094,6 +2241,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -3071,6 +3249,15 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,6 +11,7 @@ dependencies = [
  "crossterm",
  "desktop-assistant-client-common",
  "futures",
+ "pulldown-cmark",
  "ratatui",
  "serde_json",
  "tokio",
@@ -1403,6 +1404,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "unicase",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2364,6 +2376,12 @@ dependencies = [
  "tempfile",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,5 +37,6 @@ clap = { version = "4", features = ["derive", "env"] }
 ratatui = { version = "0.29", features = ["unstable-rendered-line-info"] }
 crossterm = { version = "0.28", features = ["event-stream"] }
 futures = "0.3"
+pulldown-cmark = { version = "0.13", default-features = false }
 tui-textarea = "0.7"
 desktop-assistant-client-common.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,5 +38,6 @@ ratatui = { version = "0.29", features = ["unstable-rendered-line-info"] }
 crossterm = { version = "0.28", features = ["event-stream"] }
 futures = "0.3"
 pulldown-cmark = { version = "0.13", default-features = false }
+syntect = { version = "5", default-features = false, features = ["default-fancy"] }
 tui-textarea = "0.7"
 desktop-assistant-client-common.workspace = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod app;
 pub mod keys;
+pub mod markdown;
 pub mod ui;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod app;
 mod keys;
+mod markdown;
 mod ui;
 
 use std::io;

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -1,17 +1,24 @@
 //! Renders markdown text into ratatui `Line`s.
 //!
 //! Supports inline formatting (bold, italic, inline code, links), headings,
-//! bullet/numbered lists, fenced code blocks (rendered with a distinct muted
-//! style — language-aware highlighting belongs in #8), and a simple aligned
-//! grid for tables.
+//! bullet/numbered lists, fenced code blocks (with language-aware syntax
+//! highlighting via `syntect`), and a simple aligned grid for tables.
 //!
 //! The output is plain `Line`s of styled `Span`s — no widget state — so it
 //! plugs straight into the existing `Paragraph::new(lines)` flow.
 
-use pulldown_cmark::{Event, HeadingLevel, Options, Parser, Tag, TagEnd};
+use std::sync::OnceLock;
+
+use pulldown_cmark::{CodeBlockKind, Event, HeadingLevel, Options, Parser, Tag, TagEnd};
 use ratatui::{
     style::{Color, Modifier, Style},
     text::{Line, Span},
+};
+use syntect::{
+    easy::HighlightLines,
+    highlighting::{FontStyle, Style as SynStyle, Theme, ThemeSet},
+    parsing::{SyntaxReference, SyntaxSet},
+    util::LinesWithEndings,
 };
 
 const COLOR_HEADING: Color = Color::Rgb(166, 182, 255);
@@ -20,6 +27,55 @@ const COLOR_CODE_BG: Color = Color::Rgb(40, 44, 56);
 const COLOR_LINK: Color = Color::Rgb(132, 204, 232);
 const COLOR_BLOCKQUOTE: Color = Color::Rgb(170, 178, 196);
 const COLOR_TABLE_BORDER: Color = Color::Rgb(82, 90, 110);
+
+/// Theme used for code-block syntax highlighting. `base16-ocean.dark` reads
+/// well on the dark TUI background and ships with syntect by default.
+const HIGHLIGHT_THEME: &str = "base16-ocean.dark";
+
+struct HighlightAssets {
+    syntaxes: SyntaxSet,
+    theme: Theme,
+}
+
+fn highlight_assets() -> &'static HighlightAssets {
+    static ASSETS: OnceLock<HighlightAssets> = OnceLock::new();
+    ASSETS.get_or_init(|| {
+        let syntaxes = SyntaxSet::load_defaults_newlines();
+        let themes = ThemeSet::load_defaults();
+        let theme = themes
+            .themes
+            .get(HIGHLIGHT_THEME)
+            .cloned()
+            .unwrap_or_else(|| themes.themes.values().next().cloned().unwrap_or_default());
+        HighlightAssets { syntaxes, theme }
+    })
+}
+
+fn syntax_for_lang<'a>(syntaxes: &'a SyntaxSet, lang: Option<&str>) -> Option<&'a SyntaxReference> {
+    let token = lang?.trim();
+    if token.is_empty() {
+        return None;
+    }
+    // Try by token (e.g. "rust"), then file extension (".rs").
+    syntaxes
+        .find_syntax_by_token(token)
+        .or_else(|| syntaxes.find_syntax_by_extension(token))
+}
+
+fn synstyle_to_ratatui(style: SynStyle) -> Style {
+    let fg = Color::Rgb(style.foreground.r, style.foreground.g, style.foreground.b);
+    let mut out = Style::default().fg(fg).bg(COLOR_CODE_BG);
+    if style.font_style.contains(FontStyle::BOLD) {
+        out = out.add_modifier(Modifier::BOLD);
+    }
+    if style.font_style.contains(FontStyle::ITALIC) {
+        out = out.add_modifier(Modifier::ITALIC);
+    }
+    if style.font_style.contains(FontStyle::UNDERLINE) {
+        out = out.add_modifier(Modifier::UNDERLINED);
+    }
+    out
+}
 
 /// Render a markdown source string into styled lines.
 ///
@@ -50,6 +106,11 @@ struct Renderer {
     in_code_span: bool,
     /// Are we inside a fenced code block?
     in_code_block: bool,
+    /// Language hint for the active code block (from a fenced opener).
+    code_lang: Option<String>,
+    /// Buffered code-block source — flushed to syntect on close so the
+    /// highlighter sees a complete (line-terminated) input.
+    code_buffer: String,
     /// Are we inside a link? Active link target if so.
     link_target: Option<String>,
     /// List nesting state. `Some(Some(n))` = numbered list at index n;
@@ -79,6 +140,8 @@ impl Renderer {
             modifier: Modifier::empty(),
             in_code_span: false,
             in_code_block: false,
+            code_lang: None,
+            code_buffer: String::new(),
             link_target: None,
             list_stack: Vec::new(),
             heading_level: None,
@@ -131,9 +194,21 @@ impl Renderer {
                 self.flush_line();
                 self.blockquote_depth += 1;
             }
-            Tag::CodeBlock(_) => {
+            Tag::CodeBlock(kind) => {
                 self.flush_line();
                 self.in_code_block = true;
+                self.code_buffer.clear();
+                self.code_lang = match kind {
+                    CodeBlockKind::Fenced(s) => {
+                        let trimmed = s.trim();
+                        if trimmed.is_empty() {
+                            None
+                        } else {
+                            Some(trimmed.to_string())
+                        }
+                    }
+                    CodeBlockKind::Indented => None,
+                };
             }
             Tag::List(start) => {
                 self.flush_line();
@@ -214,7 +289,10 @@ impl Renderer {
             }
             TagEnd::CodeBlock => {
                 self.flush_line();
+                let buffered = std::mem::take(&mut self.code_buffer);
+                let lang = self.code_lang.take();
                 self.in_code_block = false;
+                self.emit_highlighted_code_block(&buffered, lang.as_deref());
                 self.lines.push(Line::from(""));
             }
             TagEnd::List(_) => {
@@ -263,18 +341,9 @@ impl Renderer {
 
     fn push_text(&mut self, text: &str) {
         if self.in_code_block {
-            for line in text.split('\n') {
-                self.current.push(Span::styled(
-                    format!(" {line} "),
-                    Style::default().fg(COLOR_CODE_FG).bg(COLOR_CODE_BG),
-                ));
-                self.flush_line();
-            }
-            // Trailing flush already happened; drop the empty extra line that
-            // the trailing '\n' would create.
-            if text.ends_with('\n') && self.lines.last().is_some_and(|l| l.spans.is_empty()) {
-                self.lines.pop();
-            }
+            // Buffer the entire block; we run syntect once on close so the
+            // highlighter sees the full source and stays in sync across lines.
+            self.code_buffer.push_str(text);
             return;
         }
 
@@ -366,6 +435,71 @@ impl Renderer {
             self.lines.pop();
         }
         self.lines
+    }
+
+    fn emit_highlighted_code_block(&mut self, source: &str, lang: Option<&str>) {
+        if source.is_empty() {
+            return;
+        }
+        let assets = highlight_assets();
+        let syntax = syntax_for_lang(&assets.syntaxes, lang);
+        match syntax {
+            Some(syn) => {
+                let mut highlighter = HighlightLines::new(syn, &assets.theme);
+                for raw_line in LinesWithEndings::from(source) {
+                    let regions = highlighter
+                        .highlight_line(raw_line, &assets.syntaxes)
+                        .unwrap_or_default();
+                    let trimmed_line = raw_line.trim_end_matches('\n');
+                    let mut spans: Vec<Span<'static>> = Vec::with_capacity(regions.len() + 2);
+                    // Leading gutter so the bg covers a small left margin.
+                    spans.push(Span::styled(
+                        " ",
+                        Style::default().bg(COLOR_CODE_BG),
+                    ));
+                    if regions.is_empty() {
+                        spans.push(Span::styled(
+                            trimmed_line.to_string(),
+                            Style::default().fg(COLOR_CODE_FG).bg(COLOR_CODE_BG),
+                        ));
+                    } else {
+                        for (style, segment) in regions {
+                            // Strip the trailing newline that LinesWithEndings keeps —
+                            // ratatui adds its own line break between Line entries.
+                            let text = segment.trim_end_matches('\n').to_string();
+                            if text.is_empty() {
+                                continue;
+                            }
+                            spans.push(Span::styled(text, synstyle_to_ratatui(style)));
+                        }
+                    }
+                    spans.push(Span::styled(
+                        " ",
+                        Style::default().bg(COLOR_CODE_BG),
+                    ));
+                    self.lines.push(Line::from(spans));
+                }
+            }
+            None => {
+                // Unknown language — fall back to the muted plain code style.
+                let style = Style::default().fg(COLOR_CODE_FG).bg(COLOR_CODE_BG);
+                for raw_line in source.split('\n') {
+                    self.lines.push(Line::from(Span::styled(
+                        format!(" {raw_line} "),
+                        style,
+                    )));
+                }
+                // Drop the trailing empty line caused by the source ending in '\n'.
+                if source.ends_with('\n')
+                    && self
+                        .lines
+                        .last()
+                        .is_some_and(|l| l.spans.iter().all(|s| s.content.trim().is_empty()))
+                {
+                    self.lines.pop();
+                }
+            }
+        }
     }
 
     fn render_table(&mut self, t: TableState) {
@@ -536,5 +670,58 @@ mod tests {
     fn empty_input_produces_no_lines() {
         let lines = render_test("");
         assert!(lines.is_empty());
+    }
+
+    // --- Syntax highlighting (#8) ---
+
+    #[test]
+    fn rust_code_block_tokens_get_distinct_colors() {
+        let src = "```rust\nfn main() { let x = 1; }\n```\n";
+        let lines = render_test(src);
+        // Collect unique foreground colors on spans inside the code block.
+        let fgs: std::collections::HashSet<_> = lines
+            .iter()
+            .flat_map(|l| l.spans.iter())
+            .filter(|s| s.style.bg == Some(COLOR_CODE_BG) && !s.content.trim().is_empty())
+            .filter_map(|s| s.style.fg)
+            .collect();
+        // Highlighted rust should produce more than one distinct fg color
+        // (keyword vs. identifier vs. literal vs. punctuation).
+        assert!(
+            fgs.len() > 1,
+            "expected multiple foreground colors, got {fgs:?}"
+        );
+    }
+
+    #[test]
+    fn unknown_language_falls_back_to_plain_code_style() {
+        let src = "```not-a-real-lang\nliteral content\n```\n";
+        let lines = render_test(src);
+        let plain_span = lines.iter().flat_map(|l| l.spans.iter()).any(|s| {
+            s.style.bg == Some(COLOR_CODE_BG) && s.content.contains("literal content")
+        });
+        assert!(plain_span);
+    }
+
+    #[test]
+    fn unfenced_code_block_uses_plain_style() {
+        // No language tag — fallback path.
+        let src = "```\nplain block content\n```\n";
+        let lines = render_test(src);
+        let plain_span = lines.iter().flat_map(|l| l.spans.iter()).any(|s| {
+            s.style.bg == Some(COLOR_CODE_BG) && s.content.contains("plain block content")
+        });
+        assert!(plain_span);
+    }
+
+    #[test]
+    fn syntax_for_lang_handles_aliases_and_extensions() {
+        let assets = highlight_assets();
+        // Common aliases that should resolve to a syntax.
+        assert!(syntax_for_lang(&assets.syntaxes, Some("rust")).is_some());
+        assert!(syntax_for_lang(&assets.syntaxes, Some("py")).is_some());
+        // Empty / unknown returns None.
+        assert!(syntax_for_lang(&assets.syntaxes, Some("")).is_none());
+        assert!(syntax_for_lang(&assets.syntaxes, None).is_none());
     }
 }

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -1,0 +1,540 @@
+//! Renders markdown text into ratatui `Line`s.
+//!
+//! Supports inline formatting (bold, italic, inline code, links), headings,
+//! bullet/numbered lists, fenced code blocks (rendered with a distinct muted
+//! style — language-aware highlighting belongs in #8), and a simple aligned
+//! grid for tables.
+//!
+//! The output is plain `Line`s of styled `Span`s — no widget state — so it
+//! plugs straight into the existing `Paragraph::new(lines)` flow.
+
+use pulldown_cmark::{Event, HeadingLevel, Options, Parser, Tag, TagEnd};
+use ratatui::{
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+};
+
+const COLOR_HEADING: Color = Color::Rgb(166, 182, 255);
+const COLOR_CODE_FG: Color = Color::Rgb(244, 228, 188);
+const COLOR_CODE_BG: Color = Color::Rgb(40, 44, 56);
+const COLOR_LINK: Color = Color::Rgb(132, 204, 232);
+const COLOR_BLOCKQUOTE: Color = Color::Rgb(170, 178, 196);
+const COLOR_TABLE_BORDER: Color = Color::Rgb(82, 90, 110);
+
+/// Render a markdown source string into styled lines.
+///
+/// `base_style` is applied to inline text (so the assistant body keeps its
+/// green tint while headings/code/links override their own foreground).
+pub fn render(source: &str, base_style: Style) -> Vec<Line<'static>> {
+    let mut options = Options::empty();
+    options.insert(Options::ENABLE_TABLES);
+    options.insert(Options::ENABLE_STRIKETHROUGH);
+    options.insert(Options::ENABLE_TASKLISTS);
+
+    let parser = Parser::new_ext(source, options);
+    let mut renderer = Renderer::new(base_style);
+    for event in parser {
+        renderer.handle(event);
+    }
+    renderer.finish()
+}
+
+struct Renderer {
+    base_style: Style,
+    lines: Vec<Line<'static>>,
+    /// Spans currently being collected for the in-progress line.
+    current: Vec<Span<'static>>,
+    /// Active inline modifiers (bold/italic/strike).
+    modifier: Modifier,
+    /// Are we inside an inline code span?
+    in_code_span: bool,
+    /// Are we inside a fenced code block?
+    in_code_block: bool,
+    /// Are we inside a link? Active link target if so.
+    link_target: Option<String>,
+    /// List nesting state. `Some(Some(n))` = numbered list at index n;
+    /// `Some(None)` = bullet list.
+    list_stack: Vec<Option<u64>>,
+    /// Are we inside a heading? Level if so.
+    heading_level: Option<HeadingLevel>,
+    /// Are we inside a blockquote?
+    blockquote_depth: u32,
+    /// In-progress table rows. Cells are flat span vectors.
+    table: Option<TableState>,
+}
+
+struct TableState {
+    rows: Vec<Vec<Vec<Span<'static>>>>,
+    current_row: Vec<Vec<Span<'static>>>,
+    current_cell: Vec<Span<'static>>,
+    in_cell: bool,
+}
+
+impl Renderer {
+    fn new(base_style: Style) -> Self {
+        Self {
+            base_style,
+            lines: Vec::new(),
+            current: Vec::new(),
+            modifier: Modifier::empty(),
+            in_code_span: false,
+            in_code_block: false,
+            link_target: None,
+            list_stack: Vec::new(),
+            heading_level: None,
+            blockquote_depth: 0,
+            table: None,
+        }
+    }
+
+    fn handle(&mut self, event: Event<'_>) {
+        match event {
+            Event::Start(tag) => self.start_tag(tag),
+            Event::End(tag) => self.end_tag(tag),
+            Event::Text(text) => self.push_text(text.as_ref()),
+            Event::Code(code) => self.push_inline_code(code.as_ref()),
+            Event::Html(_) | Event::InlineHtml(_) => {
+                // Render raw HTML literally — terminals can't interpret it.
+            }
+            Event::FootnoteReference(_) => {}
+            Event::SoftBreak => self.push_text(" "),
+            Event::HardBreak => self.flush_line(),
+            Event::Rule => {
+                self.flush_line();
+                self.lines.push(Line::from(Span::styled(
+                    "─".repeat(40),
+                    Style::default().fg(COLOR_TABLE_BORDER),
+                )));
+            }
+            Event::TaskListMarker(checked) => {
+                let marker = if checked { "[x] " } else { "[ ] " };
+                self.current.push(Span::styled(marker, self.base_style));
+            }
+            Event::DisplayMath(_) | Event::InlineMath(_) => {
+                // Pass through without typesetting — we have no math renderer.
+            }
+        }
+    }
+
+    fn start_tag(&mut self, tag: Tag<'_>) {
+        match tag {
+            Tag::Paragraph => {
+                if self.blockquote_depth > 0 {
+                    self.start_blockquote_line();
+                }
+            }
+            Tag::Heading { level, .. } => {
+                self.flush_line();
+                self.heading_level = Some(level);
+            }
+            Tag::BlockQuote(_) => {
+                self.flush_line();
+                self.blockquote_depth += 1;
+            }
+            Tag::CodeBlock(_) => {
+                self.flush_line();
+                self.in_code_block = true;
+            }
+            Tag::List(start) => {
+                self.flush_line();
+                self.list_stack.push(start);
+            }
+            Tag::Item => {
+                self.flush_line();
+                let depth = self.list_stack.len().saturating_sub(1);
+                let indent = "  ".repeat(depth);
+                let marker = match self.list_stack.last_mut() {
+                    Some(Some(n)) => {
+                        let s = format!("{n}. ");
+                        *n = n.saturating_add(1);
+                        s
+                    }
+                    Some(None) => "• ".to_string(),
+                    None => "• ".to_string(),
+                };
+                self.current.push(Span::styled(
+                    format!("{indent}{marker}"),
+                    self.base_style,
+                ));
+            }
+            Tag::Emphasis => self.modifier.insert(Modifier::ITALIC),
+            Tag::Strong => self.modifier.insert(Modifier::BOLD),
+            Tag::Strikethrough => self.modifier.insert(Modifier::CROSSED_OUT),
+            Tag::Link { dest_url, .. } => {
+                self.link_target = Some(dest_url.into_string());
+            }
+            Tag::Image { .. } => {
+                // Fall back to alt-text rendering.
+            }
+            Tag::Table(_) => {
+                self.flush_line();
+                self.table = Some(TableState {
+                    rows: Vec::new(),
+                    current_row: Vec::new(),
+                    current_cell: Vec::new(),
+                    in_cell: false,
+                });
+            }
+            Tag::TableHead | Tag::TableRow => {
+                if let Some(t) = self.table.as_mut() {
+                    t.current_row.clear();
+                }
+            }
+            Tag::TableCell => {
+                if let Some(t) = self.table.as_mut() {
+                    t.current_cell.clear();
+                    t.in_cell = true;
+                }
+            }
+            Tag::FootnoteDefinition(_)
+            | Tag::DefinitionList
+            | Tag::DefinitionListTitle
+            | Tag::DefinitionListDefinition
+            | Tag::HtmlBlock
+            | Tag::MetadataBlock(_)
+            | Tag::Superscript
+            | Tag::Subscript => {}
+        }
+    }
+
+    fn end_tag(&mut self, tag: TagEnd) {
+        match tag {
+            TagEnd::Paragraph => {
+                self.flush_line();
+                self.lines.push(Line::from(""));
+            }
+            TagEnd::Heading(_) => {
+                self.flush_line();
+                self.heading_level = None;
+                self.lines.push(Line::from(""));
+            }
+            TagEnd::BlockQuote(_) => {
+                self.flush_line();
+                self.blockquote_depth = self.blockquote_depth.saturating_sub(1);
+            }
+            TagEnd::CodeBlock => {
+                self.flush_line();
+                self.in_code_block = false;
+                self.lines.push(Line::from(""));
+            }
+            TagEnd::List(_) => {
+                self.flush_line();
+                self.list_stack.pop();
+                if self.list_stack.is_empty() {
+                    self.lines.push(Line::from(""));
+                }
+            }
+            TagEnd::Item => {
+                self.flush_line();
+            }
+            TagEnd::Emphasis => self.modifier.remove(Modifier::ITALIC),
+            TagEnd::Strong => self.modifier.remove(Modifier::BOLD),
+            TagEnd::Strikethrough => self.modifier.remove(Modifier::CROSSED_OUT),
+            TagEnd::Link => self.link_target = None,
+            TagEnd::Image => {}
+            TagEnd::Table => {
+                if let Some(t) = self.table.take() {
+                    self.render_table(t);
+                }
+            }
+            TagEnd::TableHead | TagEnd::TableRow => {
+                if let Some(t) = self.table.as_mut() {
+                    let row = std::mem::take(&mut t.current_row);
+                    t.rows.push(row);
+                }
+            }
+            TagEnd::TableCell => {
+                if let Some(t) = self.table.as_mut() {
+                    let cell = std::mem::take(&mut t.current_cell);
+                    t.current_row.push(cell);
+                    t.in_cell = false;
+                }
+            }
+            TagEnd::FootnoteDefinition
+            | TagEnd::DefinitionList
+            | TagEnd::DefinitionListTitle
+            | TagEnd::DefinitionListDefinition
+            | TagEnd::HtmlBlock
+            | TagEnd::MetadataBlock(_)
+            | TagEnd::Superscript
+            | TagEnd::Subscript => {}
+        }
+    }
+
+    fn push_text(&mut self, text: &str) {
+        if self.in_code_block {
+            for line in text.split('\n') {
+                self.current.push(Span::styled(
+                    format!(" {line} "),
+                    Style::default().fg(COLOR_CODE_FG).bg(COLOR_CODE_BG),
+                ));
+                self.flush_line();
+            }
+            // Trailing flush already happened; drop the empty extra line that
+            // the trailing '\n' would create.
+            if text.ends_with('\n') && self.lines.last().is_some_and(|l| l.spans.is_empty()) {
+                self.lines.pop();
+            }
+            return;
+        }
+
+        let style = self.inline_style();
+        for (idx, segment) in text.split('\n').enumerate() {
+            if idx > 0 {
+                self.flush_line();
+            }
+            if !segment.is_empty() {
+                self.push_to_current(segment.to_string(), style);
+            }
+        }
+    }
+
+    fn push_inline_code(&mut self, code: &str) {
+        let style = Style::default().fg(COLOR_CODE_FG).bg(COLOR_CODE_BG);
+        self.in_code_span = true;
+        self.current
+            .push(Span::styled(format!("`{code}`"), style));
+        self.in_code_span = false;
+    }
+
+    fn push_to_current(&mut self, text: String, style: Style) {
+        if let Some(target) = &self.link_target {
+            // For terminals, append the URL inline so it's still useful.
+            self.current.push(Span::styled(text, style));
+            self.current.push(Span::styled(
+                format!(" ({target})"),
+                Style::default().fg(COLOR_LINK).add_modifier(Modifier::DIM),
+            ));
+        } else if self.table.as_ref().is_some_and(|t| t.in_cell) {
+            // Cell text is collected into the current cell, not the line buffer.
+            if let Some(t) = self.table.as_mut() {
+                t.current_cell.push(Span::styled(text, style));
+            }
+        } else {
+            self.current.push(Span::styled(text, style));
+        }
+    }
+
+    fn inline_style(&self) -> Style {
+        let mut style = self.base_style;
+        if let Some(level) = self.heading_level {
+            let extra = match level {
+                HeadingLevel::H1 => Modifier::BOLD | Modifier::UNDERLINED,
+                _ => Modifier::BOLD,
+            };
+            style = style.fg(COLOR_HEADING).add_modifier(extra);
+        }
+        if self.blockquote_depth > 0 {
+            style = style
+                .fg(COLOR_BLOCKQUOTE)
+                .add_modifier(Modifier::ITALIC);
+        }
+        if self.link_target.is_some() {
+            style = style
+                .fg(COLOR_LINK)
+                .add_modifier(Modifier::UNDERLINED);
+        }
+        if !self.modifier.is_empty() {
+            style = style.add_modifier(self.modifier);
+        }
+        style
+    }
+
+    fn start_blockquote_line(&mut self) {
+        self.current.push(Span::styled(
+            "│ ",
+            Style::default().fg(COLOR_BLOCKQUOTE),
+        ));
+    }
+
+    fn flush_line(&mut self) {
+        if self.current.is_empty() {
+            return;
+        }
+        let spans = std::mem::take(&mut self.current);
+        self.lines.push(Line::from(spans));
+    }
+
+    fn finish(mut self) -> Vec<Line<'static>> {
+        self.flush_line();
+        // Drop trailing empty spacer if present.
+        while self
+            .lines
+            .last()
+            .is_some_and(|l| l.spans.is_empty() || l.spans.iter().all(|s| s.content.is_empty()))
+        {
+            self.lines.pop();
+        }
+        self.lines
+    }
+
+    fn render_table(&mut self, t: TableState) {
+        if t.rows.is_empty() {
+            return;
+        }
+        let column_count = t.rows.iter().map(|r| r.len()).max().unwrap_or(0);
+        if column_count == 0 {
+            return;
+        }
+        let mut widths = vec![0usize; column_count];
+        for row in &t.rows {
+            for (idx, cell) in row.iter().enumerate() {
+                let w: usize = cell.iter().map(|s| s.content.chars().count()).sum();
+                if idx < widths.len() && w > widths[idx] {
+                    widths[idx] = w;
+                }
+            }
+        }
+
+        let border = Style::default().fg(COLOR_TABLE_BORDER);
+        for (row_idx, row) in t.rows.iter().enumerate() {
+            let mut spans: Vec<Span<'static>> = Vec::new();
+            for (col_idx, cell) in row.iter().enumerate() {
+                if col_idx > 0 {
+                    spans.push(Span::styled(" │ ", border));
+                }
+                let used: usize = cell.iter().map(|s| s.content.chars().count()).sum();
+                for span in cell {
+                    spans.push(span.clone());
+                }
+                if col_idx < widths.len() && used < widths[col_idx] {
+                    spans.push(Span::styled(
+                        " ".repeat(widths[col_idx] - used),
+                        self.base_style,
+                    ));
+                }
+            }
+            self.lines.push(Line::from(spans));
+            // Header separator after first row.
+            if row_idx == 0 {
+                let total_width: usize =
+                    widths.iter().sum::<usize>() + 3 * widths.len().saturating_sub(1);
+                self.lines.push(Line::from(Span::styled(
+                    "─".repeat(total_width),
+                    border,
+                )));
+            }
+        }
+        self.lines.push(Line::from(""));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn render_test(src: &str) -> Vec<Line<'static>> {
+        render(src, Style::default())
+    }
+
+    fn flatten(lines: &[Line]) -> String {
+        lines
+            .iter()
+            .map(|l| l.spans.iter().map(|s| s.content.as_ref()).collect::<String>())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    #[test]
+    fn plain_text_renders_unchanged_text() {
+        let lines = render_test("hello world");
+        let flat = flatten(&lines);
+        assert!(flat.contains("hello world"));
+    }
+
+    #[test]
+    fn bold_emits_bold_modifier() {
+        let lines = render_test("this is **strong** text");
+        let any_bold = lines
+            .iter()
+            .flat_map(|l| l.spans.iter())
+            .any(|s| s.content == "strong" && s.style.add_modifier.contains(Modifier::BOLD));
+        assert!(any_bold, "expected a span with BOLD modifier on 'strong'");
+    }
+
+    #[test]
+    fn italic_emits_italic_modifier() {
+        let lines = render_test("this is *emphasized* text");
+        let any_italic = lines
+            .iter()
+            .flat_map(|l| l.spans.iter())
+            .any(|s| s.content == "emphasized" && s.style.add_modifier.contains(Modifier::ITALIC));
+        assert!(any_italic);
+    }
+
+    #[test]
+    fn inline_code_keeps_backticks() {
+        let lines = render_test("a `foo()` call");
+        let flat = flatten(&lines);
+        assert!(flat.contains("`foo()`"));
+    }
+
+    #[test]
+    fn fenced_code_block_renders_distinctly() {
+        let src = "before\n\n```\nlet x = 1;\nlet y = 2;\n```\n\nafter";
+        let lines = render_test(src);
+        let flat = flatten(&lines);
+        assert!(flat.contains("let x = 1;"));
+        assert!(flat.contains("let y = 2;"));
+        // Code-block spans should carry the code background color.
+        let any_code_styled = lines.iter().flat_map(|l| l.spans.iter()).any(|s| {
+            s.style.bg == Some(COLOR_CODE_BG) && s.content.contains("let x = 1;")
+        });
+        assert!(any_code_styled, "expected a span with code bg on the code line");
+    }
+
+    #[test]
+    fn bullet_list_emits_markers() {
+        let lines = render_test("- alpha\n- beta\n- gamma");
+        let flat = flatten(&lines);
+        assert!(flat.contains("• alpha"));
+        assert!(flat.contains("• beta"));
+        assert!(flat.contains("• gamma"));
+    }
+
+    #[test]
+    fn numbered_list_emits_indices() {
+        let lines = render_test("1. first\n2. second");
+        let flat = flatten(&lines);
+        assert!(flat.contains("1. first"));
+        assert!(flat.contains("2. second"));
+    }
+
+    #[test]
+    fn heading_styles_with_bold() {
+        let lines = render_test("# Heading text\n\nbody");
+        let any_heading_bold = lines.iter().flat_map(|l| l.spans.iter()).any(|s| {
+            s.content == "Heading text" && s.style.add_modifier.contains(Modifier::BOLD)
+        });
+        assert!(any_heading_bold);
+    }
+
+    #[test]
+    fn link_rendered_with_underline_and_url() {
+        let lines = render_test("see [docs](https://example.com)");
+        let flat = flatten(&lines);
+        assert!(flat.contains("docs"));
+        assert!(flat.contains("https://example.com"));
+        let any_link = lines.iter().flat_map(|l| l.spans.iter()).any(|s| {
+            s.content == "docs" && s.style.add_modifier.contains(Modifier::UNDERLINED)
+        });
+        assert!(any_link);
+    }
+
+    #[test]
+    fn table_renders_aligned_grid() {
+        let src = "| a | b |\n|---|---|\n| 1 | 2 |\n| 3 | 4 |";
+        let lines = render_test(src);
+        let flat = flatten(&lines);
+        assert!(flat.contains("a"));
+        assert!(flat.contains("│"));
+        assert!(flat.contains("1"));
+        assert!(flat.contains("2"));
+    }
+
+    #[test]
+    fn empty_input_produces_no_lines() {
+        let lines = render_test("");
+        assert!(lines.is_empty());
+    }
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -125,50 +125,68 @@ fn draw_chat_panel(f: &mut Frame, app: &mut App, area: ratatui::layout::Rect) {
     draw_status_bar(f, app, chunks[2]);
 }
 
+fn push_user_message(lines: &mut Vec<Line<'static>>, content: &str, style: Style) {
+    let mut first = true;
+    for text_line in split_display_lines(content) {
+        if first {
+            lines.push(Line::from(vec![
+                Span::styled("You: ", style.add_modifier(Modifier::BOLD)),
+                Span::styled(text_line, style),
+            ]));
+            first = false;
+        } else {
+            lines.push(Line::from(Span::styled(text_line, style)));
+        }
+    }
+}
+
+fn push_assistant_markdown(lines: &mut Vec<Line<'static>>, content: &str, style: Style) {
+    let mut rendered = crate::markdown::render(content, style);
+    if rendered.is_empty() {
+        rendered.push(Line::from(""));
+    }
+    // Prepend "Adele: " to the first non-empty line so the prefix sits with
+    // the response rather than on its own row.
+    let prefix_pos = rendered
+        .iter()
+        .position(|l| !l.spans.is_empty())
+        .unwrap_or(0);
+    let prefix_span = Span::styled("Adele: ", style.add_modifier(Modifier::BOLD));
+    if let Some(first) = rendered.get_mut(prefix_pos) {
+        first.spans.insert(0, prefix_span);
+    } else {
+        rendered.push(Line::from(prefix_span));
+    }
+    lines.extend(rendered);
+}
+
 fn draw_messages(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
     let mut lines: Vec<Line> = Vec::new();
 
     if let Some(conv) = &app.current_conversation {
         for msg in &conv.messages {
-            let (prefix, style) = match msg.role.as_str() {
-                "user" => ("You: ", Style::default().fg(COLOR_USER_PREFIX)),
+            match msg.role.as_str() {
+                "user" => {
+                    let style = Style::default().fg(COLOR_USER_PREFIX);
+                    push_user_message(&mut lines, &msg.content, style);
+                    lines.push(Line::from(""));
+                }
                 "assistant" if !msg.content.trim().is_empty() => {
-                    ("Adele: ", Style::default().fg(COLOR_ASSISTANT_PREFIX))
+                    let style = Style::default().fg(COLOR_ASSISTANT_PREFIX);
+                    push_assistant_markdown(&mut lines, &msg.content, style);
+                    lines.push(Line::from(""));
                 }
                 // Skip tool, system, and empty assistant messages
                 _ => continue,
-            };
-            // Split content on newlines so ratatui renders them as separate lines
-            let mut first = true;
-            for text_line in split_display_lines(&msg.content) {
-                if first {
-                    lines.push(Line::from(vec![
-                        Span::styled(prefix, style.add_modifier(Modifier::BOLD)),
-                        Span::styled(text_line, style),
-                    ]));
-                    first = false;
-                } else {
-                    lines.push(Line::from(Span::styled(text_line, style)));
-                }
             }
-            lines.push(Line::from("")); // spacing
         }
 
-        // Show streaming buffer as in-progress assistant message
+        // Show streaming buffer as in-progress assistant message. Markdown is
+        // applied to the partial buffer too — unclosed fences just show
+        // their literal backticks until the stream catches up.
         if !app.streaming_buffer.is_empty() {
             let style = Style::default().fg(COLOR_ASSISTANT_STREAMING);
-            let mut first = true;
-            for text_line in split_display_lines(&app.streaming_buffer) {
-                if first {
-                    lines.push(Line::from(vec![
-                        Span::styled("Adele: ", style.add_modifier(Modifier::BOLD)),
-                        Span::styled(text_line, style),
-                    ]));
-                    first = false;
-                } else {
-                    lines.push(Line::from(Span::styled(text_line, style)));
-                }
-            }
+            push_assistant_markdown(&mut lines, &app.streaming_buffer, style);
             // Cursor on last line
             if let Some(last) = lines.last_mut() {
                 last.spans.push(Span::styled("▌", style));
@@ -356,5 +374,27 @@ mod tests {
         let mut terminal = Terminal::new(backend).unwrap();
         let mut app = App::new();
         terminal.draw(|f| draw(f, &mut app)).unwrap();
+    }
+
+    #[test]
+    fn assistant_markdown_strips_emphasis_markers() {
+        // `**strong**` should render as `strong` (markdown punctuation
+        // consumed by the parser), not literal `**strong**`.
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut app = App::new();
+        app.current_conversation = Some(ConversationDetail {
+            id: "1".into(),
+            title: "Test".into(),
+            messages: vec![ChatMessage {
+                role: "assistant".into(),
+                content: "answer with **strong** word".into(),
+            }],
+        });
+        terminal.draw(|f| draw(f, &mut app)).unwrap();
+        let buf = terminal.backend().buffer().clone();
+        let dump: String = buf.content.iter().map(|c| c.symbol()).collect();
+        assert!(dump.contains("strong"));
+        assert!(!dump.contains("**strong**"));
     }
 }


### PR DESCRIPTION
## Summary

Adds language-aware syntax highlighting to fenced code blocks via `syntect` (5.x), themed with `base16-ocean.dark`.

- Captures the language hint from `pulldown_cmark::CodeBlockKind::Fenced` and resolves it through syntect's syntax set (token, then extension).
- Buffers the whole code block during parsing and runs syntect once on close so multi-line constructs (block comments, raw strings, indentation-sensitive grammars) tokenize correctly.
- Unknown languages and unfenced blocks keep the existing muted plain style.
- Each line keeps its dark code-block background so the block reads as a unit.

## Stacked on #7

This branch is based on `feat/markdown-rendering` (#7) and the diff lives entirely inside the markdown module added there. Once #7 merges, this PR's base should be re-pointed to `main` (or just rebased onto it).

## Test plan

- [x] `cargo test` — 91 passing (+4 new in `markdown.rs`)
- [x] `cargo build` clean (adds syntect ~5MB binary footprint)
- [ ] Manual: ask the assistant for a Rust snippet → keywords, strings, types render in distinct colors
- [ ] Manual: code fence with no language → plain muted style (regression check)
- [ ] Manual: code fence with bogus language (` ```foobar `) → plain muted style

## Notes

`base16-ocean.dark` ships in syntect's defaults — no extra theme assets bundled. If we want a different palette later, a settings field can choose among the bundled themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)