### PR TITLE
Store credentials in the system keyring (closes #13)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,7 @@ dependencies = [
  "desktop-assistant-client-common",
  "futures",
  "ratatui",
+ "serde",
  "serde_json",
  "tokio",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,6 +11,7 @@ dependencies = [
  "crossterm",
  "desktop-assistant-client-common",
  "futures",
+ "keyring",
  "ratatui",
  "serde",
  "serde_json",
@@ -18,6 +19,17 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tui-textarea",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -104,6 +116,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.1.4",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix 1.1.4",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,6 +184,30 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.4",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -181,6 +276,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,6 +322,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -236,6 +362,16 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
 
 [[package]]
 name = "clap"
@@ -443,6 +579,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "dbus"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "aes",
+ "block-padding",
+ "cbc",
+ "dbus",
+ "fastrand",
+ "hkdf",
+ "num",
+ "once_cell",
+ "sha2",
+ "zeroize",
+]
+
+[[package]]
 name = "desktop-assistant-api-model"
 version = "0.1.0"
 dependencies = [
@@ -466,7 +631,7 @@ dependencies = [
  "tokio-tungstenite",
  "tracing",
  "uuid",
- "zbus",
+ "zbus 5.14.0",
 ]
 
 [[package]]
@@ -477,6 +642,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -808,10 +974,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -1050,6 +1240,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "instability"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1166,6 +1366,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "dbus-secret-service",
+ "log",
+ "secret-service",
+ "zeroize",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1182,6 +1394,15 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1274,12 +1495,98 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1358,6 +1665,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1433,7 +1771,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1482,12 +1820,33 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1497,7 +1856,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1764,6 +2132,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "secret-service"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4d35ad99a181be0a60ffcbe85d680d98f87bdc4d7644ade319b87076b9dbfd4"
+dependencies = [
+ "aes",
+ "cbc",
+ "futures-util",
+ "generic-array",
+ "hkdf",
+ "num",
+ "once_cell",
+ "rand 0.8.6",
+ "serde",
+ "sha2",
+ "zbus 4.4.0",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1851,6 +2238,17 @@ name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2342,7 +2740,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand",
+ "rand 0.9.4",
  "rustls",
  "rustls-pki-types",
  "sha1",
@@ -3056,6 +3454,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "xdg-home"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3076,6 +3484,38 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zbus"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
+dependencies = [
+ "async-broadcast",
+ "async-process",
+ "async-recursion",
+ "async-trait",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix",
+ "ordered-stream",
+ "rand 0.8.6",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.52.0",
+ "xdg-home",
+ "zbus_macros 4.4.0",
+ "zbus_names 3.0.0",
+ "zvariant 4.2.0",
 ]
 
 [[package]]
@@ -3103,9 +3543,22 @@ dependencies = [
  "uuid",
  "windows-sys 0.61.2",
  "winnow 0.7.15",
- "zbus_macros",
- "zbus_names",
- "zvariant",
+ "zbus_macros 5.14.0",
+ "zbus_names 4.3.1",
+ "zvariant 5.10.0",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zvariant_utils 2.1.0",
 ]
 
 [[package]]
@@ -3118,9 +3571,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "zbus_names",
- "zvariant",
- "zvariant_utils",
+ "zbus_names 4.3.1",
+ "zvariant 5.10.0",
+ "zvariant_utils 3.3.0",
+]
+
+[[package]]
+name = "zbus_names"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant 4.2.0",
 ]
 
 [[package]]
@@ -3131,7 +3595,7 @@ checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
 dependencies = [
  "serde",
  "winnow 0.7.15",
- "zvariant",
+ "zvariant 5.10.0",
 ]
 
 [[package]]
@@ -3180,6 +3644,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"
@@ -3222,6 +3700,19 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zvariant"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zvariant_derive 4.2.0",
+]
+
+[[package]]
+name = "zvariant"
 version = "5.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5708299b21903bbe348e94729f22c49c55d04720a004aa350f1f9c122fd2540b"
@@ -3230,8 +3721,21 @@ dependencies = [
  "enumflags2",
  "serde",
  "winnow 0.7.15",
- "zvariant_derive",
- "zvariant_utils",
+ "zvariant_derive 5.10.0",
+ "zvariant_utils 3.3.0",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zvariant_utils 2.1.0",
 ]
 
 [[package]]
@@ -3244,7 +3748,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "zvariant_utils",
+ "zvariant_utils 3.3.0",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ tokio.workspace = true
 anyhow.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 clap = { version = "4", features = ["derive", "env"] }
 ratatui = { version = "0.29", features = ["unstable-rendered-line-info"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,5 +38,6 @@ clap = { version = "4", features = ["derive", "env"] }
 ratatui = { version = "0.29", features = ["unstable-rendered-line-info"] }
 crossterm = { version = "0.28", features = ["event-stream"] }
 futures = "0.3"
+keyring = { version = "3", features = ["sync-secret-service", "crypto-rust"] }
 tui-textarea = "0.7"
 desktop-assistant-client-common.workspace = true

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -1,0 +1,131 @@
+//! Thin wrapper around the system keyring (Secret Service on Linux).
+//!
+//! Credentials are scoped per-profile by keying entries with the profile id.
+//! All operations are best-effort: if the keyring is unavailable (headless
+//! systems, CI, env without `dbus` running) we surface the error so callers
+//! can fall back to env vars or skip the credential silently.
+
+use std::{env, io};
+
+use keyring::Entry;
+
+const SERVICE: &str = "adele-tui";
+
+const ENV_DISABLE: &str = "ADELE_TUI_DISABLE_KEYRING";
+
+#[derive(Debug, Clone, Copy)]
+pub enum CredentialKind {
+    /// Login password used for username/password auth.
+    Password,
+    /// Direct JWT token.
+    Jwt,
+}
+
+impl CredentialKind {
+    fn account_prefix(self) -> &'static str {
+        match self {
+            CredentialKind::Password => "password",
+            CredentialKind::Jwt => "jwt",
+        }
+    }
+}
+
+fn account_key(profile_id: &str, kind: CredentialKind) -> String {
+    format!("{}::{}", kind.account_prefix(), profile_id)
+}
+
+/// Returns true when the keyring is intentionally disabled via env var.
+/// Useful for headless CI runs where `dbus` isn't available.
+fn keyring_disabled() -> bool {
+    env::var(ENV_DISABLE)
+        .ok()
+        .is_some_and(|v| matches!(v.as_str(), "1" | "true" | "yes"))
+}
+
+pub fn store(profile_id: &str, kind: CredentialKind, secret: &str) -> io::Result<()> {
+    if keyring_disabled() {
+        return Err(io::Error::other("keyring disabled via env"));
+    }
+    let key = account_key(profile_id, kind);
+    let entry = Entry::new(SERVICE, &key).map_err(map_err)?;
+    entry.set_password(secret).map_err(map_err)
+}
+
+pub fn retrieve(profile_id: &str, kind: CredentialKind) -> io::Result<String> {
+    if keyring_disabled() {
+        return Err(io::Error::other("keyring disabled via env"));
+    }
+    let key = account_key(profile_id, kind);
+    let entry = Entry::new(SERVICE, &key).map_err(map_err)?;
+    entry.get_password().map_err(map_err)
+}
+
+pub fn delete(profile_id: &str, kind: CredentialKind) -> io::Result<()> {
+    if keyring_disabled() {
+        return Ok(()); // Treat disabled keyring as a no-op for deletes.
+    }
+    let key = account_key(profile_id, kind);
+    let entry = Entry::new(SERVICE, &key).map_err(map_err)?;
+    match entry.delete_credential() {
+        Ok(()) => Ok(()),
+        // Missing entries are not an error for the caller's purposes.
+        Err(keyring::Error::NoEntry) => Ok(()),
+        Err(e) => Err(map_err(e)),
+    }
+}
+
+fn map_err(err: keyring::Error) -> io::Error {
+    io::Error::other(err.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Serializes env-var mutation across the tests in this module so the
+    /// parallel test runner doesn't race on `ADELE_TUI_DISABLE_KEYRING`.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_env_disabled<F: FnOnce()>(f: F) {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prior = env::var(ENV_DISABLE).ok();
+        // SAFETY: held under ENV_LOCK so no other test in this module
+        // mutates the same var concurrently.
+        unsafe { env::set_var(ENV_DISABLE, "1") };
+        f();
+        unsafe {
+            match prior {
+                Some(v) => env::set_var(ENV_DISABLE, v),
+                None => env::remove_var(ENV_DISABLE),
+            }
+        }
+    }
+
+    #[test]
+    fn account_key_includes_kind_and_profile_id() {
+        let k = account_key("abc-123", CredentialKind::Password);
+        assert_eq!(k, "password::abc-123");
+        let k = account_key("abc-123", CredentialKind::Jwt);
+        assert_eq!(k, "jwt::abc-123");
+    }
+
+    #[test]
+    fn keyring_disabled_returns_true_when_env_set() {
+        with_env_disabled(|| assert!(keyring_disabled()));
+    }
+
+    #[test]
+    fn store_returns_error_when_disabled() {
+        with_env_disabled(|| {
+            assert!(store("test-id", CredentialKind::Password, "secret").is_err());
+        });
+    }
+
+    #[test]
+    fn delete_is_noop_when_disabled() {
+        with_env_disabled(|| {
+            assert!(delete("test-id", CredentialKind::Password).is_ok());
+        });
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
 pub mod app;
 pub mod keys;
+pub mod picker;
+pub mod profile;
 pub mod ui;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod app;
+pub mod credentials;
 pub mod keys;
 pub mod picker;
 pub mod profile;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,13 @@
 mod app;
 mod keys;
+mod picker;
+mod profile;
 mod ui;
 
 use std::io;
 
 use anyhow::Result;
-use clap::Parser;
+use clap::{CommandFactory, FromArgMatches, Parser, parser::ValueSource};
 use crossterm::{
     event::{
         DisableMouseCapture, EnableMouseCapture, Event, KeyEventKind, KeyboardEnhancementFlags,
@@ -23,6 +25,8 @@ use ratatui::{Terminal, backend::CrosstermBackend};
 
 use app::{App, InputMode};
 use keys::{Action, handle_key_event};
+use picker::PickerOutcome;
+use profile::ProfileStore;
 
 const DEFAULT_WS_URL: &str = desktop_assistant_client_common::config::DEFAULT_WS_URL;
 const DEFAULT_WS_SUBJECT: &str = desktop_assistant_client_common::config::DEFAULT_WS_SUBJECT;
@@ -97,7 +101,9 @@ impl From<CliArgs> for ConnectionConfig {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let config = ConnectionConfig::from(CliArgs::parse());
+    let matches = CliArgs::command().get_matches();
+    let cli = CliArgs::from_arg_matches(&matches)?;
+    let cli_explicit = any_explicit_connection_arg(&matches);
 
     enable_raw_mode()?;
     let mut stdout = io::stdout();
@@ -114,7 +120,7 @@ async fn main() -> Result<()> {
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
-    let result = run(&mut terminal, &config).await;
+    let result = run_app(&mut terminal, cli, cli_explicit).await;
 
     // Restore terminal
     disable_raw_mode()?;
@@ -127,6 +133,42 @@ async fn main() -> Result<()> {
     terminal.show_cursor()?;
 
     result
+}
+
+/// Returns true if the user explicitly supplied any connection-related CLI
+/// flag or env var, in which case we skip the profile picker and connect
+/// using the provided values (matching pre-profile-picker behavior).
+fn any_explicit_connection_arg(matches: &clap::ArgMatches) -> bool {
+    ["transport", "ws_url", "ws_subject"]
+        .iter()
+        .any(|name| {
+            matches!(
+                matches.value_source(name),
+                Some(ValueSource::CommandLine | ValueSource::EnvVariable)
+            )
+        })
+}
+
+/// Decide between picker-driven and CLI-driven connection, then hand off
+/// to the chat loop.
+async fn run_app(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    cli: CliArgs,
+    cli_explicit: bool,
+) -> Result<()> {
+    let store = ProfileStore::load();
+
+    let config = if cli_explicit || store.profiles.is_empty() {
+        ConnectionConfig::from(cli)
+    } else {
+        let (outcome, _store) = picker::run(terminal, store).await?;
+        match outcome {
+            PickerOutcome::Selected(profile) => profile.to_connection_config(),
+            PickerOutcome::Cancelled => return Ok(()),
+        }
+    };
+
+    run(terminal, &config).await
 }
 
 async fn run(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod app;
+mod credentials;
 mod keys;
 mod picker;
 mod profile;

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -20,7 +20,10 @@ use ratatui::{
 };
 use tui_textarea::{CursorMove, TextArea};
 
-use crate::profile::{Profile, ProfileStore};
+use crate::{
+    credentials::{self, CredentialKind},
+    profile::{Profile, ProfileStore},
+};
 
 const COLOR_BORDER: Color = Color::Rgb(82, 104, 173);
 const COLOR_BORDER_ACTIVE: Color = Color::Rgb(120, 183, 109);
@@ -53,9 +56,18 @@ enum Field {
     Transport,
     Url,
     Subject,
+    Username,
+    Password,
 }
 
-const FIELD_ORDER: [Field; 4] = [Field::Name, Field::Transport, Field::Url, Field::Subject];
+const FIELD_ORDER: [Field; 6] = [
+    Field::Name,
+    Field::Transport,
+    Field::Url,
+    Field::Subject,
+    Field::Username,
+    Field::Password,
+];
 
 struct PickerState {
     store: ProfileStore,
@@ -72,6 +84,14 @@ struct FormState {
     name: TextArea<'static>,
     url: TextArea<'static>,
     subject: TextArea<'static>,
+    username: TextArea<'static>,
+    /// Password buffer — masked in the UI. Empty on edit means "leave the
+    /// stored secret untouched"; non-empty replaces the stored value.
+    password: TextArea<'static>,
+    /// Whether this profile already has a stored password (set when
+    /// editing). Drives the placeholder hint and decides whether to
+    /// preserve or clear.
+    had_stored_password: bool,
     transport: TransportMode,
 }
 
@@ -84,6 +104,9 @@ impl FormState {
         let mut subject = single_line_textarea();
         subject.insert_str("desktop-tui");
         subject.move_cursor(CursorMove::End);
+        let username = single_line_textarea();
+        let mut password = single_line_textarea();
+        password.set_mask_char('•');
         // Default focus on Name so users can just start typing.
         name.move_cursor(CursorMove::Head);
         Self {
@@ -92,6 +115,9 @@ impl FormState {
             name,
             url,
             subject,
+            username,
+            password,
+            had_stored_password: false,
             transport: TransportMode::Ws,
         }
     }
@@ -108,6 +134,15 @@ impl FormState {
         form.subject = single_line_textarea();
         form.subject.insert_str(&profile.ws_subject);
         form.subject.move_cursor(CursorMove::End);
+        form.username = single_line_textarea();
+        if let Some(user) = &profile.username {
+            form.username.insert_str(user);
+            form.username.move_cursor(CursorMove::End);
+        }
+        // Don't reveal stored password — leave the field empty and let the
+        // submit logic preserve the existing secret unless the user types
+        // a replacement.
+        form.had_stored_password = profile.has_password;
         form.transport = profile.transport;
         form
     }
@@ -122,7 +157,7 @@ impl FormState {
         self.focus = FIELD_ORDER[(pos + FIELD_ORDER.len() - 1) % FIELD_ORDER.len()];
     }
 
-    fn submit(&self) -> Result<Profile, String> {
+    fn submit(&self) -> Result<SubmittedProfile, String> {
         let name = self.name.lines().join(" ").trim().to_string();
         if name.is_empty() {
             return Err("Name is required".into());
@@ -132,6 +167,25 @@ impl FormState {
             return Err("URL is required for WebSocket transport".into());
         }
         let ws_subject = self.subject.lines().join(" ").trim().to_string();
+        let username_raw = self.username.lines().join(" ").trim().to_string();
+        let username = if username_raw.is_empty() {
+            None
+        } else {
+            Some(username_raw)
+        };
+        let password_raw = self.password.lines().join("");
+        // Empty password on edit = preserve the stored secret. On a fresh
+        // profile (no editing_id), empty just means "no password set".
+        let password_action = if password_raw.is_empty() {
+            if self.editing_id.is_some() && self.had_stored_password {
+                PasswordAction::PreserveExisting
+            } else {
+                PasswordAction::None
+            }
+        } else {
+            PasswordAction::Set(password_raw)
+        };
+
         let id = self.editing_id.clone().unwrap_or_else(|| {
             // Sourced from time-since-epoch in profile::new_id; reuse its format.
             crate::profile::Profile::new(
@@ -142,14 +196,37 @@ impl FormState {
             )
             .id
         });
-        Ok(Profile {
+        Ok(SubmittedProfile {
             id,
             name,
             transport: self.transport,
             ws_url,
             ws_subject,
+            username,
+            password_action,
         })
     }
+}
+
+#[derive(Debug, Clone)]
+enum PasswordAction {
+    /// No password — clear any existing stored secret.
+    None,
+    /// Replace stored secret with this value.
+    Set(String),
+    /// Leave the stored secret as-is (only meaningful on edit).
+    PreserveExisting,
+}
+
+#[derive(Debug, Clone)]
+struct SubmittedProfile {
+    id: String,
+    name: String,
+    transport: TransportMode,
+    ws_url: String,
+    ws_subject: String,
+    username: Option<String>,
+    password_action: PasswordAction,
 }
 
 fn single_line_textarea() -> TextArea<'static> {
@@ -287,36 +364,14 @@ fn handle_form_key(state: &mut PickerState, key: KeyEvent) {
         (KeyCode::Down, m) if m.is_empty() => state.form.next_field(),
         (KeyCode::Enter, m) if m.is_empty() => {
             match state.form.submit() {
-                Ok(profile) => {
-                    let editing = state.form.editing_id.is_some();
-                    if editing {
-                        // Replace existing profile in place.
-                        if let Some(existing) = state
-                            .store
-                            .profiles
-                            .iter_mut()
-                            .find(|p| p.id == profile.id)
-                        {
-                            *existing = profile.clone();
-                        }
+                Ok(submitted) => {
+                    if let Err(e) = apply_submission(state, submitted) {
+                        state.error = Some(e);
                     } else {
-                        state.store.add(profile.clone());
+                        state.error = None;
+                        state.mode = Mode::List;
+                        state.form = FormState::empty();
                     }
-                    if let Err(e) = state.store.save() {
-                        state.error = Some(format!("Save failed: {e}"));
-                        return;
-                    }
-                    // Reselect to the saved profile.
-                    let new_index = state
-                        .store
-                        .profiles
-                        .iter()
-                        .position(|p| p.id == profile.id)
-                        .unwrap_or(state.selected);
-                    state.selected = new_index;
-                    state.error = None;
-                    state.mode = Mode::List;
-                    state.form = FormState::empty();
                 }
                 Err(msg) => state.error = Some(msg),
             }
@@ -340,9 +395,91 @@ fn handle_form_key(state: &mut PickerState, key: KeyEvent) {
             Field::Subject => {
                 state.form.subject.input(key);
             }
+            Field::Username => {
+                state.form.username.input(key);
+            }
+            Field::Password => {
+                state.form.password.input(key);
+            }
             Field::Transport => {}
         },
     }
+}
+
+/// Persist a submitted profile: update keyring, write profile, save store,
+/// reselect. Returns an error string suitable for the UI on failure.
+fn apply_submission(state: &mut PickerState, submitted: SubmittedProfile) -> Result<(), String> {
+    let editing = state
+        .store
+        .profiles
+        .iter()
+        .any(|p| p.id == submitted.id);
+
+    let mut has_password = match &submitted.password_action {
+        PasswordAction::Set(_) => true,
+        PasswordAction::PreserveExisting => true,
+        PasswordAction::None => false,
+    };
+
+    // Apply password change first; if keyring fails, surface it before we
+    // touch the on-disk store so state stays consistent.
+    match &submitted.password_action {
+        PasswordAction::Set(secret) => {
+            if let Err(e) = credentials::store(&submitted.id, CredentialKind::Password, secret) {
+                return Err(format!("Could not store password: {e}"));
+            }
+        }
+        PasswordAction::PreserveExisting => {
+            // Keep the keyring as-is; nothing to do.
+        }
+        PasswordAction::None => {
+            let _ = credentials::delete(&submitted.id, CredentialKind::Password);
+            has_password = false;
+        }
+    }
+
+    let new_profile = Profile {
+        id: submitted.id.clone(),
+        name: submitted.name,
+        transport: submitted.transport,
+        ws_url: submitted.ws_url,
+        ws_subject: submitted.ws_subject,
+        username: submitted.username,
+        has_password,
+        // JWT is managed by #14 OAuth flow — preserve any existing flag
+        // when editing, default to false on create.
+        has_jwt: state
+            .store
+            .profiles
+            .iter()
+            .find(|p| p.id == submitted.id)
+            .map(|p| p.has_jwt)
+            .unwrap_or(false),
+    };
+
+    if editing {
+        if let Some(existing) = state
+            .store
+            .profiles
+            .iter_mut()
+            .find(|p| p.id == new_profile.id)
+        {
+            *existing = new_profile.clone();
+        }
+    } else {
+        state.store.add(new_profile.clone());
+    }
+    state
+        .store
+        .save()
+        .map_err(|e| format!("Save failed: {e}"))?;
+    state.selected = state
+        .store
+        .profiles
+        .iter()
+        .position(|p| p.id == new_profile.id)
+        .unwrap_or(state.selected);
+    Ok(())
 }
 
 fn handle_delete_key(state: &mut PickerState, key: KeyEvent) {
@@ -497,6 +634,10 @@ fn draw_form(f: &mut Frame, state: &PickerState, area: Rect) {
             Constraint::Length(3),
             Constraint::Length(1),
             Constraint::Length(3),
+            Constraint::Length(1),
+            Constraint::Length(3),
+            Constraint::Length(1),
+            Constraint::Length(3),
             Constraint::Min(0),
         ])
         .split(inner);
@@ -526,6 +667,37 @@ fn draw_form(f: &mut Frame, state: &PickerState, area: Rect) {
         rows[7],
         &state.form.subject,
         state.form.focus == Field::Subject,
+    );
+
+    draw_field_label(
+        f,
+        rows[8],
+        "Username (optional)",
+        state.form.focus == Field::Username,
+    );
+    draw_text_field(
+        f,
+        rows[9],
+        &state.form.username,
+        state.form.focus == Field::Username,
+    );
+
+    let password_label = if state.form.had_stored_password {
+        "Password (•••• stored — leave blank to keep)"
+    } else {
+        "Password (optional, masked)"
+    };
+    draw_field_label(
+        f,
+        rows[10],
+        password_label,
+        state.form.focus == Field::Password,
+    );
+    draw_text_field(
+        f,
+        rows[11],
+        &state.form.password,
+        state.form.focus == Field::Password,
     );
 }
 
@@ -691,6 +863,10 @@ fn position_cursor_in_form(f: &mut Frame, state: &PickerState, area: Rect) {
             Constraint::Length(3),
             Constraint::Length(1),
             Constraint::Length(3),
+            Constraint::Length(1),
+            Constraint::Length(3),
+            Constraint::Length(1),
+            Constraint::Length(3),
             Constraint::Min(0),
         ])
         .split(inner);
@@ -699,6 +875,8 @@ fn position_cursor_in_form(f: &mut Frame, state: &PickerState, area: Rect) {
         Field::Name => (&state.form.name, 1),
         Field::Url => (&state.form.url, 5),
         Field::Subject => (&state.form.subject, 7),
+        Field::Username => (&state.form.username, 9),
+        Field::Password => (&state.form.password, 11),
         Field::Transport => return,
     };
 

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -1,0 +1,821 @@
+//! Pre-chat profile picker.
+//!
+//! Renders a small modal-style screen listing saved profiles with shortcuts
+//! to add or delete entries. Returns the chosen `Profile` (or `None` if the
+//! user quit). Lives outside the chat UI so it doesn't widen the chat
+//! state machine.
+
+use std::io;
+
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind};
+use desktop_assistant_client_common::TransportMode;
+use futures::StreamExt;
+use ratatui::{
+    Frame, Terminal,
+    backend::CrosstermBackend,
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap},
+};
+use tui_textarea::{CursorMove, TextArea};
+
+use crate::profile::{Profile, ProfileStore};
+
+const COLOR_BORDER: Color = Color::Rgb(82, 104, 173);
+const COLOR_BORDER_ACTIVE: Color = Color::Rgb(120, 183, 109);
+const COLOR_TITLE: Color = Color::Rgb(166, 182, 255);
+const COLOR_HINT_KEY: Color = Color::Rgb(216, 223, 236);
+const COLOR_HINT_DESC: Color = Color::Rgb(143, 153, 174);
+const COLOR_HINT_SEP: Color = Color::Rgb(82, 90, 110);
+const COLOR_LIST_HIGHLIGHT: Color = Color::Rgb(72, 102, 180);
+const COLOR_LIST_HIGHLIGHT_FG: Color = Color::Rgb(245, 248, 255);
+const COLOR_ERROR: Color = Color::Rgb(232, 130, 130);
+
+/// Outcome of running the picker.
+pub enum PickerOutcome {
+    /// User picked or created a profile to connect to.
+    Selected(Profile),
+    /// User pressed quit before selecting anything.
+    Cancelled,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Mode {
+    List,
+    Form,
+    DeleteConfirm,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Field {
+    Name,
+    Transport,
+    Url,
+    Subject,
+}
+
+const FIELD_ORDER: [Field; 4] = [Field::Name, Field::Transport, Field::Url, Field::Subject];
+
+struct PickerState {
+    store: ProfileStore,
+    selected: usize,
+    mode: Mode,
+    error: Option<String>,
+    form: FormState,
+}
+
+struct FormState {
+    /// `Some(id)` when editing an existing profile; `None` for a new one.
+    editing_id: Option<String>,
+    focus: Field,
+    name: TextArea<'static>,
+    url: TextArea<'static>,
+    subject: TextArea<'static>,
+    transport: TransportMode,
+}
+
+impl FormState {
+    fn empty() -> Self {
+        let mut name = single_line_textarea();
+        let mut url = single_line_textarea();
+        url.insert_str("ws://127.0.0.1:11339/ws");
+        url.move_cursor(CursorMove::End);
+        let mut subject = single_line_textarea();
+        subject.insert_str("desktop-tui");
+        subject.move_cursor(CursorMove::End);
+        // Default focus on Name so users can just start typing.
+        name.move_cursor(CursorMove::Head);
+        Self {
+            editing_id: None,
+            focus: Field::Name,
+            name,
+            url,
+            subject,
+            transport: TransportMode::Ws,
+        }
+    }
+
+    fn from_profile(profile: &Profile) -> Self {
+        let mut form = Self::empty();
+        form.editing_id = Some(profile.id.clone());
+        form.name = single_line_textarea();
+        form.name.insert_str(&profile.name);
+        form.name.move_cursor(CursorMove::End);
+        form.url = single_line_textarea();
+        form.url.insert_str(&profile.ws_url);
+        form.url.move_cursor(CursorMove::End);
+        form.subject = single_line_textarea();
+        form.subject.insert_str(&profile.ws_subject);
+        form.subject.move_cursor(CursorMove::End);
+        form.transport = profile.transport;
+        form
+    }
+
+    fn next_field(&mut self) {
+        let pos = FIELD_ORDER.iter().position(|f| *f == self.focus).unwrap_or(0);
+        self.focus = FIELD_ORDER[(pos + 1) % FIELD_ORDER.len()];
+    }
+
+    fn prev_field(&mut self) {
+        let pos = FIELD_ORDER.iter().position(|f| *f == self.focus).unwrap_or(0);
+        self.focus = FIELD_ORDER[(pos + FIELD_ORDER.len() - 1) % FIELD_ORDER.len()];
+    }
+
+    fn submit(&self) -> Result<Profile, String> {
+        let name = self.name.lines().join(" ").trim().to_string();
+        if name.is_empty() {
+            return Err("Name is required".into());
+        }
+        let ws_url = self.url.lines().join(" ").trim().to_string();
+        if matches!(self.transport, TransportMode::Ws) && ws_url.is_empty() {
+            return Err("URL is required for WebSocket transport".into());
+        }
+        let ws_subject = self.subject.lines().join(" ").trim().to_string();
+        let id = self.editing_id.clone().unwrap_or_else(|| {
+            // Sourced from time-since-epoch in profile::new_id; reuse its format.
+            crate::profile::Profile::new(
+                String::new(),
+                TransportMode::Ws,
+                String::new(),
+                String::new(),
+            )
+            .id
+        });
+        Ok(Profile {
+            id,
+            name,
+            transport: self.transport,
+            ws_url,
+            ws_subject,
+        })
+    }
+}
+
+fn single_line_textarea() -> TextArea<'static> {
+    let mut ta = TextArea::default();
+    ta.set_cursor_line_style(Style::default());
+    ta
+}
+
+/// Run the picker until the user selects, creates, or quits.
+pub async fn run(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    store: ProfileStore,
+) -> io::Result<(PickerOutcome, ProfileStore)> {
+    let initial_mode = if store.profiles.is_empty() {
+        Mode::Form
+    } else {
+        Mode::List
+    };
+    let initial_selected = store.last_used_index().unwrap_or(0);
+    let mut state = PickerState {
+        selected: initial_selected,
+        store,
+        mode: initial_mode,
+        error: None,
+        form: FormState::empty(),
+    };
+    if state.selected >= state.store.profiles.len() {
+        state.selected = state.store.profiles.len().saturating_sub(1);
+    }
+
+    let mut events = crossterm::event::EventStream::new();
+    loop {
+        terminal.draw(|f| draw(f, &state))?;
+
+        let evt = match events.next().await {
+            Some(Ok(e)) => e,
+            Some(Err(_)) | None => return Ok((PickerOutcome::Cancelled, state.store)),
+        };
+        let Event::Key(key) = evt else { continue };
+        if key.kind == KeyEventKind::Release {
+            continue;
+        }
+
+        match state.mode {
+            Mode::List => {
+                if let Some(outcome) = handle_list_key(&mut state, key) {
+                    return Ok((outcome, state.store));
+                }
+            }
+            Mode::Form => handle_form_key(&mut state, key),
+            Mode::DeleteConfirm => handle_delete_key(&mut state, key),
+        }
+    }
+}
+
+fn handle_list_key(state: &mut PickerState, key: KeyEvent) -> Option<PickerOutcome> {
+    match (key.code, key.modifiers) {
+        (KeyCode::Char('q'), m) if m.is_empty() => Some(PickerOutcome::Cancelled),
+        (KeyCode::Esc, _) => Some(PickerOutcome::Cancelled),
+        (KeyCode::Char('j') | KeyCode::Down, m) if m.is_empty() => {
+            advance_selection(state, 1);
+            None
+        }
+        (KeyCode::Char('k') | KeyCode::Up, m) if m.is_empty() => {
+            advance_selection(state, -1);
+            None
+        }
+        (KeyCode::Enter, m) if m.is_empty() => {
+            if let Some(profile) = state.store.profiles.get(state.selected).cloned() {
+                state.store.mark_used(&profile.id);
+                let _ = state.store.save();
+                Some(PickerOutcome::Selected(profile))
+            } else {
+                None
+            }
+        }
+        (KeyCode::Char('a') | KeyCode::Char('+'), m) if m.is_empty() => {
+            state.form = FormState::empty();
+            state.error = None;
+            state.mode = Mode::Form;
+            None
+        }
+        (KeyCode::Char('e'), m) if m.is_empty() => {
+            if let Some(profile) = state.store.profiles.get(state.selected) {
+                state.form = FormState::from_profile(profile);
+                state.error = None;
+                state.mode = Mode::Form;
+            }
+            None
+        }
+        (KeyCode::Char('d'), m) if m.is_empty() => {
+            if state.store.profiles.get(state.selected).is_some() {
+                state.mode = Mode::DeleteConfirm;
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+fn advance_selection(state: &mut PickerState, delta: i32) {
+    let len = state.store.profiles.len();
+    if len == 0 {
+        return;
+    }
+    let mut idx = state.selected as i32 + delta;
+    if idx < 0 {
+        idx = (len as i32) - 1;
+    }
+    if idx >= len as i32 {
+        idx = 0;
+    }
+    state.selected = idx as usize;
+}
+
+fn handle_form_key(state: &mut PickerState, key: KeyEvent) {
+    match (key.code, key.modifiers) {
+        (KeyCode::Esc, _) => {
+            state.error = None;
+            state.mode = if state.store.profiles.is_empty() {
+                // No way back to a list — Esc with nothing to go to means
+                // exit the picker entirely; we surface that on the next
+                // iteration via the outer loop. Simpler: treat as a noop
+                // so the user stays in the form. Add a dedicated quit hint.
+                Mode::Form
+            } else {
+                Mode::List
+            };
+            // Clear form on cancel of edit so a re-entry starts fresh.
+            state.form = FormState::empty();
+        }
+        (KeyCode::Tab, _) => state.form.next_field(),
+        (KeyCode::BackTab, _) => state.form.prev_field(),
+        (KeyCode::Up, m) if m.is_empty() => state.form.prev_field(),
+        (KeyCode::Down, m) if m.is_empty() => state.form.next_field(),
+        (KeyCode::Enter, m) if m.is_empty() => {
+            match state.form.submit() {
+                Ok(profile) => {
+                    let editing = state.form.editing_id.is_some();
+                    if editing {
+                        // Replace existing profile in place.
+                        if let Some(existing) = state
+                            .store
+                            .profiles
+                            .iter_mut()
+                            .find(|p| p.id == profile.id)
+                        {
+                            *existing = profile.clone();
+                        }
+                    } else {
+                        state.store.add(profile.clone());
+                    }
+                    if let Err(e) = state.store.save() {
+                        state.error = Some(format!("Save failed: {e}"));
+                        return;
+                    }
+                    // Reselect to the saved profile.
+                    let new_index = state
+                        .store
+                        .profiles
+                        .iter()
+                        .position(|p| p.id == profile.id)
+                        .unwrap_or(state.selected);
+                    state.selected = new_index;
+                    state.error = None;
+                    state.mode = Mode::List;
+                    state.form = FormState::empty();
+                }
+                Err(msg) => state.error = Some(msg),
+            }
+        }
+        // Transport field uses left/right or space to flip the toggle.
+        (KeyCode::Left | KeyCode::Right | KeyCode::Char(' '), _)
+            if state.form.focus == Field::Transport =>
+        {
+            state.form.transport = match state.form.transport {
+                TransportMode::Ws => TransportMode::Dbus,
+                TransportMode::Dbus => TransportMode::Ws,
+            };
+        }
+        _ => match state.form.focus {
+            Field::Name => {
+                state.form.name.input(key);
+            }
+            Field::Url => {
+                state.form.url.input(key);
+            }
+            Field::Subject => {
+                state.form.subject.input(key);
+            }
+            Field::Transport => {}
+        },
+    }
+}
+
+fn handle_delete_key(state: &mut PickerState, key: KeyEvent) {
+    match (key.code, key.modifiers) {
+        (KeyCode::Char('y') | KeyCode::Char('Y') | KeyCode::Enter, _) => {
+            if let Some(profile) = state.store.profiles.get(state.selected).cloned() {
+                state.store.remove(&profile.id);
+                let _ = state.store.save();
+                if state.selected >= state.store.profiles.len() {
+                    state.selected = state.store.profiles.len().saturating_sub(1);
+                }
+            }
+            state.mode = if state.store.profiles.is_empty() {
+                Mode::Form
+            } else {
+                Mode::List
+            };
+            if matches!(state.mode, Mode::Form) {
+                state.form = FormState::empty();
+            }
+        }
+        _ => state.mode = Mode::List,
+    }
+}
+
+fn draw(f: &mut Frame, state: &PickerState) {
+    let area = f.area();
+    f.render_widget(Clear, area);
+
+    let layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(5),
+            Constraint::Length(1),
+            Constraint::Length(1),
+        ])
+        .split(area);
+
+    draw_header(f, layout[0]);
+    match state.mode {
+        Mode::List => draw_list(f, state, layout[1]),
+        Mode::Form => draw_form(f, state, layout[1]),
+        Mode::DeleteConfirm => {
+            draw_list(f, state, layout[1]);
+            draw_delete_overlay(f, state, area);
+        }
+    }
+    draw_error(f, state, layout[2]);
+    draw_hints(f, state, layout[3]);
+
+    if matches!(state.mode, Mode::Form) {
+        // Keep cursor blinking in the focused text field.
+        position_cursor_in_form(f, state, layout[1]);
+    }
+}
+
+fn draw_header(f: &mut Frame, area: Rect) {
+    let title = Paragraph::new(vec![
+        Line::from(Span::styled(
+            "Adele connection profiles",
+            Style::default()
+                .fg(COLOR_TITLE)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(Span::styled(
+            "Pick a daemon to connect to, or create a new profile.",
+            Style::default().fg(COLOR_HINT_DESC),
+        )),
+    ]);
+    f.render_widget(title, area);
+}
+
+fn draw_list(f: &mut Frame, state: &PickerState, area: Rect) {
+    let items: Vec<ListItem> = if state.store.profiles.is_empty() {
+        vec![ListItem::new(Line::from(Span::styled(
+            "(no saved profiles — press 'a' to add one)",
+            Style::default().fg(COLOR_HINT_DESC),
+        )))]
+    } else {
+        state
+            .store
+            .profiles
+            .iter()
+            .enumerate()
+            .map(|(idx, p)| {
+                let mut spans: Vec<Span<'static>> = Vec::new();
+                if state.store.last_used_index() == Some(idx) {
+                    spans.push(Span::styled(
+                        "★ ",
+                        Style::default().fg(Color::Rgb(255, 207, 119)),
+                    ));
+                }
+                spans.push(Span::styled(p.display_label(), Style::default()));
+                ListItem::new(Line::from(spans))
+            })
+            .collect()
+    };
+
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(COLOR_BORDER))
+                .title(Line::from(Span::styled(
+                    "Profiles",
+                    Style::default()
+                        .fg(COLOR_TITLE)
+                        .add_modifier(Modifier::BOLD),
+                ))),
+        )
+        .highlight_style(
+            Style::default()
+                .bg(COLOR_LIST_HIGHLIGHT)
+                .fg(COLOR_LIST_HIGHLIGHT_FG)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("▸ ");
+
+    let mut list_state = ListState::default();
+    if !state.store.profiles.is_empty() {
+        list_state.select(Some(state.selected));
+    }
+    f.render_stateful_widget(list, area, &mut list_state);
+}
+
+fn draw_form(f: &mut Frame, state: &PickerState, area: Rect) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(COLOR_BORDER))
+        .title(Line::from(Span::styled(
+            if state.form.editing_id.is_some() {
+                "Edit profile"
+            } else {
+                "New profile"
+            },
+            Style::default()
+                .fg(COLOR_TITLE)
+                .add_modifier(Modifier::BOLD),
+        )));
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Length(3),
+            Constraint::Length(1),
+            Constraint::Length(3),
+            Constraint::Length(1),
+            Constraint::Length(3),
+            Constraint::Length(1),
+            Constraint::Length(3),
+            Constraint::Min(0),
+        ])
+        .split(inner);
+
+    draw_field_label(f, rows[0], "Name", state.form.focus == Field::Name);
+    draw_text_field(f, rows[1], &state.form.name, state.form.focus == Field::Name);
+
+    draw_field_label(
+        f,
+        rows[2],
+        "Transport (←/→ or Space to toggle)",
+        state.form.focus == Field::Transport,
+    );
+    draw_transport_toggle(f, rows[3], state);
+
+    draw_field_label(f, rows[4], "URL", state.form.focus == Field::Url);
+    draw_text_field(f, rows[5], &state.form.url, state.form.focus == Field::Url);
+
+    draw_field_label(
+        f,
+        rows[6],
+        "JWT subject",
+        state.form.focus == Field::Subject,
+    );
+    draw_text_field(
+        f,
+        rows[7],
+        &state.form.subject,
+        state.form.focus == Field::Subject,
+    );
+}
+
+fn draw_field_label(f: &mut Frame, area: Rect, label: &str, focused: bool) {
+    let style = if focused {
+        Style::default()
+            .fg(COLOR_BORDER_ACTIVE)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(COLOR_HINT_DESC)
+    };
+    f.render_widget(Paragraph::new(Span::styled(label.to_string(), style)), area);
+}
+
+fn draw_text_field(f: &mut Frame, area: Rect, textarea: &TextArea<'static>, focused: bool) {
+    let mut ta = textarea.clone();
+    let border_color = if focused {
+        COLOR_BORDER_ACTIVE
+    } else {
+        COLOR_BORDER
+    };
+    ta.set_block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(border_color)),
+    );
+    f.render_widget(&ta, area);
+}
+
+fn draw_transport_toggle(f: &mut Frame, area: Rect, state: &PickerState) {
+    let focused = state.form.focus == Field::Transport;
+    let border_color = if focused {
+        COLOR_BORDER_ACTIVE
+    } else {
+        COLOR_BORDER
+    };
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(border_color));
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    let render_chip = |label: &str, selected: bool| {
+        let style = if selected {
+            Style::default()
+                .fg(Color::Black)
+                .bg(COLOR_BORDER_ACTIVE)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(COLOR_HINT_DESC)
+        };
+        Span::styled(format!(" {label} "), style)
+    };
+
+    let line = Line::from(vec![
+        render_chip("WebSocket", state.form.transport == TransportMode::Ws),
+        Span::styled("  ", Style::default()),
+        render_chip("D-Bus", state.form.transport == TransportMode::Dbus),
+    ]);
+    f.render_widget(Paragraph::new(line), inner);
+}
+
+fn draw_delete_overlay(f: &mut Frame, state: &PickerState, area: Rect) {
+    let label = state
+        .store
+        .profiles
+        .get(state.selected)
+        .map(|p| p.name.clone())
+        .unwrap_or_else(|| "this profile".to_string());
+    let popup_width = 60.min(area.width.saturating_sub(4));
+    let popup_height = 5.min(area.height.saturating_sub(2));
+    let popup = Rect {
+        x: area.x + (area.width.saturating_sub(popup_width)) / 2,
+        y: area.y + (area.height.saturating_sub(popup_height)) / 2,
+        width: popup_width,
+        height: popup_height,
+    };
+    f.render_widget(Clear, popup);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Rgb(232, 130, 130)))
+        .title(Line::from(Span::styled(
+            "Delete profile",
+            Style::default()
+                .fg(Color::Rgb(255, 200, 200))
+                .add_modifier(Modifier::BOLD),
+        )));
+    let inner = block.inner(popup);
+    f.render_widget(block, popup);
+    let body = Paragraph::new(vec![
+        Line::from(Span::styled(
+            format!("Delete \"{label}\"?"),
+            Style::default().fg(Color::White),
+        )),
+        Line::from(Span::styled(
+            "y/Enter = confirm · any other key = cancel",
+            Style::default().fg(COLOR_HINT_DESC),
+        )),
+    ])
+    .wrap(Wrap { trim: true });
+    f.render_widget(body, inner);
+}
+
+fn draw_error(f: &mut Frame, state: &PickerState, area: Rect) {
+    if let Some(err) = &state.error {
+        let style = Style::default().fg(COLOR_ERROR);
+        f.render_widget(
+            Paragraph::new(Span::styled(format!(" • {err}"), style)),
+            area,
+        );
+    }
+}
+
+fn draw_hints(f: &mut Frame, state: &PickerState, area: Rect) {
+    let hints: &[(&str, &str)] = match state.mode {
+        Mode::List => &[
+            ("Enter", "connect"),
+            ("a", "add"),
+            ("e", "edit"),
+            ("d", "delete"),
+            ("q/Esc", "quit"),
+        ],
+        Mode::Form => &[
+            ("Tab", "next field"),
+            ("Enter", "save"),
+            ("Esc", "back"),
+        ],
+        Mode::DeleteConfirm => &[("y/Enter", "confirm"), ("any", "cancel")],
+    };
+
+    let mut spans: Vec<Span> = Vec::with_capacity(hints.len() * 4);
+    for (idx, (key, desc)) in hints.iter().enumerate() {
+        if idx > 0 {
+            spans.push(Span::styled("  ·  ", Style::default().fg(COLOR_HINT_SEP)));
+        }
+        spans.push(Span::styled(
+            (*key).to_string(),
+            Style::default()
+                .fg(COLOR_HINT_KEY)
+                .add_modifier(Modifier::BOLD),
+        ));
+        spans.push(Span::raw(" "));
+        spans.push(Span::styled(
+            (*desc).to_string(),
+            Style::default().fg(COLOR_HINT_DESC),
+        ));
+    }
+    f.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+
+fn position_cursor_in_form(f: &mut Frame, state: &PickerState, area: Rect) {
+    // Re-derive the inner box of the focused field's text area. The form
+    // layout is mirrored from `draw_form`; we use the same constraints.
+    let inner = Block::default().borders(Borders::ALL).inner(area);
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Length(3),
+            Constraint::Length(1),
+            Constraint::Length(3),
+            Constraint::Length(1),
+            Constraint::Length(3),
+            Constraint::Length(1),
+            Constraint::Length(3),
+            Constraint::Min(0),
+        ])
+        .split(inner);
+
+    let (textarea, row_idx) = match state.form.focus {
+        Field::Name => (&state.form.name, 1),
+        Field::Url => (&state.form.url, 5),
+        Field::Subject => (&state.form.subject, 7),
+        Field::Transport => return,
+    };
+
+    let row = rows[row_idx];
+    let inner_row = Block::default().borders(Borders::ALL).inner(row);
+    let (cursor_row, cursor_col) = textarea.cursor();
+    let x = inner_row.x + cursor_col.min(inner_row.width.saturating_sub(1) as usize) as u16;
+    let y = inner_row.y + cursor_row.min(inner_row.height.saturating_sub(1) as usize) as u16;
+    f.set_cursor_position((x, y));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::{KeyEventKind, KeyEventState, KeyModifiers};
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent {
+            code,
+            modifiers: KeyModifiers::NONE,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::NONE,
+        }
+    }
+
+    fn make_state(profiles: Vec<Profile>) -> PickerState {
+        let mut store = ProfileStore::default();
+        for p in profiles {
+            store.add(p);
+        }
+        PickerState {
+            selected: 0,
+            store,
+            mode: Mode::List,
+            error: None,
+            form: FormState::empty(),
+        }
+    }
+
+    #[test]
+    fn list_q_returns_cancelled() {
+        let mut state = make_state(vec![]);
+        let outcome = handle_list_key(&mut state, key(KeyCode::Char('q')));
+        assert!(matches!(outcome, Some(PickerOutcome::Cancelled)));
+    }
+
+    #[test]
+    fn list_enter_returns_selected_profile() {
+        let p = Profile::new("Local".into(), TransportMode::Ws, "ws://x".into(), "s".into());
+        let id = p.id.clone();
+        let mut state = make_state(vec![p]);
+        let outcome = handle_list_key(&mut state, key(KeyCode::Enter));
+        match outcome {
+            Some(PickerOutcome::Selected(picked)) => assert_eq!(picked.id, id),
+            _ => panic!("expected Selected outcome"),
+        }
+    }
+
+    #[test]
+    fn list_a_enters_form_mode() {
+        let mut state = make_state(vec![]);
+        handle_list_key(&mut state, key(KeyCode::Char('a')));
+        assert_eq!(state.mode, Mode::Form);
+        assert!(state.form.editing_id.is_none());
+    }
+
+    #[test]
+    fn form_tab_cycles_focus() {
+        let mut state = make_state(vec![]);
+        state.mode = Mode::Form;
+        assert_eq!(state.form.focus, Field::Name);
+        handle_form_key(&mut state, key(KeyCode::Tab));
+        assert_eq!(state.form.focus, Field::Transport);
+        handle_form_key(&mut state, key(KeyCode::Tab));
+        assert_eq!(state.form.focus, Field::Url);
+    }
+
+    #[test]
+    fn form_transport_toggles_with_arrow() {
+        let mut state = make_state(vec![]);
+        state.mode = Mode::Form;
+        state.form.focus = Field::Transport;
+        assert_eq!(state.form.transport, TransportMode::Ws);
+        handle_form_key(&mut state, key(KeyCode::Right));
+        assert_eq!(state.form.transport, TransportMode::Dbus);
+        handle_form_key(&mut state, key(KeyCode::Left));
+        assert_eq!(state.form.transport, TransportMode::Ws);
+    }
+
+    #[test]
+    fn form_submit_with_blank_name_records_error() {
+        let mut state = make_state(vec![]);
+        state.mode = Mode::Form;
+        // Name is empty by default.
+        handle_form_key(&mut state, key(KeyCode::Enter));
+        assert!(state.error.is_some());
+        assert_eq!(state.mode, Mode::Form);
+    }
+
+    #[test]
+    fn delete_confirm_y_removes_profile() {
+        let p = Profile::new("Local".into(), TransportMode::Ws, "ws://x".into(), "s".into());
+        let mut state = make_state(vec![p]);
+        state.mode = Mode::DeleteConfirm;
+        handle_delete_key(&mut state, key(KeyCode::Char('y')));
+        assert!(state.store.profiles.is_empty());
+        // Falls back to Form when nothing left.
+        assert_eq!(state.mode, Mode::Form);
+    }
+
+    #[test]
+    fn delete_confirm_other_key_cancels() {
+        let p = Profile::new("Local".into(), TransportMode::Ws, "ws://x".into(), "s".into());
+        let mut state = make_state(vec![p]);
+        state.mode = Mode::DeleteConfirm;
+        handle_delete_key(&mut state, key(KeyCode::Char('n')));
+        assert_eq!(state.store.profiles.len(), 1);
+        assert_eq!(state.mode, Mode::List);
+    }
+}

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -1,8 +1,10 @@
 //! Saved connection profiles.
 //!
 //! A profile bundles the transport metadata needed to dial a specific
-//! daemon. Credentials are intentionally **not** stored here — those land
-//! in the keyring in #13.
+//! daemon. Credentials live in the system keyring (see
+//! [`crate::credentials`]); the profile only carries non-secret hints
+//! (username, "has a stored password" flags) so the UI can show what
+//! state to expect.
 //!
 //! Persisted to `$XDG_CONFIG_HOME/adele-tui/profiles.json` (or
 //! `~/.config/adele-tui/profiles.json`).
@@ -11,6 +13,8 @@ use std::{env, fs, io, path::PathBuf, time::SystemTime};
 
 use desktop_assistant_client_common::{ConnectionConfig, TransportMode};
 use serde::{Deserialize, Serialize};
+
+use crate::credentials::{self, CredentialKind};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Profile {
@@ -24,6 +28,18 @@ pub struct Profile {
     /// JWT subject claim. Only meaningful when `transport == Ws`.
     #[serde(default)]
     pub ws_subject: String,
+    /// Username for password-based login. `None` means no username/password
+    /// auth — fall back to JWT or anonymous.
+    #[serde(default)]
+    pub username: Option<String>,
+    /// True when a password has been stored in the keyring under this
+    /// profile's id. The actual secret never leaves the keyring.
+    #[serde(default)]
+    pub has_password: bool,
+    /// True when a JWT token has been stored in the keyring under this
+    /// profile's id.
+    #[serde(default)]
+    pub has_jwt: bool,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -42,19 +58,42 @@ impl Profile {
             transport,
             ws_url,
             ws_subject,
+            username: None,
+            has_password: false,
+            has_jwt: false,
         }
     }
 
+    /// Build a connection config, pulling stored credentials from the keyring.
+    /// Keyring failures are silently downgraded to "no credential" — callers
+    /// should still allow CLI/env fallback.
     pub fn to_connection_config(&self) -> ConnectionConfig {
+        let password = if self.has_password {
+            credentials::retrieve(&self.id, CredentialKind::Password).ok()
+        } else {
+            None
+        };
+        let jwt = if self.has_jwt {
+            credentials::retrieve(&self.id, CredentialKind::Jwt).ok()
+        } else {
+            None
+        };
         ConnectionConfig {
             transport_mode: self.transport,
             ws_url: self.ws_url.clone(),
             ws_subject: self.ws_subject.clone(),
-            ws_jwt: None,
-            ws_login_username: None,
-            ws_login_password: None,
+            ws_jwt: jwt,
+            ws_login_username: self.username.clone(),
+            ws_login_password: password,
             ..Default::default()
         }
+    }
+
+    /// Drop any keyring entries associated with this profile. Errors are
+    /// swallowed — there's nothing useful for a caller to do with them.
+    pub fn purge_credentials(&self) {
+        let _ = credentials::delete(&self.id, CredentialKind::Password);
+        let _ = credentials::delete(&self.id, CredentialKind::Jwt);
     }
 
     /// Short display label combining name and URL/transport.
@@ -104,6 +143,9 @@ impl ProfileStore {
         if self.last_used.as_deref() == Some(id) {
             self.last_used = None;
         }
+        // Drop the keyring entries — leaving orphaned secrets after a
+        // delete is a footgun, especially when re-adding under a new id.
+        removed.purge_credentials();
         Some(removed)
     }
 

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -1,0 +1,247 @@
+//! Saved connection profiles.
+//!
+//! A profile bundles the transport metadata needed to dial a specific
+//! daemon. Credentials are intentionally **not** stored here — those land
+//! in the keyring in #13.
+//!
+//! Persisted to `$XDG_CONFIG_HOME/adele-tui/profiles.json` (or
+//! `~/.config/adele-tui/profiles.json`).
+
+use std::{env, fs, io, path::PathBuf, time::SystemTime};
+
+use desktop_assistant_client_common::{ConnectionConfig, TransportMode};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Profile {
+    pub id: String,
+    pub name: String,
+    #[serde(with = "transport_mode_serde")]
+    pub transport: TransportMode,
+    /// WebSocket URL. Only meaningful when `transport == Ws`.
+    #[serde(default)]
+    pub ws_url: String,
+    /// JWT subject claim. Only meaningful when `transport == Ws`.
+    #[serde(default)]
+    pub ws_subject: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProfileStore {
+    #[serde(default)]
+    pub profiles: Vec<Profile>,
+    #[serde(default)]
+    pub last_used: Option<String>,
+}
+
+impl Profile {
+    pub fn new(name: String, transport: TransportMode, ws_url: String, ws_subject: String) -> Self {
+        Self {
+            id: new_id(),
+            name,
+            transport,
+            ws_url,
+            ws_subject,
+        }
+    }
+
+    pub fn to_connection_config(&self) -> ConnectionConfig {
+        ConnectionConfig {
+            transport_mode: self.transport,
+            ws_url: self.ws_url.clone(),
+            ws_subject: self.ws_subject.clone(),
+            ws_jwt: None,
+            ws_login_username: None,
+            ws_login_password: None,
+            ..Default::default()
+        }
+    }
+
+    /// Short display label combining name and URL/transport.
+    pub fn display_label(&self) -> String {
+        let detail = match self.transport {
+            TransportMode::Ws => self.ws_url.clone(),
+            TransportMode::Dbus => "D-Bus".to_string(),
+        };
+        if detail.is_empty() {
+            self.name.clone()
+        } else {
+            format!("{}  ·  {}", self.name, detail)
+        }
+    }
+}
+
+impl ProfileStore {
+    pub fn load() -> Self {
+        let Some(path) = profiles_path() else {
+            return Self::default();
+        };
+        let Ok(bytes) = fs::read(&path) else {
+            return Self::default();
+        };
+        serde_json::from_slice(&bytes).unwrap_or_default()
+    }
+
+    pub fn save(&self) -> io::Result<()> {
+        let Some(path) = profiles_path() else {
+            return Err(io::Error::other("could not resolve profiles path"));
+        };
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let bytes = serde_json::to_vec_pretty(self)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        fs::write(path, bytes)
+    }
+
+    pub fn add(&mut self, profile: Profile) {
+        self.profiles.push(profile);
+    }
+
+    pub fn remove(&mut self, id: &str) -> Option<Profile> {
+        let idx = self.profiles.iter().position(|p| p.id == id)?;
+        let removed = self.profiles.remove(idx);
+        if self.last_used.as_deref() == Some(id) {
+            self.last_used = None;
+        }
+        Some(removed)
+    }
+
+    pub fn mark_used(&mut self, id: &str) {
+        if self.profiles.iter().any(|p| p.id == id) {
+            self.last_used = Some(id.to_string());
+        }
+    }
+
+    pub fn last_used_index(&self) -> Option<usize> {
+        let id = self.last_used.as_deref()?;
+        self.profiles.iter().position(|p| p.id == id)
+    }
+}
+
+fn profiles_path() -> Option<PathBuf> {
+    let base = if let Ok(xdg) = env::var("XDG_CONFIG_HOME")
+        && !xdg.is_empty()
+    {
+        PathBuf::from(xdg)
+    } else {
+        let home = env::var("HOME").ok()?;
+        PathBuf::from(home).join(".config")
+    };
+    Some(base.join("adele-tui").join("profiles.json"))
+}
+
+fn new_id() -> String {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_nanos().to_string())
+        .unwrap_or_else(|_| "0".to_string())
+}
+
+mod transport_mode_serde {
+    use super::TransportMode;
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(value: &TransportMode, s: S) -> Result<S::Ok, S::Error> {
+        let token = match value {
+            TransportMode::Ws => "ws",
+            TransportMode::Dbus => "dbus",
+        };
+        s.serialize_str(token)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<TransportMode, D::Error> {
+        let token = String::deserialize(d)?;
+        match token.as_str() {
+            "ws" => Ok(TransportMode::Ws),
+            "dbus" => Ok(TransportMode::Dbus),
+            other => Err(serde::de::Error::custom(format!(
+                "unknown transport mode {other:?}"
+            ))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_serializes_transport_as_token() {
+        let profile = Profile::new(
+            "Local".into(),
+            TransportMode::Ws,
+            "ws://127.0.0.1:11339/ws".into(),
+            "desktop-tui".into(),
+        );
+        let json = serde_json::to_string(&profile).unwrap();
+        assert!(json.contains("\"transport\":\"ws\""));
+        let back: Profile = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, profile);
+    }
+
+    #[test]
+    fn unknown_transport_token_fails_loud() {
+        let json = r#"{"id":"1","name":"X","transport":"smtp","ws_url":"","ws_subject":""}"#;
+        assert!(serde_json::from_str::<Profile>(json).is_err());
+    }
+
+    #[test]
+    fn store_remove_clears_last_used_when_matches() {
+        let mut store = ProfileStore::default();
+        let p = Profile::new("a".into(), TransportMode::Ws, "ws://x".into(), "s".into());
+        let id = p.id.clone();
+        store.add(p);
+        store.mark_used(&id);
+        assert_eq!(store.last_used.as_deref(), Some(id.as_str()));
+        store.remove(&id);
+        assert!(store.last_used.is_none());
+    }
+
+    #[test]
+    fn store_mark_used_ignores_unknown_id() {
+        let mut store = ProfileStore::default();
+        store.mark_used("does-not-exist");
+        assert!(store.last_used.is_none());
+    }
+
+    #[test]
+    fn last_used_index_finds_correct_position() {
+        let mut store = ProfileStore::default();
+        let a = Profile::new("a".into(), TransportMode::Ws, "ws://a".into(), "s".into());
+        let b = Profile::new("b".into(), TransportMode::Ws, "ws://b".into(), "s".into());
+        let b_id = b.id.clone();
+        store.add(a);
+        store.add(b);
+        store.mark_used(&b_id);
+        assert_eq!(store.last_used_index(), Some(1));
+    }
+
+    #[test]
+    fn unknown_fields_in_json_are_ignored() {
+        let json = r#"{
+            "profiles": [{"id":"1","name":"X","transport":"ws","ws_url":"ws://x","ws_subject":"s","extra_field":42}],
+            "last_used": null,
+            "another_unknown": "ok"
+        }"#;
+        let store: ProfileStore = serde_json::from_str(json).unwrap();
+        assert_eq!(store.profiles.len(), 1);
+        assert_eq!(store.profiles[0].name, "X");
+    }
+
+    #[test]
+    fn to_connection_config_strips_credentials() {
+        let p = Profile::new(
+            "Local".into(),
+            TransportMode::Ws,
+            "ws://127.0.0.1:11339/ws".into(),
+            "desktop-tui".into(),
+        );
+        let cfg = p.to_connection_config();
+        assert_eq!(cfg.transport_mode, TransportMode::Ws);
+        assert_eq!(cfg.ws_url, "ws://127.0.0.1:11339/ws");
+        assert!(cfg.ws_jwt.is_none());
+        assert!(cfg.ws_login_username.is_none());
+        assert!(cfg.ws_login_password.is_none());
+    }
+}


### PR DESCRIPTION
## Summary

- New `src/credentials.rs` thin wrapper around `keyring` 3.x (matches adele-gtk).
- Entries scoped per-profile: `service="adele-tui"`, `account="{kind}::{profile_id}"` (kind ∈ password/jwt).
- `Profile` struct gains `username: Option<String>`, `has_password: bool`, `has_jwt: bool`. The secrets never enter the JSON store.
- `Profile::to_connection_config()` now reads the keyring on demand. `Profile::purge_credentials()` runs on delete so secrets don't outlive their profile.

## Form UX

- Two new fields: Username (plaintext) and Password (masked via `tui-textarea::set_mask_char('•')`).
- Empty password on edit → preserve stored secret. Non-empty → replace. Clearing on a profile that previously had one → wipe the keyring entry.
- Label tells you when a stored secret is present: `Password (•••• stored — leave blank to keep)`.

## Headless fallback

Set `ADELE_TUI_DISABLE_KEYRING=1` to short-circuit all keyring calls — useful for CI or environments without `dbus`. Stores return `Err`, retrievals return `Err`, deletes are no-ops.

## Stacked on #12

Branched from `feat/connection-profiles`. Re-base to `main` once #12 lands.

## Out of scope

- JWT storage is wired (`has_jwt`, `CredentialKind::Jwt`) but unused at the form level — #14 OAuth2+PKCE will populate it via the auth flow.
- Switch-connection without restart is #15.

## Test plan

- [x] `cargo test` — 94 passing (+4 new in `credentials.rs`)
- [x] `cargo build` clean
- [ ] Manual: add profile with username/password → daemon login works on connect
- [ ] Manual: edit profile, leave password blank → existing secret preserved
- [ ] Manual: edit profile, clear password → keyring entry removed
- [ ] Manual: delete profile → no orphaned keyring entries (check `secret-tool`)
- [ ] Manual: `ADELE_TUI_DISABLE_KEYRING=1 adele` on a system with dbus → no keyring access, profiles still load (creds just absent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)