### PR TITLE
Syntax-highlight fenced code blocks (closes #8)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,11 +16,18 @@ dependencies = [
  "ratatui",
  "serde",
  "serde_json",
+ "syntect",
  "tokio",
  "tracing",
  "tracing-subscriber",
  "tui-textarea",
 ]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
@@ -175,6 +182,30 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -385,6 +416,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -467,9 +507,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "desktop-assistant-api-model"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#b1cd211d62e3b7a2656fa802634dfb3c8a98e4a6"
+source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#533f80265b381e5aaf03ec7320ce5207aa31de94"
 dependencies = [
  "desktop-assistant-core",
  "serde",
@@ -479,7 +528,7 @@ dependencies = [
 [[package]]
 name = "desktop-assistant-client-common"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#b1cd211d62e3b7a2656fa802634dfb3c8a98e4a6"
+source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#533f80265b381e5aaf03ec7320ce5207aa31de94"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -499,8 +548,9 @@ dependencies = [
 [[package]]
 name = "desktop-assistant-core"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#b1cd211d62e3b7a2656fa802634dfb3c8a98e4a6"
+source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#533f80265b381e5aaf03ec7320ce5207aa31de94"
 dependencies = [
+ "async-trait",
  "chrono",
  "serde",
  "serde_json",
@@ -616,6 +666,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -626,6 +687,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -1248,6 +1319,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1326,6 +1403,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1345,6 +1432,12 @@ checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-traits"
@@ -1431,6 +1524,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "plist"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
+dependencies = [
+ "base64",
+ "indexmap",
+ "quick-xml",
+ "serde",
+ "time",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1438,6 +1544,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1485,6 +1597,15 @@ dependencies = [
  "bitflags",
  "memchr",
  "unicase",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1988,6 +2109,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2087,6 +2214,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "syntect"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656b45c05d95a5704399aeef6bd0ddec7b2b3531b7c9e900abbf7c4d2190c925"
+dependencies = [
+ "bincode",
+ "fancy-regex",
+ "flate2",
+ "fnv",
+ "once_cell",
+ "plist",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror 2.0.18",
+ "walkdir",
+ "yaml-rust",
+]
+
+[[package]]
 name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2167,6 +2315,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -3179,6 +3358,15 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ ratatui = { version = "0.29", features = ["unstable-rendered-line-info"] }
 crossterm = { version = "0.28", features = ["event-stream"] }
 futures = "0.3"
 pulldown-cmark = { version = "0.13", default-features = false }
+syntect = { version = "5", default-features = false, features = ["default-fancy"] }
 tui-textarea = "0.7"
 # Shared protocol + transport crates live in the desktop-assistant repo.
 # Cargo resolves the package by name from that workspace; Cargo.lock pins

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -1,17 +1,24 @@
 //! Renders markdown text into ratatui `Line`s.
 //!
 //! Supports inline formatting (bold, italic, inline code, links), headings,
-//! bullet/numbered lists, fenced code blocks (rendered with a distinct muted
-//! style — language-aware highlighting belongs in #8), and a simple aligned
-//! grid for tables.
+//! bullet/numbered lists, fenced code blocks (with language-aware syntax
+//! highlighting via `syntect`), and a simple aligned grid for tables.
 //!
 //! The output is plain `Line`s of styled `Span`s — no widget state — so it
 //! plugs straight into the existing `Paragraph::new(lines)` flow.
 
-use pulldown_cmark::{Event, HeadingLevel, Options, Parser, Tag, TagEnd};
+use std::sync::OnceLock;
+
+use pulldown_cmark::{CodeBlockKind, Event, HeadingLevel, Options, Parser, Tag, TagEnd};
 use ratatui::{
     style::{Color, Modifier, Style},
     text::{Line, Span},
+};
+use syntect::{
+    easy::HighlightLines,
+    highlighting::{FontStyle, Style as SynStyle, Theme, ThemeSet},
+    parsing::{SyntaxReference, SyntaxSet},
+    util::LinesWithEndings,
 };
 
 const COLOR_HEADING: Color = Color::Rgb(166, 182, 255);
@@ -20,6 +27,55 @@ const COLOR_CODE_BG: Color = Color::Rgb(40, 44, 56);
 const COLOR_LINK: Color = Color::Rgb(132, 204, 232);
 const COLOR_BLOCKQUOTE: Color = Color::Rgb(170, 178, 196);
 const COLOR_TABLE_BORDER: Color = Color::Rgb(82, 90, 110);
+
+/// Theme used for code-block syntax highlighting. `base16-ocean.dark` reads
+/// well on the dark TUI background and ships with syntect by default.
+const HIGHLIGHT_THEME: &str = "base16-ocean.dark";
+
+struct HighlightAssets {
+    syntaxes: SyntaxSet,
+    theme: Theme,
+}
+
+fn highlight_assets() -> &'static HighlightAssets {
+    static ASSETS: OnceLock<HighlightAssets> = OnceLock::new();
+    ASSETS.get_or_init(|| {
+        let syntaxes = SyntaxSet::load_defaults_newlines();
+        let themes = ThemeSet::load_defaults();
+        let theme = themes
+            .themes
+            .get(HIGHLIGHT_THEME)
+            .cloned()
+            .unwrap_or_else(|| themes.themes.values().next().cloned().unwrap_or_default());
+        HighlightAssets { syntaxes, theme }
+    })
+}
+
+fn syntax_for_lang<'a>(syntaxes: &'a SyntaxSet, lang: Option<&str>) -> Option<&'a SyntaxReference> {
+    let token = lang?.trim();
+    if token.is_empty() {
+        return None;
+    }
+    // Try by token (e.g. "rust"), then file extension (".rs").
+    syntaxes
+        .find_syntax_by_token(token)
+        .or_else(|| syntaxes.find_syntax_by_extension(token))
+}
+
+fn synstyle_to_ratatui(style: SynStyle) -> Style {
+    let fg = Color::Rgb(style.foreground.r, style.foreground.g, style.foreground.b);
+    let mut out = Style::default().fg(fg).bg(COLOR_CODE_BG);
+    if style.font_style.contains(FontStyle::BOLD) {
+        out = out.add_modifier(Modifier::BOLD);
+    }
+    if style.font_style.contains(FontStyle::ITALIC) {
+        out = out.add_modifier(Modifier::ITALIC);
+    }
+    if style.font_style.contains(FontStyle::UNDERLINE) {
+        out = out.add_modifier(Modifier::UNDERLINED);
+    }
+    out
+}
 
 /// Render a markdown source string into styled lines.
 ///
@@ -50,6 +106,11 @@ struct Renderer {
     in_code_span: bool,
     /// Are we inside a fenced code block?
     in_code_block: bool,
+    /// Language hint for the active code block (from a fenced opener).
+    code_lang: Option<String>,
+    /// Buffered code-block source — flushed to syntect on close so the
+    /// highlighter sees a complete (line-terminated) input.
+    code_buffer: String,
     /// Are we inside a link? Active link target if so.
     link_target: Option<String>,
     /// List nesting state. `Some(Some(n))` = numbered list at index n;
@@ -79,6 +140,8 @@ impl Renderer {
             modifier: Modifier::empty(),
             in_code_span: false,
             in_code_block: false,
+            code_lang: None,
+            code_buffer: String::new(),
             link_target: None,
             list_stack: Vec::new(),
             heading_level: None,
@@ -131,9 +194,21 @@ impl Renderer {
                 self.flush_line();
                 self.blockquote_depth += 1;
             }
-            Tag::CodeBlock(_) => {
+            Tag::CodeBlock(kind) => {
                 self.flush_line();
                 self.in_code_block = true;
+                self.code_buffer.clear();
+                self.code_lang = match kind {
+                    CodeBlockKind::Fenced(s) => {
+                        let trimmed = s.trim();
+                        if trimmed.is_empty() {
+                            None
+                        } else {
+                            Some(trimmed.to_string())
+                        }
+                    }
+                    CodeBlockKind::Indented => None,
+                };
             }
             Tag::List(start) => {
                 self.flush_line();
@@ -214,7 +289,10 @@ impl Renderer {
             }
             TagEnd::CodeBlock => {
                 self.flush_line();
+                let buffered = std::mem::take(&mut self.code_buffer);
+                let lang = self.code_lang.take();
                 self.in_code_block = false;
+                self.emit_highlighted_code_block(&buffered, lang.as_deref());
                 self.lines.push(Line::from(""));
             }
             TagEnd::List(_) => {
@@ -263,18 +341,9 @@ impl Renderer {
 
     fn push_text(&mut self, text: &str) {
         if self.in_code_block {
-            for line in text.split('\n') {
-                self.current.push(Span::styled(
-                    format!(" {line} "),
-                    Style::default().fg(COLOR_CODE_FG).bg(COLOR_CODE_BG),
-                ));
-                self.flush_line();
-            }
-            // Trailing flush already happened; drop the empty extra line that
-            // the trailing '\n' would create.
-            if text.ends_with('\n') && self.lines.last().is_some_and(|l| l.spans.is_empty()) {
-                self.lines.pop();
-            }
+            // Buffer the entire block; we run syntect once on close so the
+            // highlighter sees the full source and stays in sync across lines.
+            self.code_buffer.push_str(text);
             return;
         }
 
@@ -366,6 +435,71 @@ impl Renderer {
             self.lines.pop();
         }
         self.lines
+    }
+
+    fn emit_highlighted_code_block(&mut self, source: &str, lang: Option<&str>) {
+        if source.is_empty() {
+            return;
+        }
+        let assets = highlight_assets();
+        let syntax = syntax_for_lang(&assets.syntaxes, lang);
+        match syntax {
+            Some(syn) => {
+                let mut highlighter = HighlightLines::new(syn, &assets.theme);
+                for raw_line in LinesWithEndings::from(source) {
+                    let regions = highlighter
+                        .highlight_line(raw_line, &assets.syntaxes)
+                        .unwrap_or_default();
+                    let trimmed_line = raw_line.trim_end_matches('\n');
+                    let mut spans: Vec<Span<'static>> = Vec::with_capacity(regions.len() + 2);
+                    // Leading gutter so the bg covers a small left margin.
+                    spans.push(Span::styled(
+                        " ",
+                        Style::default().bg(COLOR_CODE_BG),
+                    ));
+                    if regions.is_empty() {
+                        spans.push(Span::styled(
+                            trimmed_line.to_string(),
+                            Style::default().fg(COLOR_CODE_FG).bg(COLOR_CODE_BG),
+                        ));
+                    } else {
+                        for (style, segment) in regions {
+                            // Strip the trailing newline that LinesWithEndings keeps —
+                            // ratatui adds its own line break between Line entries.
+                            let text = segment.trim_end_matches('\n').to_string();
+                            if text.is_empty() {
+                                continue;
+                            }
+                            spans.push(Span::styled(text, synstyle_to_ratatui(style)));
+                        }
+                    }
+                    spans.push(Span::styled(
+                        " ",
+                        Style::default().bg(COLOR_CODE_BG),
+                    ));
+                    self.lines.push(Line::from(spans));
+                }
+            }
+            None => {
+                // Unknown language — fall back to the muted plain code style.
+                let style = Style::default().fg(COLOR_CODE_FG).bg(COLOR_CODE_BG);
+                for raw_line in source.split('\n') {
+                    self.lines.push(Line::from(Span::styled(
+                        format!(" {raw_line} "),
+                        style,
+                    )));
+                }
+                // Drop the trailing empty line caused by the source ending in '\n'.
+                if source.ends_with('\n')
+                    && self
+                        .lines
+                        .last()
+                        .is_some_and(|l| l.spans.iter().all(|s| s.content.trim().is_empty()))
+                {
+                    self.lines.pop();
+                }
+            }
+        }
     }
 
     fn render_table(&mut self, t: TableState) {
@@ -536,5 +670,58 @@ mod tests {
     fn empty_input_produces_no_lines() {
         let lines = render_test("");
         assert!(lines.is_empty());
+    }
+
+    // --- Syntax highlighting (#8) ---
+
+    #[test]
+    fn rust_code_block_tokens_get_distinct_colors() {
+        let src = "```rust\nfn main() { let x = 1; }\n```\n";
+        let lines = render_test(src);
+        // Collect unique foreground colors on spans inside the code block.
+        let fgs: std::collections::HashSet<_> = lines
+            .iter()
+            .flat_map(|l| l.spans.iter())
+            .filter(|s| s.style.bg == Some(COLOR_CODE_BG) && !s.content.trim().is_empty())
+            .filter_map(|s| s.style.fg)
+            .collect();
+        // Highlighted rust should produce more than one distinct fg color
+        // (keyword vs. identifier vs. literal vs. punctuation).
+        assert!(
+            fgs.len() > 1,
+            "expected multiple foreground colors, got {fgs:?}"
+        );
+    }
+
+    #[test]
+    fn unknown_language_falls_back_to_plain_code_style() {
+        let src = "```not-a-real-lang\nliteral content\n```\n";
+        let lines = render_test(src);
+        let plain_span = lines.iter().flat_map(|l| l.spans.iter()).any(|s| {
+            s.style.bg == Some(COLOR_CODE_BG) && s.content.contains("literal content")
+        });
+        assert!(plain_span);
+    }
+
+    #[test]
+    fn unfenced_code_block_uses_plain_style() {
+        // No language tag — fallback path.
+        let src = "```\nplain block content\n```\n";
+        let lines = render_test(src);
+        let plain_span = lines.iter().flat_map(|l| l.spans.iter()).any(|s| {
+            s.style.bg == Some(COLOR_CODE_BG) && s.content.contains("plain block content")
+        });
+        assert!(plain_span);
+    }
+
+    #[test]
+    fn syntax_for_lang_handles_aliases_and_extensions() {
+        let assets = highlight_assets();
+        // Common aliases that should resolve to a syntax.
+        assert!(syntax_for_lang(&assets.syntaxes, Some("rust")).is_some());
+        assert!(syntax_for_lang(&assets.syntaxes, Some("py")).is_some());
+        // Empty / unknown returns None.
+        assert!(syntax_for_lang(&assets.syntaxes, Some("")).is_none());
+        assert!(syntax_for_lang(&assets.syntaxes, None).is_none());
     }
 }


### PR DESCRIPTION
Re-opens #27 (the original PR closed when its base branch was deleted on #26 merge).

## Summary

Adds language-aware syntax highlighting to fenced code blocks via `syntect` (5.x), themed with `base16-ocean.dark`.

- Captures the language hint from `pulldown_cmark::CodeBlockKind::Fenced` and resolves it through syntect's syntax set (token, then extension).
- Buffers the whole code block during parsing and runs syntect once on close so multi-line constructs (block comments, raw strings, indentation-sensitive grammars) tokenize correctly.
- Unknown languages and unfenced blocks keep the existing muted plain style.
- Each line keeps its dark code-block background so the block reads as a unit.

## Test plan

- [x] `cargo test` — 134 passing
- [x] `cargo build` clean
- [ ] Manual: rust snippet → keyword/string/type colors
- [ ] Manual: no language → plain style
- [ ] Manual: bogus language → plain style

🤖 Generated with [Claude Code](https://claude.com/claude-code)