### PR TITLE
Switch connection without restart with F2 (closes #15)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -94,6 +94,9 @@ pub struct App {
     /// Whether the conversation list pane is visible. When `false`, the chat
     /// panel takes the full window width.
     pub show_sidebar: bool,
+    /// Set when the user asks to switch to a different connection. Causes
+    /// the chat loop to exit cleanly so the picker can run again.
+    pub switch_requested: bool,
 }
 
 impl App {
@@ -117,6 +120,7 @@ impl App {
             show_debug: false,
             assistant_status: None,
             show_sidebar: true,
+            switch_requested: false,
         }
     }
 
@@ -990,6 +994,11 @@ mod tests {
             app.current_conversation.as_ref().unwrap().title,
             "Renamed"
         );
+    }
+
+    #[test]
+    fn switch_requested_default_false() {
+        assert!(!App::new().switch_requested);
     }
 
     // --- Scroll tests ---

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -24,6 +24,7 @@ pub enum Action {
     CancelRename,
     ToggleDebug,
     ToggleSidebar,
+    SwitchConnection,
 }
 
 /// Handle key events that we intercept before passing to textarea.
@@ -31,6 +32,12 @@ pub enum Action {
 pub fn handle_key_event(key: KeyEvent, mode: &InputMode) -> Option<Action> {
     let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
     let alt = key.modifiers.contains(KeyModifiers::ALT);
+
+    // F2 opens the connection picker from any mode. Chosen over Ctrl+Shift+C
+    // since terminal emulators commonly intercept that for clipboard copy.
+    if key.code == KeyCode::F(2) && key.modifiers.is_empty() {
+        return Some(Action::SwitchConnection);
+    }
 
     // Ctrl combos. Most apply across modes, but in Renaming we forward
     // all Ctrl combos to the rename textarea (Ctrl+a/e/u/k word/line edits).
@@ -532,6 +539,24 @@ mod tests {
                 &InputMode::Editing
             ),
             Some(Action::ToggleSidebar)
+        );
+    }
+
+    // --- F2 switch connection ---
+
+    #[test]
+    fn f2_triggers_switch_in_normal() {
+        assert_eq!(
+            handle_key_event(key(KeyCode::F(2)), &InputMode::Normal),
+            Some(Action::SwitchConnection)
+        );
+    }
+
+    #[test]
+    fn f2_triggers_switch_in_editing() {
+        assert_eq!(
+            handle_key_event(key(KeyCode::F(2)), &InputMode::Editing),
+            Some(Action::SwitchConnection)
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -185,32 +185,60 @@ fn any_explicit_connection_arg(matches: &clap::ArgMatches) -> bool {
         })
 }
 
-/// Decide between picker-driven and CLI-driven connection, then hand off
-/// to the chat loop.
+/// Outcome of a single chat session loop. `Switch` re-enters the picker;
+/// `Quit` exits the program.
+enum RunOutcome {
+    Quit,
+    Switch,
+}
+
+/// Decide between picker-driven and CLI-driven connection, then run the
+/// chat loop. Loops back into the picker when the user requests a
+/// connection switch.
 async fn run_app(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     cli: CliArgs,
     cli_explicit: bool,
 ) -> Result<()> {
-    let store = ProfileStore::load();
-
-    let config = if cli_explicit || store.profiles.is_empty() {
+    // First connection: respect explicit CLI/env args; otherwise picker if
+    // we have profiles, else fall back to CLI defaults.
+    let mut config = if cli_explicit {
         ConnectionConfig::from(cli)
     } else {
-        let (outcome, _store) = picker::run(terminal, store).await?;
-        match outcome {
-            PickerOutcome::Selected(profile) => profile.to_connection_config(),
-            PickerOutcome::Cancelled => return Ok(()),
+        let store = ProfileStore::load();
+        if store.profiles.is_empty() {
+            ConnectionConfig::from(cli)
+        } else {
+            match picker::run(terminal, store).await?.0 {
+                PickerOutcome::Selected(profile) => profile.to_connection_config(),
+                PickerOutcome::Cancelled => return Ok(()),
+            }
         }
     };
 
-    run(terminal, &config).await
+    loop {
+        match run(terminal, &config).await? {
+            RunOutcome::Quit => return Ok(()),
+            RunOutcome::Switch => {
+                // Always show the picker on switch — even if CLI args were
+                // used initially, the user is opting into profile-based
+                // selection now.
+                let store = ProfileStore::load();
+                match picker::run(terminal, store).await?.0 {
+                    PickerOutcome::Selected(profile) => {
+                        config = profile.to_connection_config();
+                    }
+                    PickerOutcome::Cancelled => return Ok(()),
+                }
+            }
+        }
+    }
 }
 
 async fn run(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     config: &ConnectionConfig,
-) -> Result<()> {
+) -> Result<RunOutcome> {
     let mut app = App::new();
     let settings = Settings::load();
     app.show_debug = settings.show_debug;
@@ -244,7 +272,10 @@ async fn run(
         terminal.draw(|f| ui::draw(f, &mut app))?;
 
         if app.should_quit {
-            return Ok(());
+            return Ok(RunOutcome::Quit);
+        }
+        if app.switch_requested {
+            return Ok(RunOutcome::Switch);
         }
 
         // The reconnect timer is built fresh each loop iteration so that it
@@ -515,6 +546,10 @@ async fn handle_action(
             } else {
                 "Conversation list hidden (Ctrl+B to show)".into()
             };
+        }
+        Action::SwitchConnection => {
+            app.switch_requested = true;
+            app.status_message = "Switching connection...".into();
         }
     }
 }


### PR DESCRIPTION
Re-opens #30 (closed when its base branch was deleted on #29 merge). Substantive changes unchanged from the original PR — see #30 for full description.