### PR TITLE
OAuth2 + PKCE authentication flow (closes #14)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,13 +12,17 @@ dependencies = [
  "desktop-assistant-client-common",
  "futures",
  "keyring",
+ "oauth2",
+ "open",
  "ratatui",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tokio",
  "tracing",
  "tracing-subscriber",
  "tui-textarea",
+ "url",
 ]
 
 [[package]]
@@ -46,6 +50,15 @@ name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "anstream"
@@ -364,6 +377,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,7 +650,7 @@ dependencies = [
  "async-trait",
  "desktop-assistant-api-model",
  "futures",
- "reqwest",
+ "reqwest 0.13.2",
  "rustls",
  "rustls-pemfile",
  "serde_json",
@@ -1076,6 +1103,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -1101,6 +1129,30 @@ dependencies = [
  "tower-service",
  "tracing",
  "windows-registry",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1276,6 +1328,25 @@ checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
 ]
 
 [[package]]
@@ -1590,6 +1661,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "oauth2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
+dependencies = [
+ "base64",
+ "chrono",
+ "getrandom 0.2.17",
+ "http",
+ "rand 0.8.6",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1600,6 +1691,17 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "open"
+version = "5.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f3bab717c29a857abf75fcef718d441ec7cb2725f937343c734740a985d37fd"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
 
 [[package]]
 name = "openssl-probe"
@@ -1651,6 +1753,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"
@@ -1926,6 +2034,44 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
@@ -2019,6 +2165,7 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -2223,6 +2370,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2231,6 +2389,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -2821,6 +2991,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -3068,6 +3239,41 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "windows-link"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,7 @@ dependencies = [
  "desktop-assistant-client-common",
  "futures",
  "ratatui",
+ "serde",
  "serde_json",
  "tokio",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11,6 +11,7 @@ dependencies = [
  "crossterm",
  "desktop-assistant-client-common",
  "futures",
+ "keyring",
  "ratatui",
  "serde",
  "serde_json",
@@ -18,6 +19,17 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tui-textarea",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -104,6 +116,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.1.4",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix 1.1.4",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,6 +184,30 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.4",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -181,6 +276,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -205,6 +322,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "cbc"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -236,6 +362,16 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
 
 [[package]]
 name = "clap"
@@ -443,6 +579,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "dbus"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "aes",
+ "block-padding",
+ "cbc",
+ "dbus",
+ "fastrand",
+ "hkdf",
+ "num",
+ "once_cell",
+ "sha2",
+ "zeroize",
+]
+
+[[package]]
 name = "desktop-assistant-api-model"
 version = "0.1.0"
 dependencies = [
@@ -466,7 +631,7 @@ dependencies = [
  "tokio-tungstenite",
  "tracing",
  "uuid",
- "zbus",
+ "zbus 5.14.0",
 ]
 
 [[package]]
@@ -477,6 +642,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -808,10 +974,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -1050,6 +1240,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "block-padding",
+ "generic-array",
+]
+
+[[package]]
 name = "instability"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1166,6 +1366,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "dbus-secret-service",
+ "log",
+ "secret-service",
+ "zeroize",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1182,6 +1394,15 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1274,12 +1495,98 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1358,6 +1665,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1433,7 +1771,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1482,12 +1820,33 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1497,7 +1856,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1764,6 +2132,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "secret-service"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4d35ad99a181be0a60ffcbe85d680d98f87bdc4d7644ade319b87076b9dbfd4"
+dependencies = [
+ "aes",
+ "cbc",
+ "futures-util",
+ "generic-array",
+ "hkdf",
+ "num",
+ "once_cell",
+ "rand 0.8.6",
+ "serde",
+ "sha2",
+ "zbus 4.4.0",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1851,6 +2238,17 @@ name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2342,7 +2740,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand",
+ "rand 0.9.4",
  "rustls",
  "rustls-pki-types",
  "sha1",
@@ -3056,6 +3454,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "xdg-home"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3076,6 +3484,38 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zbus"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
+dependencies = [
+ "async-broadcast",
+ "async-process",
+ "async-recursion",
+ "async-trait",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix",
+ "ordered-stream",
+ "rand 0.8.6",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.52.0",
+ "xdg-home",
+ "zbus_macros 4.4.0",
+ "zbus_names 3.0.0",
+ "zvariant 4.2.0",
 ]
 
 [[package]]
@@ -3103,9 +3543,22 @@ dependencies = [
  "uuid",
  "windows-sys 0.61.2",
  "winnow 0.7.15",
- "zbus_macros",
- "zbus_names",
- "zvariant",
+ "zbus_macros 5.14.0",
+ "zbus_names 4.3.1",
+ "zvariant 5.10.0",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zvariant_utils 2.1.0",
 ]
 
 [[package]]
@@ -3118,9 +3571,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "zbus_names",
- "zvariant",
- "zvariant_utils",
+ "zbus_names 4.3.1",
+ "zvariant 5.10.0",
+ "zvariant_utils 3.3.0",
+]
+
+[[package]]
+name = "zbus_names"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant 4.2.0",
 ]
 
 [[package]]
@@ -3131,7 +3595,7 @@ checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
 dependencies = [
  "serde",
  "winnow 0.7.15",
- "zvariant",
+ "zvariant 5.10.0",
 ]
 
 [[package]]
@@ -3180,6 +3644,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"
@@ -3222,6 +3700,19 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zvariant"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zvariant_derive 4.2.0",
+]
+
+[[package]]
+name = "zvariant"
 version = "5.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5708299b21903bbe348e94729f22c49c55d04720a004aa350f1f9c122fd2540b"
@@ -3230,8 +3721,21 @@ dependencies = [
  "enumflags2",
  "serde",
  "winnow 0.7.15",
- "zvariant_derive",
- "zvariant_utils",
+ "zvariant_derive 5.10.0",
+ "zvariant_utils 3.3.0",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zvariant_utils 2.1.0",
 ]
 
 [[package]]
@@ -3244,7 +3748,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "zvariant_utils",
+ "zvariant_utils 3.3.0",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ tokio.workspace = true
 anyhow.workspace = true
 tracing.workspace = true
 tracing-subscriber.workspace = true
+serde.workspace = true
 serde_json.workspace = true
 clap = { version = "4", features = ["derive", "env"] }
 ratatui = { version = "0.29", features = ["unstable-rendered-line-info"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,5 +38,6 @@ clap = { version = "4", features = ["derive", "env"] }
 ratatui = { version = "0.29", features = ["unstable-rendered-line-info"] }
 crossterm = { version = "0.28", features = ["event-stream"] }
 futures = "0.3"
+keyring = { version = "3", features = ["sync-secret-service", "crypto-rust"] }
 tui-textarea = "0.7"
 desktop-assistant-client-common.workspace = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,5 +39,9 @@ ratatui = { version = "0.29", features = ["unstable-rendered-line-info"] }
 crossterm = { version = "0.28", features = ["event-stream"] }
 futures = "0.3"
 keyring = { version = "3", features = ["sync-secret-service", "crypto-rust"] }
+oauth2 = "5"
+open = "5"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 tui-textarea = "0.7"
+url = "2"
 desktop-assistant-client-common.workspace = true

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -1,0 +1,131 @@
+//! Thin wrapper around the system keyring (Secret Service on Linux).
+//!
+//! Credentials are scoped per-profile by keying entries with the profile id.
+//! All operations are best-effort: if the keyring is unavailable (headless
+//! systems, CI, env without `dbus` running) we surface the error so callers
+//! can fall back to env vars or skip the credential silently.
+
+use std::{env, io};
+
+use keyring::Entry;
+
+const SERVICE: &str = "adele-tui";
+
+const ENV_DISABLE: &str = "ADELE_TUI_DISABLE_KEYRING";
+
+#[derive(Debug, Clone, Copy)]
+pub enum CredentialKind {
+    /// Login password used for username/password auth.
+    Password,
+    /// Direct JWT token.
+    Jwt,
+}
+
+impl CredentialKind {
+    fn account_prefix(self) -> &'static str {
+        match self {
+            CredentialKind::Password => "password",
+            CredentialKind::Jwt => "jwt",
+        }
+    }
+}
+
+fn account_key(profile_id: &str, kind: CredentialKind) -> String {
+    format!("{}::{}", kind.account_prefix(), profile_id)
+}
+
+/// Returns true when the keyring is intentionally disabled via env var.
+/// Useful for headless CI runs where `dbus` isn't available.
+fn keyring_disabled() -> bool {
+    env::var(ENV_DISABLE)
+        .ok()
+        .is_some_and(|v| matches!(v.as_str(), "1" | "true" | "yes"))
+}
+
+pub fn store(profile_id: &str, kind: CredentialKind, secret: &str) -> io::Result<()> {
+    if keyring_disabled() {
+        return Err(io::Error::other("keyring disabled via env"));
+    }
+    let key = account_key(profile_id, kind);
+    let entry = Entry::new(SERVICE, &key).map_err(map_err)?;
+    entry.set_password(secret).map_err(map_err)
+}
+
+pub fn retrieve(profile_id: &str, kind: CredentialKind) -> io::Result<String> {
+    if keyring_disabled() {
+        return Err(io::Error::other("keyring disabled via env"));
+    }
+    let key = account_key(profile_id, kind);
+    let entry = Entry::new(SERVICE, &key).map_err(map_err)?;
+    entry.get_password().map_err(map_err)
+}
+
+pub fn delete(profile_id: &str, kind: CredentialKind) -> io::Result<()> {
+    if keyring_disabled() {
+        return Ok(()); // Treat disabled keyring as a no-op for deletes.
+    }
+    let key = account_key(profile_id, kind);
+    let entry = Entry::new(SERVICE, &key).map_err(map_err)?;
+    match entry.delete_credential() {
+        Ok(()) => Ok(()),
+        // Missing entries are not an error for the caller's purposes.
+        Err(keyring::Error::NoEntry) => Ok(()),
+        Err(e) => Err(map_err(e)),
+    }
+}
+
+fn map_err(err: keyring::Error) -> io::Error {
+    io::Error::other(err.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Serializes env-var mutation across the tests in this module so the
+    /// parallel test runner doesn't race on `ADELE_TUI_DISABLE_KEYRING`.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn with_env_disabled<F: FnOnce()>(f: F) {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prior = env::var(ENV_DISABLE).ok();
+        // SAFETY: held under ENV_LOCK so no other test in this module
+        // mutates the same var concurrently.
+        unsafe { env::set_var(ENV_DISABLE, "1") };
+        f();
+        unsafe {
+            match prior {
+                Some(v) => env::set_var(ENV_DISABLE, v),
+                None => env::remove_var(ENV_DISABLE),
+            }
+        }
+    }
+
+    #[test]
+    fn account_key_includes_kind_and_profile_id() {
+        let k = account_key("abc-123", CredentialKind::Password);
+        assert_eq!(k, "password::abc-123");
+        let k = account_key("abc-123", CredentialKind::Jwt);
+        assert_eq!(k, "jwt::abc-123");
+    }
+
+    #[test]
+    fn keyring_disabled_returns_true_when_env_set() {
+        with_env_disabled(|| assert!(keyring_disabled()));
+    }
+
+    #[test]
+    fn store_returns_error_when_disabled() {
+        with_env_disabled(|| {
+            assert!(store("test-id", CredentialKind::Password, "secret").is_err());
+        });
+    }
+
+    #[test]
+    fn delete_is_noop_when_disabled() {
+        with_env_disabled(|| {
+            assert!(delete("test-id", CredentialKind::Password).is_ok());
+        });
+    }
+}

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -17,8 +17,10 @@ const ENV_DISABLE: &str = "ADELE_TUI_DISABLE_KEYRING";
 pub enum CredentialKind {
     /// Login password used for username/password auth.
     Password,
-    /// Direct JWT token.
+    /// Direct JWT (or OAuth access token after sign-in).
     Jwt,
+    /// OAuth refresh token, paired with an access token stored under `Jwt`.
+    OauthRefresh,
 }
 
 impl CredentialKind {
@@ -26,6 +28,7 @@ impl CredentialKind {
         match self {
             CredentialKind::Password => "password",
             CredentialKind::Jwt => "jwt",
+            CredentialKind::OauthRefresh => "oauth_refresh",
         }
     }
 }
@@ -108,6 +111,8 @@ mod tests {
         assert_eq!(k, "password::abc-123");
         let k = account_key("abc-123", CredentialKind::Jwt);
         assert_eq!(k, "jwt::abc-123");
+        let k = account_key("abc-123", CredentialKind::OauthRefresh);
+        assert_eq!(k, "oauth_refresh::abc-123");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
 pub mod app;
 pub mod keys;
+pub mod picker;
+pub mod profile;
 pub mod ui;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod app;
 pub mod credentials;
 pub mod keys;
+pub mod oauth;
 pub mod picker;
 pub mod profile;
 pub mod ui;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod app;
+pub mod credentials;
 pub mod keys;
 pub mod picker;
 pub mod profile;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod app;
 mod credentials;
 mod keys;
+mod oauth;
 mod picker;
 mod profile;
 mod ui;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,13 @@
 mod app;
 mod keys;
+mod picker;
+mod profile;
 mod ui;
 
 use std::io;
 
 use anyhow::Result;
-use clap::Parser;
+use clap::{CommandFactory, FromArgMatches, Parser, parser::ValueSource};
 use crossterm::{
     event::{
         DisableMouseCapture, EnableMouseCapture, Event, KeyEventKind, KeyboardEnhancementFlags,
@@ -23,6 +25,8 @@ use ratatui::{Terminal, backend::CrosstermBackend};
 
 use app::{App, InputMode};
 use keys::{Action, handle_key_event};
+use picker::PickerOutcome;
+use profile::ProfileStore;
 
 const DEFAULT_WS_URL: &str = desktop_assistant_client_common::config::DEFAULT_WS_URL;
 const DEFAULT_WS_SUBJECT: &str = desktop_assistant_client_common::config::DEFAULT_WS_SUBJECT;
@@ -97,7 +101,9 @@ impl From<CliArgs> for ConnectionConfig {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let config = ConnectionConfig::from(CliArgs::parse());
+    let matches = CliArgs::command().get_matches();
+    let cli = CliArgs::from_arg_matches(&matches)?;
+    let cli_explicit = any_explicit_connection_arg(&matches);
 
     enable_raw_mode()?;
     let mut stdout = io::stdout();
@@ -114,7 +120,7 @@ async fn main() -> Result<()> {
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
-    let result = run(&mut terminal, &config).await;
+    let result = run_app(&mut terminal, cli, cli_explicit).await;
 
     // Restore terminal
     disable_raw_mode()?;
@@ -127,6 +133,42 @@ async fn main() -> Result<()> {
     terminal.show_cursor()?;
 
     result
+}
+
+/// Returns true if the user explicitly supplied any connection-related CLI
+/// flag or env var, in which case we skip the profile picker and connect
+/// using the provided values (matching pre-profile-picker behavior).
+fn any_explicit_connection_arg(matches: &clap::ArgMatches) -> bool {
+    ["transport", "ws_url", "ws_subject"]
+        .iter()
+        .any(|name| {
+            matches!(
+                matches.value_source(name),
+                Some(ValueSource::CommandLine | ValueSource::EnvVariable)
+            )
+        })
+}
+
+/// Decide between picker-driven and CLI-driven connection, then hand off
+/// to the chat loop.
+async fn run_app(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    cli: CliArgs,
+    cli_explicit: bool,
+) -> Result<()> {
+    let store = ProfileStore::load();
+
+    let config = if cli_explicit || store.profiles.is_empty() {
+        ConnectionConfig::from(cli)
+    } else {
+        let (outcome, _store) = picker::run(terminal, store).await?;
+        match outcome {
+            PickerOutcome::Selected(profile) => profile.to_connection_config(),
+            PickerOutcome::Cancelled => return Ok(()),
+        }
+    };
+
+    run(terminal, &config).await
 }
 
 async fn run(

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod app;
+mod credentials;
 mod keys;
 mod picker;
 mod profile;

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -1,0 +1,292 @@
+//! OAuth2 + PKCE auth flow.
+//!
+//! Mirrors `adele-gtk/src/oauth.rs`. The daemon advertises its OAuth/OIDC
+//! configuration via `GET /auth/config`; we run the standard Authorization
+//! Code + PKCE flow with a local loopback redirect, exchange the code for
+//! tokens, and hand the access token to `ConnectionConfig::ws_jwt`.
+
+use anyhow::{Context, Result};
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct AuthDiscovery {
+    #[serde(default)]
+    pub methods: Vec<String>,
+    pub oidc: Option<OidcDiscovery>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OidcDiscovery {
+    pub authorization_endpoint: String,
+    pub token_endpoint: String,
+    pub client_id: String,
+    pub scopes: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct TokenResponse {
+    pub access_token: String,
+    pub refresh_token: Option<String>,
+}
+
+/// Discover auth configuration via the daemon's `/auth/config` endpoint.
+///
+/// Falls back to `methods=[password]` when the server returns a non-success
+/// status — keeps backward compatibility with daemons that predate auth
+/// discovery.
+pub async fn discover_auth_config(ws_url: &str) -> Result<AuthDiscovery> {
+    let base_url = ws_url_to_http_base(ws_url);
+    let url = format!("{base_url}/auth/config");
+
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new());
+
+    let response = client
+        .get(&url)
+        .send()
+        .await
+        .with_context(|| format!("fetching auth config from {url}"))?;
+
+    if !response.status().is_success() {
+        return Ok(AuthDiscovery {
+            methods: vec!["password".to_string()],
+            oidc: None,
+        });
+    }
+
+    response
+        .json::<AuthDiscovery>()
+        .await
+        .context("parsing auth config response")
+}
+
+/// Run the full OAuth2 Authorization Code + PKCE flow.
+pub async fn run_oauth_flow(oidc: &OidcDiscovery) -> Result<TokenResponse> {
+    use oauth2::{
+        AuthUrl, AuthorizationCode, ClientId, CsrfToken, PkceCodeChallenge, RedirectUrl, Scope,
+        TokenResponse as _, TokenUrl, basic::BasicClient,
+    };
+
+    let http_client = reqwest::ClientBuilder::new()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .expect("HTTP client should build");
+
+    let client = BasicClient::new(ClientId::new(oidc.client_id.clone()))
+        .set_auth_uri(AuthUrl::new(oidc.authorization_endpoint.clone())?)
+        .set_token_uri(TokenUrl::new(oidc.token_endpoint.clone())?);
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await?;
+    let local_addr = listener.local_addr()?;
+    let redirect_uri = format!("http://127.0.0.1:{}", local_addr.port());
+
+    let client = client.set_redirect_uri(RedirectUrl::new(redirect_uri)?);
+
+    let (pkce_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
+
+    let scopes: Vec<Scope> = oidc
+        .scopes
+        .split_whitespace()
+        .map(|s| Scope::new(s.to_string()))
+        .collect();
+
+    let (auth_url, csrf_state) = {
+        let mut req = client
+            .authorize_url(CsrfToken::new_random)
+            .set_pkce_challenge(pkce_challenge);
+        for scope in &scopes {
+            req = req.add_scope(scope.clone());
+        }
+        req.url()
+    };
+
+    open::that(auth_url.to_string()).context("failed to open browser")?;
+
+    let code = tokio::time::timeout(
+        std::time::Duration::from_secs(120),
+        accept_redirect(listener, &csrf_state),
+    )
+    .await
+    .map_err(|_| anyhow::anyhow!("OAuth redirect timed out after 120s"))??;
+
+    let token_result = client
+        .exchange_code(AuthorizationCode::new(code))
+        .set_pkce_verifier(pkce_verifier)
+        .request_async(&http_client)
+        .await
+        .map_err(|e| anyhow::anyhow!("token exchange failed: {e}"))?;
+
+    Ok(TokenResponse {
+        access_token: token_result.access_token().secret().clone(),
+        refresh_token: token_result.refresh_token().map(|t| t.secret().clone()),
+    })
+}
+
+/// Refresh an access token using a stored refresh token.
+///
+/// Currently exposed for follow-up work that wires automatic re-auth on
+/// 401 responses; not used by the bin entry point yet.
+#[allow(dead_code)]
+pub async fn refresh_access_token(
+    oidc: &OidcDiscovery,
+    refresh_token: &str,
+) -> Result<TokenResponse> {
+    use oauth2::{
+        AuthUrl, ClientId, RefreshToken, TokenResponse as _, TokenUrl, basic::BasicClient,
+    };
+
+    let http_client = reqwest::ClientBuilder::new()
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .expect("HTTP client should build");
+
+    let client = BasicClient::new(ClientId::new(oidc.client_id.clone()))
+        .set_auth_uri(AuthUrl::new(oidc.authorization_endpoint.clone())?)
+        .set_token_uri(TokenUrl::new(oidc.token_endpoint.clone())?);
+
+    let token_result = client
+        .exchange_refresh_token(&RefreshToken::new(refresh_token.to_string()))
+        .request_async(&http_client)
+        .await
+        .map_err(|e| anyhow::anyhow!("refresh token exchange failed: {e}"))?;
+
+    Ok(TokenResponse {
+        access_token: token_result.access_token().secret().clone(),
+        refresh_token: token_result.refresh_token().map(|t| t.secret().clone()),
+    })
+}
+
+async fn accept_redirect(
+    listener: tokio::net::TcpListener,
+    expected_state: &oauth2::CsrfToken,
+) -> Result<String> {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let (mut stream, _) = listener.accept().await?;
+
+    let mut buf = vec![0u8; 4096];
+    let n = stream.read(&mut buf).await?;
+    let request = String::from_utf8_lossy(&buf[..n]);
+
+    let path = request
+        .lines()
+        .next()
+        .and_then(|line| line.split_whitespace().nth(1))
+        .ok_or_else(|| anyhow::anyhow!("invalid HTTP request from redirect"))?;
+
+    let url = url::Url::parse(&format!("http://localhost{path}"))?;
+    let params: std::collections::HashMap<String, String> = url
+        .query_pairs()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect();
+
+    let state = params
+        .get("state")
+        .ok_or_else(|| anyhow::anyhow!("missing state parameter"))?;
+    if state != expected_state.secret() {
+        anyhow::bail!("CSRF state mismatch");
+    }
+
+    if let Some(error) = params.get("error") {
+        let desc = params.get("error_description").cloned().unwrap_or_default();
+        anyhow::bail!("OAuth error: {error} - {desc}");
+    }
+
+    let code = params
+        .get("code")
+        .ok_or_else(|| anyhow::anyhow!("missing authorization code"))?
+        .clone();
+
+    let response = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n\
+        <html><body><h2>Login successful!</h2>\
+        <p>You can close this window and return to Adele.</p></body></html>";
+    let _ = stream.write_all(response.as_bytes()).await;
+    let _ = stream.shutdown().await;
+
+    Ok(code)
+}
+
+fn ws_url_to_http_base(ws_url: &str) -> String {
+    let http_url = ws_url
+        .replacen("wss://", "https://", 1)
+        .replacen("ws://", "http://", 1);
+    if let Ok(parsed) = url::Url::parse(&http_url) {
+        format!(
+            "{}://{}{}",
+            parsed.scheme(),
+            parsed.host_str().unwrap_or("localhost"),
+            parsed.port().map(|p| format!(":{p}")).unwrap_or_default()
+        )
+    } else {
+        http_url
+    }
+}
+
+/// True when `methods` advertises OIDC and we have an OIDC config block.
+pub fn supports_oauth(discovery: &AuthDiscovery) -> bool {
+    discovery.oidc.is_some()
+        && discovery
+            .methods
+            .iter()
+            .any(|m| matches!(m.as_str(), "oidc" | "oauth" | "oauth2"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ws_url_to_http_base_strips_path_and_swaps_scheme() {
+        assert_eq!(
+            ws_url_to_http_base("ws://127.0.0.1:11339/ws"),
+            "http://127.0.0.1:11339"
+        );
+        assert_eq!(
+            ws_url_to_http_base("wss://example.com/ws"),
+            "https://example.com"
+        );
+        assert_eq!(
+            ws_url_to_http_base("wss://example.com:8443/ws"),
+            "https://example.com:8443"
+        );
+    }
+
+    #[test]
+    fn supports_oauth_true_when_methods_include_oidc_and_oidc_block_present() {
+        let d = AuthDiscovery {
+            methods: vec!["password".into(), "oidc".into()],
+            oidc: Some(OidcDiscovery {
+                authorization_endpoint: "https://idp/authorize".into(),
+                token_endpoint: "https://idp/token".into(),
+                client_id: "abc".into(),
+                scopes: "openid profile".into(),
+            }),
+        };
+        assert!(supports_oauth(&d));
+    }
+
+    #[test]
+    fn supports_oauth_false_without_oidc_block() {
+        let d = AuthDiscovery {
+            methods: vec!["oidc".into()],
+            oidc: None,
+        };
+        assert!(!supports_oauth(&d));
+    }
+
+    #[test]
+    fn supports_oauth_false_without_oidc_method() {
+        let d = AuthDiscovery {
+            methods: vec!["password".into()],
+            oidc: Some(OidcDiscovery {
+                authorization_endpoint: "https://idp/authorize".into(),
+                token_endpoint: "https://idp/token".into(),
+                client_id: "abc".into(),
+                scopes: "openid".into(),
+            }),
+        };
+        assert!(!supports_oauth(&d));
+    }
+}

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -7,7 +7,7 @@
 
 use std::io;
 
-use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind};
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use desktop_assistant_client_common::TransportMode;
 use futures::StreamExt;
 use ratatui::{
@@ -75,11 +75,19 @@ struct PickerState {
     mode: Mode,
     error: Option<String>,
     form: FormState,
+    /// Set when the user triggers OAuth from the form. The outer event
+    /// loop drains this flag and awaits the async flow.
+    oauth_pending: bool,
+    /// Transient status line shown during OAuth flows.
+    busy: Option<String>,
 }
 
 struct FormState {
     /// `Some(id)` when editing an existing profile; `None` for a new one.
     editing_id: Option<String>,
+    /// Stable id for this form. For new profiles this is generated up
+    /// front so OAuth flows can store tokens against it before save.
+    form_id: String,
     focus: Field,
     name: TextArea<'static>,
     url: TextArea<'static>,
@@ -92,6 +100,8 @@ struct FormState {
     /// editing). Drives the placeholder hint and decides whether to
     /// preserve or clear.
     had_stored_password: bool,
+    /// Whether OAuth tokens are currently stored for this form's id.
+    has_oauth_tokens: bool,
     transport: TransportMode,
 }
 
@@ -109,8 +119,17 @@ impl FormState {
         password.set_mask_char('•');
         // Default focus on Name so users can just start typing.
         name.move_cursor(CursorMove::Head);
+        // Pre-allocate an id so OAuth tokens (if any) can be written before
+        // the user presses save.
+        let seed = crate::profile::Profile::new(
+            String::new(),
+            TransportMode::Ws,
+            String::new(),
+            String::new(),
+        );
         Self {
             editing_id: None,
+            form_id: seed.id,
             focus: Field::Name,
             name,
             url,
@@ -118,6 +137,7 @@ impl FormState {
             username,
             password,
             had_stored_password: false,
+            has_oauth_tokens: false,
             transport: TransportMode::Ws,
         }
     }
@@ -125,6 +145,7 @@ impl FormState {
     fn from_profile(profile: &Profile) -> Self {
         let mut form = Self::empty();
         form.editing_id = Some(profile.id.clone());
+        form.form_id = profile.id.clone();
         form.name = single_line_textarea();
         form.name.insert_str(&profile.name);
         form.name.move_cursor(CursorMove::End);
@@ -143,6 +164,7 @@ impl FormState {
         // submit logic preserve the existing secret unless the user types
         // a replacement.
         form.had_stored_password = profile.has_password;
+        form.has_oauth_tokens = profile.has_jwt;
         form.transport = profile.transport;
         form
     }
@@ -186,24 +208,15 @@ impl FormState {
             PasswordAction::Set(password_raw)
         };
 
-        let id = self.editing_id.clone().unwrap_or_else(|| {
-            // Sourced from time-since-epoch in profile::new_id; reuse its format.
-            crate::profile::Profile::new(
-                String::new(),
-                TransportMode::Ws,
-                String::new(),
-                String::new(),
-            )
-            .id
-        });
         Ok(SubmittedProfile {
-            id,
+            id: self.form_id.clone(),
             name,
             transport: self.transport,
             ws_url,
             ws_subject,
             username,
             password_action,
+            has_oauth_tokens: self.has_oauth_tokens,
         })
     }
 }
@@ -227,6 +240,7 @@ struct SubmittedProfile {
     ws_subject: String,
     username: Option<String>,
     password_action: PasswordAction,
+    has_oauth_tokens: bool,
 }
 
 fn single_line_textarea() -> TextArea<'static> {
@@ -252,6 +266,8 @@ pub async fn run(
         mode: initial_mode,
         error: None,
         form: FormState::empty(),
+        oauth_pending: false,
+        busy: None,
     };
     if state.selected >= state.store.profiles.len() {
         state.selected = state.store.profiles.len().saturating_sub(1);
@@ -260,6 +276,12 @@ pub async fn run(
     let mut events = crossterm::event::EventStream::new();
     loop {
         terminal.draw(|f| draw(f, &state))?;
+
+        if state.oauth_pending {
+            state.oauth_pending = false;
+            run_oauth_for_form(&mut state, terminal).await;
+            continue;
+        }
 
         let evt = match events.next().await {
             Some(Ok(e)) => e,
@@ -343,6 +365,20 @@ fn advance_selection(state: &mut PickerState, delta: i32) {
 }
 
 fn handle_form_key(state: &mut PickerState, key: KeyEvent) {
+    // Ctrl+L: launch OAuth flow against the URL currently in the form.
+    if key.code == KeyCode::Char('l') && key.modifiers.contains(KeyModifiers::CONTROL) {
+        let url = state.form.url.lines().join(" ").trim().to_string();
+        if matches!(state.form.transport, TransportMode::Ws) && !url.is_empty() {
+            state.oauth_pending = true;
+            state.error = None;
+        } else {
+            state.error = Some(
+                "OAuth requires a WebSocket URL — fill in the URL field first".into(),
+            );
+        }
+        return;
+    }
+
     match (key.code, key.modifiers) {
         (KeyCode::Esc, _) => {
             state.error = None;
@@ -406,6 +442,77 @@ fn handle_form_key(state: &mut PickerState, key: KeyEvent) {
     }
 }
 
+/// Run the OAuth flow for the form currently being edited. Updates the
+/// busy status line as it progresses; the outer loop redraws each step.
+async fn run_oauth_for_form(
+    state: &mut PickerState,
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+) {
+    let url = state.form.url.lines().join(" ").trim().to_string();
+
+    state.busy = Some("Discovering auth config...".into());
+    let _ = terminal.draw(|f| draw(f, state));
+
+    let discovery = match crate::oauth::discover_auth_config(&url).await {
+        Ok(d) => d,
+        Err(e) => {
+            state.busy = None;
+            state.error = Some(format!("Auth discovery failed: {e}"));
+            return;
+        }
+    };
+
+    let oidc = match discovery.oidc {
+        Some(o) if crate::oauth::supports_oauth(&crate::oauth::AuthDiscovery {
+            methods: discovery.methods.clone(),
+            oidc: Some(o.clone()),
+        }) =>
+        {
+            o
+        }
+        _ => {
+            state.busy = None;
+            state.error = Some("Server does not advertise OAuth/OIDC support".into());
+            return;
+        }
+    };
+
+    state.busy = Some("Browser opened — complete sign-in to continue...".into());
+    let _ = terminal.draw(|f| draw(f, state));
+
+    let tokens = match crate::oauth::run_oauth_flow(&oidc).await {
+        Ok(t) => t,
+        Err(e) => {
+            state.busy = None;
+            state.error = Some(format!("Sign-in failed: {e}"));
+            return;
+        }
+    };
+
+    let id = state.form.form_id.clone();
+    if let Err(e) = credentials::store(&id, CredentialKind::Jwt, &tokens.access_token) {
+        state.busy = None;
+        state.error = Some(format!("Could not store access token: {e}"));
+        return;
+    }
+    if let Some(refresh) = tokens.refresh_token.as_deref() {
+        if let Err(e) = credentials::store(&id, CredentialKind::OauthRefresh, refresh) {
+            // Non-fatal — access token works for now, but warn so the user
+            // knows refresh is unavailable.
+            state.error = Some(format!("Stored access token but refresh failed: {e}"));
+        }
+    } else {
+        // No refresh token offered — clear any stale entry.
+        let _ = credentials::delete(&id, CredentialKind::OauthRefresh);
+    }
+
+    state.form.has_oauth_tokens = true;
+    state.busy = None;
+    if state.error.is_none() {
+        state.error = Some("Signed in — save the profile to keep these tokens".into());
+    }
+}
+
 /// Persist a submitted profile: update keyring, write profile, save store,
 /// reselect. Returns an error string suitable for the UI on failure.
 fn apply_submission(state: &mut PickerState, submitted: SubmittedProfile) -> Result<(), String> {
@@ -446,15 +553,7 @@ fn apply_submission(state: &mut PickerState, submitted: SubmittedProfile) -> Res
         ws_subject: submitted.ws_subject,
         username: submitted.username,
         has_password,
-        // JWT is managed by #14 OAuth flow — preserve any existing flag
-        // when editing, default to false on create.
-        has_jwt: state
-            .store
-            .profiles
-            .iter()
-            .find(|p| p.id == submitted.id)
-            .map(|p| p.has_jwt)
-            .unwrap_or(false),
+        has_jwt: submitted.has_oauth_tokens,
     };
 
     if editing {
@@ -802,7 +901,15 @@ fn draw_delete_overlay(f: &mut Frame, state: &PickerState, area: Rect) {
 }
 
 fn draw_error(f: &mut Frame, state: &PickerState, area: Rect) {
-    if let Some(err) = &state.error {
+    if let Some(busy) = &state.busy {
+        let style = Style::default()
+            .fg(Color::Rgb(178, 220, 245))
+            .add_modifier(Modifier::ITALIC);
+        f.render_widget(
+            Paragraph::new(Span::styled(format!(" ● {busy}"), style)),
+            area,
+        );
+    } else if let Some(err) = &state.error {
         let style = Style::default().fg(COLOR_ERROR);
         f.render_widget(
             Paragraph::new(Span::styled(format!(" • {err}"), style)),
@@ -823,6 +930,7 @@ fn draw_hints(f: &mut Frame, state: &PickerState, area: Rect) {
         Mode::Form => &[
             ("Tab", "next field"),
             ("Enter", "save"),
+            ("Ctrl+L", "OAuth sign-in"),
             ("Esc", "back"),
         ],
         Mode::DeleteConfirm => &[("y/Enter", "confirm"), ("any", "cancel")],
@@ -913,6 +1021,8 @@ mod tests {
             mode: Mode::List,
             error: None,
             form: FormState::empty(),
+            oauth_pending: false,
+            busy: None,
         }
     }
 

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -20,7 +20,10 @@ use ratatui::{
 };
 use tui_textarea::{CursorMove, TextArea};
 
-use crate::profile::{Profile, ProfileStore};
+use crate::{
+    credentials::{self, CredentialKind},
+    profile::{Profile, ProfileStore},
+};
 
 const COLOR_BORDER: Color = Color::Rgb(82, 104, 173);
 const COLOR_BORDER_ACTIVE: Color = Color::Rgb(120, 183, 109);
@@ -53,9 +56,18 @@ enum Field {
     Transport,
     Url,
     Subject,
+    Username,
+    Password,
 }
 
-const FIELD_ORDER: [Field; 4] = [Field::Name, Field::Transport, Field::Url, Field::Subject];
+const FIELD_ORDER: [Field; 6] = [
+    Field::Name,
+    Field::Transport,
+    Field::Url,
+    Field::Subject,
+    Field::Username,
+    Field::Password,
+];
 
 struct PickerState {
     store: ProfileStore,
@@ -72,6 +84,14 @@ struct FormState {
     name: TextArea<'static>,
     url: TextArea<'static>,
     subject: TextArea<'static>,
+    username: TextArea<'static>,
+    /// Password buffer — masked in the UI. Empty on edit means "leave the
+    /// stored secret untouched"; non-empty replaces the stored value.
+    password: TextArea<'static>,
+    /// Whether this profile already has a stored password (set when
+    /// editing). Drives the placeholder hint and decides whether to
+    /// preserve or clear.
+    had_stored_password: bool,
     transport: TransportMode,
 }
 
@@ -84,6 +104,9 @@ impl FormState {
         let mut subject = single_line_textarea();
         subject.insert_str("desktop-tui");
         subject.move_cursor(CursorMove::End);
+        let username = single_line_textarea();
+        let mut password = single_line_textarea();
+        password.set_mask_char('•');
         // Default focus on Name so users can just start typing.
         name.move_cursor(CursorMove::Head);
         Self {
@@ -92,6 +115,9 @@ impl FormState {
             name,
             url,
             subject,
+            username,
+            password,
+            had_stored_password: false,
             transport: TransportMode::Ws,
         }
     }
@@ -108,6 +134,15 @@ impl FormState {
         form.subject = single_line_textarea();
         form.subject.insert_str(&profile.ws_subject);
         form.subject.move_cursor(CursorMove::End);
+        form.username = single_line_textarea();
+        if let Some(user) = &profile.username {
+            form.username.insert_str(user);
+            form.username.move_cursor(CursorMove::End);
+        }
+        // Don't reveal stored password — leave the field empty and let the
+        // submit logic preserve the existing secret unless the user types
+        // a replacement.
+        form.had_stored_password = profile.has_password;
         form.transport = profile.transport;
         form
     }
@@ -122,7 +157,7 @@ impl FormState {
         self.focus = FIELD_ORDER[(pos + FIELD_ORDER.len() - 1) % FIELD_ORDER.len()];
     }
 
-    fn submit(&self) -> Result<Profile, String> {
+    fn submit(&self) -> Result<SubmittedProfile, String> {
         let name = self.name.lines().join(" ").trim().to_string();
         if name.is_empty() {
             return Err("Name is required".into());
@@ -132,6 +167,25 @@ impl FormState {
             return Err("URL is required for WebSocket transport".into());
         }
         let ws_subject = self.subject.lines().join(" ").trim().to_string();
+        let username_raw = self.username.lines().join(" ").trim().to_string();
+        let username = if username_raw.is_empty() {
+            None
+        } else {
+            Some(username_raw)
+        };
+        let password_raw = self.password.lines().join("");
+        // Empty password on edit = preserve the stored secret. On a fresh
+        // profile (no editing_id), empty just means "no password set".
+        let password_action = if password_raw.is_empty() {
+            if self.editing_id.is_some() && self.had_stored_password {
+                PasswordAction::PreserveExisting
+            } else {
+                PasswordAction::None
+            }
+        } else {
+            PasswordAction::Set(password_raw)
+        };
+
         let id = self.editing_id.clone().unwrap_or_else(|| {
             // Sourced from time-since-epoch in profile::new_id; reuse its format.
             crate::profile::Profile::new(
@@ -142,14 +196,37 @@ impl FormState {
             )
             .id
         });
-        Ok(Profile {
+        Ok(SubmittedProfile {
             id,
             name,
             transport: self.transport,
             ws_url,
             ws_subject,
+            username,
+            password_action,
         })
     }
+}
+
+#[derive(Debug, Clone)]
+enum PasswordAction {
+    /// No password — clear any existing stored secret.
+    None,
+    /// Replace stored secret with this value.
+    Set(String),
+    /// Leave the stored secret as-is (only meaningful on edit).
+    PreserveExisting,
+}
+
+#[derive(Debug, Clone)]
+struct SubmittedProfile {
+    id: String,
+    name: String,
+    transport: TransportMode,
+    ws_url: String,
+    ws_subject: String,
+    username: Option<String>,
+    password_action: PasswordAction,
 }
 
 fn single_line_textarea() -> TextArea<'static> {
@@ -287,36 +364,14 @@ fn handle_form_key(state: &mut PickerState, key: KeyEvent) {
         (KeyCode::Down, m) if m.is_empty() => state.form.next_field(),
         (KeyCode::Enter, m) if m.is_empty() => {
             match state.form.submit() {
-                Ok(profile) => {
-                    let editing = state.form.editing_id.is_some();
-                    if editing {
-                        // Replace existing profile in place.
-                        if let Some(existing) = state
-                            .store
-                            .profiles
-                            .iter_mut()
-                            .find(|p| p.id == profile.id)
-                        {
-                            *existing = profile.clone();
-                        }
+                Ok(submitted) => {
+                    if let Err(e) = apply_submission(state, submitted) {
+                        state.error = Some(e);
                     } else {
-                        state.store.add(profile.clone());
+                        state.error = None;
+                        state.mode = Mode::List;
+                        state.form = FormState::empty();
                     }
-                    if let Err(e) = state.store.save() {
-                        state.error = Some(format!("Save failed: {e}"));
-                        return;
-                    }
-                    // Reselect to the saved profile.
-                    let new_index = state
-                        .store
-                        .profiles
-                        .iter()
-                        .position(|p| p.id == profile.id)
-                        .unwrap_or(state.selected);
-                    state.selected = new_index;
-                    state.error = None;
-                    state.mode = Mode::List;
-                    state.form = FormState::empty();
                 }
                 Err(msg) => state.error = Some(msg),
             }
@@ -340,9 +395,91 @@ fn handle_form_key(state: &mut PickerState, key: KeyEvent) {
             Field::Subject => {
                 state.form.subject.input(key);
             }
+            Field::Username => {
+                state.form.username.input(key);
+            }
+            Field::Password => {
+                state.form.password.input(key);
+            }
             Field::Transport => {}
         },
     }
+}
+
+/// Persist a submitted profile: update keyring, write profile, save store,
+/// reselect. Returns an error string suitable for the UI on failure.
+fn apply_submission(state: &mut PickerState, submitted: SubmittedProfile) -> Result<(), String> {
+    let editing = state
+        .store
+        .profiles
+        .iter()
+        .any(|p| p.id == submitted.id);
+
+    let mut has_password = match &submitted.password_action {
+        PasswordAction::Set(_) => true,
+        PasswordAction::PreserveExisting => true,
+        PasswordAction::None => false,
+    };
+
+    // Apply password change first; if keyring fails, surface it before we
+    // touch the on-disk store so state stays consistent.
+    match &submitted.password_action {
+        PasswordAction::Set(secret) => {
+            if let Err(e) = credentials::store(&submitted.id, CredentialKind::Password, secret) {
+                return Err(format!("Could not store password: {e}"));
+            }
+        }
+        PasswordAction::PreserveExisting => {
+            // Keep the keyring as-is; nothing to do.
+        }
+        PasswordAction::None => {
+            let _ = credentials::delete(&submitted.id, CredentialKind::Password);
+            has_password = false;
+        }
+    }
+
+    let new_profile = Profile {
+        id: submitted.id.clone(),
+        name: submitted.name,
+        transport: submitted.transport,
+        ws_url: submitted.ws_url,
+        ws_subject: submitted.ws_subject,
+        username: submitted.username,
+        has_password,
+        // JWT is managed by #14 OAuth flow — preserve any existing flag
+        // when editing, default to false on create.
+        has_jwt: state
+            .store
+            .profiles
+            .iter()
+            .find(|p| p.id == submitted.id)
+            .map(|p| p.has_jwt)
+            .unwrap_or(false),
+    };
+
+    if editing {
+        if let Some(existing) = state
+            .store
+            .profiles
+            .iter_mut()
+            .find(|p| p.id == new_profile.id)
+        {
+            *existing = new_profile.clone();
+        }
+    } else {
+        state.store.add(new_profile.clone());
+    }
+    state
+        .store
+        .save()
+        .map_err(|e| format!("Save failed: {e}"))?;
+    state.selected = state
+        .store
+        .profiles
+        .iter()
+        .position(|p| p.id == new_profile.id)
+        .unwrap_or(state.selected);
+    Ok(())
 }
 
 fn handle_delete_key(state: &mut PickerState, key: KeyEvent) {
@@ -497,6 +634,10 @@ fn draw_form(f: &mut Frame, state: &PickerState, area: Rect) {
             Constraint::Length(3),
             Constraint::Length(1),
             Constraint::Length(3),
+            Constraint::Length(1),
+            Constraint::Length(3),
+            Constraint::Length(1),
+            Constraint::Length(3),
             Constraint::Min(0),
         ])
         .split(inner);
@@ -526,6 +667,37 @@ fn draw_form(f: &mut Frame, state: &PickerState, area: Rect) {
         rows[7],
         &state.form.subject,
         state.form.focus == Field::Subject,
+    );
+
+    draw_field_label(
+        f,
+        rows[8],
+        "Username (optional)",
+        state.form.focus == Field::Username,
+    );
+    draw_text_field(
+        f,
+        rows[9],
+        &state.form.username,
+        state.form.focus == Field::Username,
+    );
+
+    let password_label = if state.form.had_stored_password {
+        "Password (•••• stored — leave blank to keep)"
+    } else {
+        "Password (optional, masked)"
+    };
+    draw_field_label(
+        f,
+        rows[10],
+        password_label,
+        state.form.focus == Field::Password,
+    );
+    draw_text_field(
+        f,
+        rows[11],
+        &state.form.password,
+        state.form.focus == Field::Password,
     );
 }
 
@@ -691,6 +863,10 @@ fn position_cursor_in_form(f: &mut Frame, state: &PickerState, area: Rect) {
             Constraint::Length(3),
             Constraint::Length(1),
             Constraint::Length(3),
+            Constraint::Length(1),
+            Constraint::Length(3),
+            Constraint::Length(1),
+            Constraint::Length(3),
             Constraint::Min(0),
         ])
         .split(inner);
@@ -699,6 +875,8 @@ fn position_cursor_in_form(f: &mut Frame, state: &PickerState, area: Rect) {
         Field::Name => (&state.form.name, 1),
         Field::Url => (&state.form.url, 5),
         Field::Subject => (&state.form.subject, 7),
+        Field::Username => (&state.form.username, 9),
+        Field::Password => (&state.form.password, 11),
         Field::Transport => return,
     };
 

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -1,0 +1,821 @@
+//! Pre-chat profile picker.
+//!
+//! Renders a small modal-style screen listing saved profiles with shortcuts
+//! to add or delete entries. Returns the chosen `Profile` (or `None` if the
+//! user quit). Lives outside the chat UI so it doesn't widen the chat
+//! state machine.
+
+use std::io;
+
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind};
+use desktop_assistant_client_common::TransportMode;
+use futures::StreamExt;
+use ratatui::{
+    Frame, Terminal,
+    backend::CrosstermBackend,
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap},
+};
+use tui_textarea::{CursorMove, TextArea};
+
+use crate::profile::{Profile, ProfileStore};
+
+const COLOR_BORDER: Color = Color::Rgb(82, 104, 173);
+const COLOR_BORDER_ACTIVE: Color = Color::Rgb(120, 183, 109);
+const COLOR_TITLE: Color = Color::Rgb(166, 182, 255);
+const COLOR_HINT_KEY: Color = Color::Rgb(216, 223, 236);
+const COLOR_HINT_DESC: Color = Color::Rgb(143, 153, 174);
+const COLOR_HINT_SEP: Color = Color::Rgb(82, 90, 110);
+const COLOR_LIST_HIGHLIGHT: Color = Color::Rgb(72, 102, 180);
+const COLOR_LIST_HIGHLIGHT_FG: Color = Color::Rgb(245, 248, 255);
+const COLOR_ERROR: Color = Color::Rgb(232, 130, 130);
+
+/// Outcome of running the picker.
+pub enum PickerOutcome {
+    /// User picked or created a profile to connect to.
+    Selected(Profile),
+    /// User pressed quit before selecting anything.
+    Cancelled,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Mode {
+    List,
+    Form,
+    DeleteConfirm,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Field {
+    Name,
+    Transport,
+    Url,
+    Subject,
+}
+
+const FIELD_ORDER: [Field; 4] = [Field::Name, Field::Transport, Field::Url, Field::Subject];
+
+struct PickerState {
+    store: ProfileStore,
+    selected: usize,
+    mode: Mode,
+    error: Option<String>,
+    form: FormState,
+}
+
+struct FormState {
+    /// `Some(id)` when editing an existing profile; `None` for a new one.
+    editing_id: Option<String>,
+    focus: Field,
+    name: TextArea<'static>,
+    url: TextArea<'static>,
+    subject: TextArea<'static>,
+    transport: TransportMode,
+}
+
+impl FormState {
+    fn empty() -> Self {
+        let mut name = single_line_textarea();
+        let mut url = single_line_textarea();
+        url.insert_str("ws://127.0.0.1:11339/ws");
+        url.move_cursor(CursorMove::End);
+        let mut subject = single_line_textarea();
+        subject.insert_str("desktop-tui");
+        subject.move_cursor(CursorMove::End);
+        // Default focus on Name so users can just start typing.
+        name.move_cursor(CursorMove::Head);
+        Self {
+            editing_id: None,
+            focus: Field::Name,
+            name,
+            url,
+            subject,
+            transport: TransportMode::Ws,
+        }
+    }
+
+    fn from_profile(profile: &Profile) -> Self {
+        let mut form = Self::empty();
+        form.editing_id = Some(profile.id.clone());
+        form.name = single_line_textarea();
+        form.name.insert_str(&profile.name);
+        form.name.move_cursor(CursorMove::End);
+        form.url = single_line_textarea();
+        form.url.insert_str(&profile.ws_url);
+        form.url.move_cursor(CursorMove::End);
+        form.subject = single_line_textarea();
+        form.subject.insert_str(&profile.ws_subject);
+        form.subject.move_cursor(CursorMove::End);
+        form.transport = profile.transport;
+        form
+    }
+
+    fn next_field(&mut self) {
+        let pos = FIELD_ORDER.iter().position(|f| *f == self.focus).unwrap_or(0);
+        self.focus = FIELD_ORDER[(pos + 1) % FIELD_ORDER.len()];
+    }
+
+    fn prev_field(&mut self) {
+        let pos = FIELD_ORDER.iter().position(|f| *f == self.focus).unwrap_or(0);
+        self.focus = FIELD_ORDER[(pos + FIELD_ORDER.len() - 1) % FIELD_ORDER.len()];
+    }
+
+    fn submit(&self) -> Result<Profile, String> {
+        let name = self.name.lines().join(" ").trim().to_string();
+        if name.is_empty() {
+            return Err("Name is required".into());
+        }
+        let ws_url = self.url.lines().join(" ").trim().to_string();
+        if matches!(self.transport, TransportMode::Ws) && ws_url.is_empty() {
+            return Err("URL is required for WebSocket transport".into());
+        }
+        let ws_subject = self.subject.lines().join(" ").trim().to_string();
+        let id = self.editing_id.clone().unwrap_or_else(|| {
+            // Sourced from time-since-epoch in profile::new_id; reuse its format.
+            crate::profile::Profile::new(
+                String::new(),
+                TransportMode::Ws,
+                String::new(),
+                String::new(),
+            )
+            .id
+        });
+        Ok(Profile {
+            id,
+            name,
+            transport: self.transport,
+            ws_url,
+            ws_subject,
+        })
+    }
+}
+
+fn single_line_textarea() -> TextArea<'static> {
+    let mut ta = TextArea::default();
+    ta.set_cursor_line_style(Style::default());
+    ta
+}
+
+/// Run the picker until the user selects, creates, or quits.
+pub async fn run(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    store: ProfileStore,
+) -> io::Result<(PickerOutcome, ProfileStore)> {
+    let initial_mode = if store.profiles.is_empty() {
+        Mode::Form
+    } else {
+        Mode::List
+    };
+    let initial_selected = store.last_used_index().unwrap_or(0);
+    let mut state = PickerState {
+        selected: initial_selected,
+        store,
+        mode: initial_mode,
+        error: None,
+        form: FormState::empty(),
+    };
+    if state.selected >= state.store.profiles.len() {
+        state.selected = state.store.profiles.len().saturating_sub(1);
+    }
+
+    let mut events = crossterm::event::EventStream::new();
+    loop {
+        terminal.draw(|f| draw(f, &state))?;
+
+        let evt = match events.next().await {
+            Some(Ok(e)) => e,
+            Some(Err(_)) | None => return Ok((PickerOutcome::Cancelled, state.store)),
+        };
+        let Event::Key(key) = evt else { continue };
+        if key.kind == KeyEventKind::Release {
+            continue;
+        }
+
+        match state.mode {
+            Mode::List => {
+                if let Some(outcome) = handle_list_key(&mut state, key) {
+                    return Ok((outcome, state.store));
+                }
+            }
+            Mode::Form => handle_form_key(&mut state, key),
+            Mode::DeleteConfirm => handle_delete_key(&mut state, key),
+        }
+    }
+}
+
+fn handle_list_key(state: &mut PickerState, key: KeyEvent) -> Option<PickerOutcome> {
+    match (key.code, key.modifiers) {
+        (KeyCode::Char('q'), m) if m.is_empty() => Some(PickerOutcome::Cancelled),
+        (KeyCode::Esc, _) => Some(PickerOutcome::Cancelled),
+        (KeyCode::Char('j') | KeyCode::Down, m) if m.is_empty() => {
+            advance_selection(state, 1);
+            None
+        }
+        (KeyCode::Char('k') | KeyCode::Up, m) if m.is_empty() => {
+            advance_selection(state, -1);
+            None
+        }
+        (KeyCode::Enter, m) if m.is_empty() => {
+            if let Some(profile) = state.store.profiles.get(state.selected).cloned() {
+                state.store.mark_used(&profile.id);
+                let _ = state.store.save();
+                Some(PickerOutcome::Selected(profile))
+            } else {
+                None
+            }
+        }
+        (KeyCode::Char('a') | KeyCode::Char('+'), m) if m.is_empty() => {
+            state.form = FormState::empty();
+            state.error = None;
+            state.mode = Mode::Form;
+            None
+        }
+        (KeyCode::Char('e'), m) if m.is_empty() => {
+            if let Some(profile) = state.store.profiles.get(state.selected) {
+                state.form = FormState::from_profile(profile);
+                state.error = None;
+                state.mode = Mode::Form;
+            }
+            None
+        }
+        (KeyCode::Char('d'), m) if m.is_empty() => {
+            if state.store.profiles.get(state.selected).is_some() {
+                state.mode = Mode::DeleteConfirm;
+            }
+            None
+        }
+        _ => None,
+    }
+}
+
+fn advance_selection(state: &mut PickerState, delta: i32) {
+    let len = state.store.profiles.len();
+    if len == 0 {
+        return;
+    }
+    let mut idx = state.selected as i32 + delta;
+    if idx < 0 {
+        idx = (len as i32) - 1;
+    }
+    if idx >= len as i32 {
+        idx = 0;
+    }
+    state.selected = idx as usize;
+}
+
+fn handle_form_key(state: &mut PickerState, key: KeyEvent) {
+    match (key.code, key.modifiers) {
+        (KeyCode::Esc, _) => {
+            state.error = None;
+            state.mode = if state.store.profiles.is_empty() {
+                // No way back to a list — Esc with nothing to go to means
+                // exit the picker entirely; we surface that on the next
+                // iteration via the outer loop. Simpler: treat as a noop
+                // so the user stays in the form. Add a dedicated quit hint.
+                Mode::Form
+            } else {
+                Mode::List
+            };
+            // Clear form on cancel of edit so a re-entry starts fresh.
+            state.form = FormState::empty();
+        }
+        (KeyCode::Tab, _) => state.form.next_field(),
+        (KeyCode::BackTab, _) => state.form.prev_field(),
+        (KeyCode::Up, m) if m.is_empty() => state.form.prev_field(),
+        (KeyCode::Down, m) if m.is_empty() => state.form.next_field(),
+        (KeyCode::Enter, m) if m.is_empty() => {
+            match state.form.submit() {
+                Ok(profile) => {
+                    let editing = state.form.editing_id.is_some();
+                    if editing {
+                        // Replace existing profile in place.
+                        if let Some(existing) = state
+                            .store
+                            .profiles
+                            .iter_mut()
+                            .find(|p| p.id == profile.id)
+                        {
+                            *existing = profile.clone();
+                        }
+                    } else {
+                        state.store.add(profile.clone());
+                    }
+                    if let Err(e) = state.store.save() {
+                        state.error = Some(format!("Save failed: {e}"));
+                        return;
+                    }
+                    // Reselect to the saved profile.
+                    let new_index = state
+                        .store
+                        .profiles
+                        .iter()
+                        .position(|p| p.id == profile.id)
+                        .unwrap_or(state.selected);
+                    state.selected = new_index;
+                    state.error = None;
+                    state.mode = Mode::List;
+                    state.form = FormState::empty();
+                }
+                Err(msg) => state.error = Some(msg),
+            }
+        }
+        // Transport field uses left/right or space to flip the toggle.
+        (KeyCode::Left | KeyCode::Right | KeyCode::Char(' '), _)
+            if state.form.focus == Field::Transport =>
+        {
+            state.form.transport = match state.form.transport {
+                TransportMode::Ws => TransportMode::Dbus,
+                TransportMode::Dbus => TransportMode::Ws,
+            };
+        }
+        _ => match state.form.focus {
+            Field::Name => {
+                state.form.name.input(key);
+            }
+            Field::Url => {
+                state.form.url.input(key);
+            }
+            Field::Subject => {
+                state.form.subject.input(key);
+            }
+            Field::Transport => {}
+        },
+    }
+}
+
+fn handle_delete_key(state: &mut PickerState, key: KeyEvent) {
+    match (key.code, key.modifiers) {
+        (KeyCode::Char('y') | KeyCode::Char('Y') | KeyCode::Enter, _) => {
+            if let Some(profile) = state.store.profiles.get(state.selected).cloned() {
+                state.store.remove(&profile.id);
+                let _ = state.store.save();
+                if state.selected >= state.store.profiles.len() {
+                    state.selected = state.store.profiles.len().saturating_sub(1);
+                }
+            }
+            state.mode = if state.store.profiles.is_empty() {
+                Mode::Form
+            } else {
+                Mode::List
+            };
+            if matches!(state.mode, Mode::Form) {
+                state.form = FormState::empty();
+            }
+        }
+        _ => state.mode = Mode::List,
+    }
+}
+
+fn draw(f: &mut Frame, state: &PickerState) {
+    let area = f.area();
+    f.render_widget(Clear, area);
+
+    let layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(5),
+            Constraint::Length(1),
+            Constraint::Length(1),
+        ])
+        .split(area);
+
+    draw_header(f, layout[0]);
+    match state.mode {
+        Mode::List => draw_list(f, state, layout[1]),
+        Mode::Form => draw_form(f, state, layout[1]),
+        Mode::DeleteConfirm => {
+            draw_list(f, state, layout[1]);
+            draw_delete_overlay(f, state, area);
+        }
+    }
+    draw_error(f, state, layout[2]);
+    draw_hints(f, state, layout[3]);
+
+    if matches!(state.mode, Mode::Form) {
+        // Keep cursor blinking in the focused text field.
+        position_cursor_in_form(f, state, layout[1]);
+    }
+}
+
+fn draw_header(f: &mut Frame, area: Rect) {
+    let title = Paragraph::new(vec![
+        Line::from(Span::styled(
+            "Adele connection profiles",
+            Style::default()
+                .fg(COLOR_TITLE)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(Span::styled(
+            "Pick a daemon to connect to, or create a new profile.",
+            Style::default().fg(COLOR_HINT_DESC),
+        )),
+    ]);
+    f.render_widget(title, area);
+}
+
+fn draw_list(f: &mut Frame, state: &PickerState, area: Rect) {
+    let items: Vec<ListItem> = if state.store.profiles.is_empty() {
+        vec![ListItem::new(Line::from(Span::styled(
+            "(no saved profiles — press 'a' to add one)",
+            Style::default().fg(COLOR_HINT_DESC),
+        )))]
+    } else {
+        state
+            .store
+            .profiles
+            .iter()
+            .enumerate()
+            .map(|(idx, p)| {
+                let mut spans: Vec<Span<'static>> = Vec::new();
+                if state.store.last_used_index() == Some(idx) {
+                    spans.push(Span::styled(
+                        "★ ",
+                        Style::default().fg(Color::Rgb(255, 207, 119)),
+                    ));
+                }
+                spans.push(Span::styled(p.display_label(), Style::default()));
+                ListItem::new(Line::from(spans))
+            })
+            .collect()
+    };
+
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(COLOR_BORDER))
+                .title(Line::from(Span::styled(
+                    "Profiles",
+                    Style::default()
+                        .fg(COLOR_TITLE)
+                        .add_modifier(Modifier::BOLD),
+                ))),
+        )
+        .highlight_style(
+            Style::default()
+                .bg(COLOR_LIST_HIGHLIGHT)
+                .fg(COLOR_LIST_HIGHLIGHT_FG)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("▸ ");
+
+    let mut list_state = ListState::default();
+    if !state.store.profiles.is_empty() {
+        list_state.select(Some(state.selected));
+    }
+    f.render_stateful_widget(list, area, &mut list_state);
+}
+
+fn draw_form(f: &mut Frame, state: &PickerState, area: Rect) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(COLOR_BORDER))
+        .title(Line::from(Span::styled(
+            if state.form.editing_id.is_some() {
+                "Edit profile"
+            } else {
+                "New profile"
+            },
+            Style::default()
+                .fg(COLOR_TITLE)
+                .add_modifier(Modifier::BOLD),
+        )));
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Length(3),
+            Constraint::Length(1),
+            Constraint::Length(3),
+            Constraint::Length(1),
+            Constraint::Length(3),
+            Constraint::Length(1),
+            Constraint::Length(3),
+            Constraint::Min(0),
+        ])
+        .split(inner);
+
+    draw_field_label(f, rows[0], "Name", state.form.focus == Field::Name);
+    draw_text_field(f, rows[1], &state.form.name, state.form.focus == Field::Name);
+
+    draw_field_label(
+        f,
+        rows[2],
+        "Transport (←/→ or Space to toggle)",
+        state.form.focus == Field::Transport,
+    );
+    draw_transport_toggle(f, rows[3], state);
+
+    draw_field_label(f, rows[4], "URL", state.form.focus == Field::Url);
+    draw_text_field(f, rows[5], &state.form.url, state.form.focus == Field::Url);
+
+    draw_field_label(
+        f,
+        rows[6],
+        "JWT subject",
+        state.form.focus == Field::Subject,
+    );
+    draw_text_field(
+        f,
+        rows[7],
+        &state.form.subject,
+        state.form.focus == Field::Subject,
+    );
+}
+
+fn draw_field_label(f: &mut Frame, area: Rect, label: &str, focused: bool) {
+    let style = if focused {
+        Style::default()
+            .fg(COLOR_BORDER_ACTIVE)
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(COLOR_HINT_DESC)
+    };
+    f.render_widget(Paragraph::new(Span::styled(label.to_string(), style)), area);
+}
+
+fn draw_text_field(f: &mut Frame, area: Rect, textarea: &TextArea<'static>, focused: bool) {
+    let mut ta = textarea.clone();
+    let border_color = if focused {
+        COLOR_BORDER_ACTIVE
+    } else {
+        COLOR_BORDER
+    };
+    ta.set_block(
+        Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(border_color)),
+    );
+    f.render_widget(&ta, area);
+}
+
+fn draw_transport_toggle(f: &mut Frame, area: Rect, state: &PickerState) {
+    let focused = state.form.focus == Field::Transport;
+    let border_color = if focused {
+        COLOR_BORDER_ACTIVE
+    } else {
+        COLOR_BORDER
+    };
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(border_color));
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    let render_chip = |label: &str, selected: bool| {
+        let style = if selected {
+            Style::default()
+                .fg(Color::Black)
+                .bg(COLOR_BORDER_ACTIVE)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(COLOR_HINT_DESC)
+        };
+        Span::styled(format!(" {label} "), style)
+    };
+
+    let line = Line::from(vec![
+        render_chip("WebSocket", state.form.transport == TransportMode::Ws),
+        Span::styled("  ", Style::default()),
+        render_chip("D-Bus", state.form.transport == TransportMode::Dbus),
+    ]);
+    f.render_widget(Paragraph::new(line), inner);
+}
+
+fn draw_delete_overlay(f: &mut Frame, state: &PickerState, area: Rect) {
+    let label = state
+        .store
+        .profiles
+        .get(state.selected)
+        .map(|p| p.name.clone())
+        .unwrap_or_else(|| "this profile".to_string());
+    let popup_width = 60.min(area.width.saturating_sub(4));
+    let popup_height = 5.min(area.height.saturating_sub(2));
+    let popup = Rect {
+        x: area.x + (area.width.saturating_sub(popup_width)) / 2,
+        y: area.y + (area.height.saturating_sub(popup_height)) / 2,
+        width: popup_width,
+        height: popup_height,
+    };
+    f.render_widget(Clear, popup);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Rgb(232, 130, 130)))
+        .title(Line::from(Span::styled(
+            "Delete profile",
+            Style::default()
+                .fg(Color::Rgb(255, 200, 200))
+                .add_modifier(Modifier::BOLD),
+        )));
+    let inner = block.inner(popup);
+    f.render_widget(block, popup);
+    let body = Paragraph::new(vec![
+        Line::from(Span::styled(
+            format!("Delete \"{label}\"?"),
+            Style::default().fg(Color::White),
+        )),
+        Line::from(Span::styled(
+            "y/Enter = confirm · any other key = cancel",
+            Style::default().fg(COLOR_HINT_DESC),
+        )),
+    ])
+    .wrap(Wrap { trim: true });
+    f.render_widget(body, inner);
+}
+
+fn draw_error(f: &mut Frame, state: &PickerState, area: Rect) {
+    if let Some(err) = &state.error {
+        let style = Style::default().fg(COLOR_ERROR);
+        f.render_widget(
+            Paragraph::new(Span::styled(format!(" • {err}"), style)),
+            area,
+        );
+    }
+}
+
+fn draw_hints(f: &mut Frame, state: &PickerState, area: Rect) {
+    let hints: &[(&str, &str)] = match state.mode {
+        Mode::List => &[
+            ("Enter", "connect"),
+            ("a", "add"),
+            ("e", "edit"),
+            ("d", "delete"),
+            ("q/Esc", "quit"),
+        ],
+        Mode::Form => &[
+            ("Tab", "next field"),
+            ("Enter", "save"),
+            ("Esc", "back"),
+        ],
+        Mode::DeleteConfirm => &[("y/Enter", "confirm"), ("any", "cancel")],
+    };
+
+    let mut spans: Vec<Span> = Vec::with_capacity(hints.len() * 4);
+    for (idx, (key, desc)) in hints.iter().enumerate() {
+        if idx > 0 {
+            spans.push(Span::styled("  ·  ", Style::default().fg(COLOR_HINT_SEP)));
+        }
+        spans.push(Span::styled(
+            (*key).to_string(),
+            Style::default()
+                .fg(COLOR_HINT_KEY)
+                .add_modifier(Modifier::BOLD),
+        ));
+        spans.push(Span::raw(" "));
+        spans.push(Span::styled(
+            (*desc).to_string(),
+            Style::default().fg(COLOR_HINT_DESC),
+        ));
+    }
+    f.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+
+fn position_cursor_in_form(f: &mut Frame, state: &PickerState, area: Rect) {
+    // Re-derive the inner box of the focused field's text area. The form
+    // layout is mirrored from `draw_form`; we use the same constraints.
+    let inner = Block::default().borders(Borders::ALL).inner(area);
+    let rows = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Length(3),
+            Constraint::Length(1),
+            Constraint::Length(3),
+            Constraint::Length(1),
+            Constraint::Length(3),
+            Constraint::Length(1),
+            Constraint::Length(3),
+            Constraint::Min(0),
+        ])
+        .split(inner);
+
+    let (textarea, row_idx) = match state.form.focus {
+        Field::Name => (&state.form.name, 1),
+        Field::Url => (&state.form.url, 5),
+        Field::Subject => (&state.form.subject, 7),
+        Field::Transport => return,
+    };
+
+    let row = rows[row_idx];
+    let inner_row = Block::default().borders(Borders::ALL).inner(row);
+    let (cursor_row, cursor_col) = textarea.cursor();
+    let x = inner_row.x + cursor_col.min(inner_row.width.saturating_sub(1) as usize) as u16;
+    let y = inner_row.y + cursor_row.min(inner_row.height.saturating_sub(1) as usize) as u16;
+    f.set_cursor_position((x, y));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::{KeyEventKind, KeyEventState, KeyModifiers};
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent {
+            code,
+            modifiers: KeyModifiers::NONE,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::NONE,
+        }
+    }
+
+    fn make_state(profiles: Vec<Profile>) -> PickerState {
+        let mut store = ProfileStore::default();
+        for p in profiles {
+            store.add(p);
+        }
+        PickerState {
+            selected: 0,
+            store,
+            mode: Mode::List,
+            error: None,
+            form: FormState::empty(),
+        }
+    }
+
+    #[test]
+    fn list_q_returns_cancelled() {
+        let mut state = make_state(vec![]);
+        let outcome = handle_list_key(&mut state, key(KeyCode::Char('q')));
+        assert!(matches!(outcome, Some(PickerOutcome::Cancelled)));
+    }
+
+    #[test]
+    fn list_enter_returns_selected_profile() {
+        let p = Profile::new("Local".into(), TransportMode::Ws, "ws://x".into(), "s".into());
+        let id = p.id.clone();
+        let mut state = make_state(vec![p]);
+        let outcome = handle_list_key(&mut state, key(KeyCode::Enter));
+        match outcome {
+            Some(PickerOutcome::Selected(picked)) => assert_eq!(picked.id, id),
+            _ => panic!("expected Selected outcome"),
+        }
+    }
+
+    #[test]
+    fn list_a_enters_form_mode() {
+        let mut state = make_state(vec![]);
+        handle_list_key(&mut state, key(KeyCode::Char('a')));
+        assert_eq!(state.mode, Mode::Form);
+        assert!(state.form.editing_id.is_none());
+    }
+
+    #[test]
+    fn form_tab_cycles_focus() {
+        let mut state = make_state(vec![]);
+        state.mode = Mode::Form;
+        assert_eq!(state.form.focus, Field::Name);
+        handle_form_key(&mut state, key(KeyCode::Tab));
+        assert_eq!(state.form.focus, Field::Transport);
+        handle_form_key(&mut state, key(KeyCode::Tab));
+        assert_eq!(state.form.focus, Field::Url);
+    }
+
+    #[test]
+    fn form_transport_toggles_with_arrow() {
+        let mut state = make_state(vec![]);
+        state.mode = Mode::Form;
+        state.form.focus = Field::Transport;
+        assert_eq!(state.form.transport, TransportMode::Ws);
+        handle_form_key(&mut state, key(KeyCode::Right));
+        assert_eq!(state.form.transport, TransportMode::Dbus);
+        handle_form_key(&mut state, key(KeyCode::Left));
+        assert_eq!(state.form.transport, TransportMode::Ws);
+    }
+
+    #[test]
+    fn form_submit_with_blank_name_records_error() {
+        let mut state = make_state(vec![]);
+        state.mode = Mode::Form;
+        // Name is empty by default.
+        handle_form_key(&mut state, key(KeyCode::Enter));
+        assert!(state.error.is_some());
+        assert_eq!(state.mode, Mode::Form);
+    }
+
+    #[test]
+    fn delete_confirm_y_removes_profile() {
+        let p = Profile::new("Local".into(), TransportMode::Ws, "ws://x".into(), "s".into());
+        let mut state = make_state(vec![p]);
+        state.mode = Mode::DeleteConfirm;
+        handle_delete_key(&mut state, key(KeyCode::Char('y')));
+        assert!(state.store.profiles.is_empty());
+        // Falls back to Form when nothing left.
+        assert_eq!(state.mode, Mode::Form);
+    }
+
+    #[test]
+    fn delete_confirm_other_key_cancels() {
+        let p = Profile::new("Local".into(), TransportMode::Ws, "ws://x".into(), "s".into());
+        let mut state = make_state(vec![p]);
+        state.mode = Mode::DeleteConfirm;
+        handle_delete_key(&mut state, key(KeyCode::Char('n')));
+        assert_eq!(state.store.profiles.len(), 1);
+        assert_eq!(state.mode, Mode::List);
+    }
+}

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -94,6 +94,7 @@ impl Profile {
     pub fn purge_credentials(&self) {
         let _ = credentials::delete(&self.id, CredentialKind::Password);
         let _ = credentials::delete(&self.id, CredentialKind::Jwt);
+        let _ = credentials::delete(&self.id, CredentialKind::OauthRefresh);
     }
 
     /// Short display label combining name and URL/transport.

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -1,8 +1,10 @@
 //! Saved connection profiles.
 //!
 //! A profile bundles the transport metadata needed to dial a specific
-//! daemon. Credentials are intentionally **not** stored here — those land
-//! in the keyring in #13.
+//! daemon. Credentials live in the system keyring (see
+//! [`crate::credentials`]); the profile only carries non-secret hints
+//! (username, "has a stored password" flags) so the UI can show what
+//! state to expect.
 //!
 //! Persisted to `$XDG_CONFIG_HOME/adele-tui/profiles.json` (or
 //! `~/.config/adele-tui/profiles.json`).
@@ -11,6 +13,8 @@ use std::{env, fs, io, path::PathBuf, time::SystemTime};
 
 use desktop_assistant_client_common::{ConnectionConfig, TransportMode};
 use serde::{Deserialize, Serialize};
+
+use crate::credentials::{self, CredentialKind};
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Profile {
@@ -24,6 +28,18 @@ pub struct Profile {
     /// JWT subject claim. Only meaningful when `transport == Ws`.
     #[serde(default)]
     pub ws_subject: String,
+    /// Username for password-based login. `None` means no username/password
+    /// auth — fall back to JWT or anonymous.
+    #[serde(default)]
+    pub username: Option<String>,
+    /// True when a password has been stored in the keyring under this
+    /// profile's id. The actual secret never leaves the keyring.
+    #[serde(default)]
+    pub has_password: bool,
+    /// True when a JWT token has been stored in the keyring under this
+    /// profile's id.
+    #[serde(default)]
+    pub has_jwt: bool,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
@@ -42,19 +58,42 @@ impl Profile {
             transport,
             ws_url,
             ws_subject,
+            username: None,
+            has_password: false,
+            has_jwt: false,
         }
     }
 
+    /// Build a connection config, pulling stored credentials from the keyring.
+    /// Keyring failures are silently downgraded to "no credential" — callers
+    /// should still allow CLI/env fallback.
     pub fn to_connection_config(&self) -> ConnectionConfig {
+        let password = if self.has_password {
+            credentials::retrieve(&self.id, CredentialKind::Password).ok()
+        } else {
+            None
+        };
+        let jwt = if self.has_jwt {
+            credentials::retrieve(&self.id, CredentialKind::Jwt).ok()
+        } else {
+            None
+        };
         ConnectionConfig {
             transport_mode: self.transport,
             ws_url: self.ws_url.clone(),
             ws_subject: self.ws_subject.clone(),
-            ws_jwt: None,
-            ws_login_username: None,
-            ws_login_password: None,
+            ws_jwt: jwt,
+            ws_login_username: self.username.clone(),
+            ws_login_password: password,
             ..Default::default()
         }
+    }
+
+    /// Drop any keyring entries associated with this profile. Errors are
+    /// swallowed — there's nothing useful for a caller to do with them.
+    pub fn purge_credentials(&self) {
+        let _ = credentials::delete(&self.id, CredentialKind::Password);
+        let _ = credentials::delete(&self.id, CredentialKind::Jwt);
     }
 
     /// Short display label combining name and URL/transport.
@@ -104,6 +143,9 @@ impl ProfileStore {
         if self.last_used.as_deref() == Some(id) {
             self.last_used = None;
         }
+        // Drop the keyring entries — leaving orphaned secrets after a
+        // delete is a footgun, especially when re-adding under a new id.
+        removed.purge_credentials();
         Some(removed)
     }
 

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -1,0 +1,247 @@
+//! Saved connection profiles.
+//!
+//! A profile bundles the transport metadata needed to dial a specific
+//! daemon. Credentials are intentionally **not** stored here — those land
+//! in the keyring in #13.
+//!
+//! Persisted to `$XDG_CONFIG_HOME/adele-tui/profiles.json` (or
+//! `~/.config/adele-tui/profiles.json`).
+
+use std::{env, fs, io, path::PathBuf, time::SystemTime};
+
+use desktop_assistant_client_common::{ConnectionConfig, TransportMode};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Profile {
+    pub id: String,
+    pub name: String,
+    #[serde(with = "transport_mode_serde")]
+    pub transport: TransportMode,
+    /// WebSocket URL. Only meaningful when `transport == Ws`.
+    #[serde(default)]
+    pub ws_url: String,
+    /// JWT subject claim. Only meaningful when `transport == Ws`.
+    #[serde(default)]
+    pub ws_subject: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ProfileStore {
+    #[serde(default)]
+    pub profiles: Vec<Profile>,
+    #[serde(default)]
+    pub last_used: Option<String>,
+}
+
+impl Profile {
+    pub fn new(name: String, transport: TransportMode, ws_url: String, ws_subject: String) -> Self {
+        Self {
+            id: new_id(),
+            name,
+            transport,
+            ws_url,
+            ws_subject,
+        }
+    }
+
+    pub fn to_connection_config(&self) -> ConnectionConfig {
+        ConnectionConfig {
+            transport_mode: self.transport,
+            ws_url: self.ws_url.clone(),
+            ws_subject: self.ws_subject.clone(),
+            ws_jwt: None,
+            ws_login_username: None,
+            ws_login_password: None,
+            ..Default::default()
+        }
+    }
+
+    /// Short display label combining name and URL/transport.
+    pub fn display_label(&self) -> String {
+        let detail = match self.transport {
+            TransportMode::Ws => self.ws_url.clone(),
+            TransportMode::Dbus => "D-Bus".to_string(),
+        };
+        if detail.is_empty() {
+            self.name.clone()
+        } else {
+            format!("{}  ·  {}", self.name, detail)
+        }
+    }
+}
+
+impl ProfileStore {
+    pub fn load() -> Self {
+        let Some(path) = profiles_path() else {
+            return Self::default();
+        };
+        let Ok(bytes) = fs::read(&path) else {
+            return Self::default();
+        };
+        serde_json::from_slice(&bytes).unwrap_or_default()
+    }
+
+    pub fn save(&self) -> io::Result<()> {
+        let Some(path) = profiles_path() else {
+            return Err(io::Error::other("could not resolve profiles path"));
+        };
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let bytes = serde_json::to_vec_pretty(self)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+        fs::write(path, bytes)
+    }
+
+    pub fn add(&mut self, profile: Profile) {
+        self.profiles.push(profile);
+    }
+
+    pub fn remove(&mut self, id: &str) -> Option<Profile> {
+        let idx = self.profiles.iter().position(|p| p.id == id)?;
+        let removed = self.profiles.remove(idx);
+        if self.last_used.as_deref() == Some(id) {
+            self.last_used = None;
+        }
+        Some(removed)
+    }
+
+    pub fn mark_used(&mut self, id: &str) {
+        if self.profiles.iter().any(|p| p.id == id) {
+            self.last_used = Some(id.to_string());
+        }
+    }
+
+    pub fn last_used_index(&self) -> Option<usize> {
+        let id = self.last_used.as_deref()?;
+        self.profiles.iter().position(|p| p.id == id)
+    }
+}
+
+fn profiles_path() -> Option<PathBuf> {
+    let base = if let Ok(xdg) = env::var("XDG_CONFIG_HOME")
+        && !xdg.is_empty()
+    {
+        PathBuf::from(xdg)
+    } else {
+        let home = env::var("HOME").ok()?;
+        PathBuf::from(home).join(".config")
+    };
+    Some(base.join("adele-tui").join("profiles.json"))
+}
+
+fn new_id() -> String {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_nanos().to_string())
+        .unwrap_or_else(|_| "0".to_string())
+}
+
+mod transport_mode_serde {
+    use super::TransportMode;
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(value: &TransportMode, s: S) -> Result<S::Ok, S::Error> {
+        let token = match value {
+            TransportMode::Ws => "ws",
+            TransportMode::Dbus => "dbus",
+        };
+        s.serialize_str(token)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<TransportMode, D::Error> {
+        let token = String::deserialize(d)?;
+        match token.as_str() {
+            "ws" => Ok(TransportMode::Ws),
+            "dbus" => Ok(TransportMode::Dbus),
+            other => Err(serde::de::Error::custom(format!(
+                "unknown transport mode {other:?}"
+            ))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_serializes_transport_as_token() {
+        let profile = Profile::new(
+            "Local".into(),
+            TransportMode::Ws,
+            "ws://127.0.0.1:11339/ws".into(),
+            "desktop-tui".into(),
+        );
+        let json = serde_json::to_string(&profile).unwrap();
+        assert!(json.contains("\"transport\":\"ws\""));
+        let back: Profile = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, profile);
+    }
+
+    #[test]
+    fn unknown_transport_token_fails_loud() {
+        let json = r#"{"id":"1","name":"X","transport":"smtp","ws_url":"","ws_subject":""}"#;
+        assert!(serde_json::from_str::<Profile>(json).is_err());
+    }
+
+    #[test]
+    fn store_remove_clears_last_used_when_matches() {
+        let mut store = ProfileStore::default();
+        let p = Profile::new("a".into(), TransportMode::Ws, "ws://x".into(), "s".into());
+        let id = p.id.clone();
+        store.add(p);
+        store.mark_used(&id);
+        assert_eq!(store.last_used.as_deref(), Some(id.as_str()));
+        store.remove(&id);
+        assert!(store.last_used.is_none());
+    }
+
+    #[test]
+    fn store_mark_used_ignores_unknown_id() {
+        let mut store = ProfileStore::default();
+        store.mark_used("does-not-exist");
+        assert!(store.last_used.is_none());
+    }
+
+    #[test]
+    fn last_used_index_finds_correct_position() {
+        let mut store = ProfileStore::default();
+        let a = Profile::new("a".into(), TransportMode::Ws, "ws://a".into(), "s".into());
+        let b = Profile::new("b".into(), TransportMode::Ws, "ws://b".into(), "s".into());
+        let b_id = b.id.clone();
+        store.add(a);
+        store.add(b);
+        store.mark_used(&b_id);
+        assert_eq!(store.last_used_index(), Some(1));
+    }
+
+    #[test]
+    fn unknown_fields_in_json_are_ignored() {
+        let json = r#"{
+            "profiles": [{"id":"1","name":"X","transport":"ws","ws_url":"ws://x","ws_subject":"s","extra_field":42}],
+            "last_used": null,
+            "another_unknown": "ok"
+        }"#;
+        let store: ProfileStore = serde_json::from_str(json).unwrap();
+        assert_eq!(store.profiles.len(), 1);
+        assert_eq!(store.profiles[0].name, "X");
+    }
+
+    #[test]
+    fn to_connection_config_strips_credentials() {
+        let p = Profile::new(
+            "Local".into(),
+            TransportMode::Ws,
+            "ws://127.0.0.1:11339/ws".into(),
+            "desktop-tui".into(),
+        );
+        let cfg = p.to_connection_config();
+        assert_eq!(cfg.transport_mode, TransportMode::Ws);
+        assert_eq!(cfg.ws_url, "ws://127.0.0.1:11339/ws");
+        assert!(cfg.ws_jwt.is_none());
+        assert!(cfg.ws_login_username.is_none());
+        assert!(cfg.ws_login_password.is_none());
+    }
+}


### PR DESCRIPTION
## Summary

Full Authorization Code + PKCE flow ported from `adele-gtk/src/oauth.rs` with TUI-appropriate plumbing.

- `src/oauth.rs`: discovery (`/auth/config`), local loopback listener, browser launch (`open`), PKCE code exchange, refresh helper. 120s redirect timeout.
- Daemons predating auth discovery get `methods=[password]` as a graceful fallback.
- New `CredentialKind::OauthRefresh` so refresh tokens live next to access tokens in the keyring.
- `Profile::has_jwt` is now populated by the OAuth flow (was a stub from #13). `Profile::to_connection_config()` already pulls from keyring → access token rides as `ws_jwt`.

## Picker integration

- Press **`Ctrl+L`** in the form to start OAuth against the current URL field. The form pre-allocates a stable id so tokens can be stored before save.
- Picker's outer loop drains an `oauth_pending` flag and awaits the flow between iterations. A `busy` status line drives the redraw — UI stays responsive and shows "Discovering auth config...", then "Browser opened — complete sign-in to continue..." until tokens arrive.
- On success, the form is marked `has_oauth_tokens=true` and submitting saves with `has_jwt=true`.
- On failure (timeout, server doesn't advertise OIDC, browser refused, etc.), an error line surfaces in the picker.

## Stacked on #13

Branched from `feat/keyring-storage`. Re-base to `main` after #12 + #13 land.

## Out of scope (follow-ups)

- **Automatic refresh-on-401.** `refresh_access_token` is implemented and exported but not wired to a retry path yet. Expired tokens currently require a fresh `Ctrl+L`.
- **Headless / SSH device-code flow.** The acceptance criteria mention this; today the flow requires a working `xdg-open`-style browser. A copy-paste-redirect or device-code variant can ship as a separate PR.

## Test plan

- [x] `cargo test` — 98 passing (+4 new in `oauth.rs`)
- [x] `cargo build` clean
- [ ] Manual: OAuth-capable daemon, run picker → fill URL → `Ctrl+L` → browser opens, sign in, "Signed in — save the profile to keep these tokens" → save → connect succeeds with bearer JWT
- [ ] Manual: cancel browser tab → 120s timeout, error in picker
- [ ] Manual: daemon without OIDC → "Server does not advertise OAuth/OIDC support"

🤖 Generated with [Claude Code](https://claude.com/claude-code)