### PR TITLE
Per-conversation model selector with Ctrl+M (closes #41)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -105,6 +105,13 @@ pub struct App {
     pub connections_requested: bool,
     /// Set when the user asks to open the purposes manager.
     pub purposes_requested: bool,
+    /// Set when the user asks to open the per-conversation model picker.
+    pub model_picker_requested: bool,
+    /// One-shot override staged by the model picker. Applied to the next
+    /// `SendPrompt` and then cleared — the daemon persists it as the
+    /// conversation's `last_model_selection`, so subsequent prompts pick
+    /// it up automatically.
+    pub pending_model_override: Option<desktop_assistant_api_model::SendPromptOverride>,
 }
 
 impl App {
@@ -132,7 +139,35 @@ impl App {
             kb_requested: false,
             connections_requested: false,
             purposes_requested: false,
+            model_picker_requested: false,
+            pending_model_override: None,
         }
+    }
+
+    /// Apply the user's model picker selection to local state so the
+    /// chat title/status reflects it immediately. The override is staged
+    /// for the next prompt; once that prompt fires the daemon persists it
+    /// as `last_model_selection`.
+    pub fn apply_model_override(
+        &mut self,
+        override_selection: desktop_assistant_api_model::SendPromptOverride,
+    ) {
+        if let Some(conv) = self.current_conversation.as_mut() {
+            conv.model_selection =
+                Some(desktop_assistant_api_model::ConversationModelSelectionView {
+                    connection_id: override_selection.connection_id.clone(),
+                    model_id: override_selection.model_id.clone(),
+                    effort: override_selection.effort,
+                });
+        }
+        self.pending_model_override = Some(override_selection);
+    }
+
+    /// Take and clear the pending override. Called once per `SendPrompt`.
+    pub fn take_pending_override(
+        &mut self,
+    ) -> Option<desktop_assistant_api_model::SendPromptOverride> {
+        self.pending_model_override.take()
     }
 
     pub fn set_assistant_status(&mut self, message: impl Into<String>) {
@@ -1010,6 +1045,46 @@ mod tests {
     #[test]
     fn switch_requested_default_false() {
         assert!(!App::new().switch_requested);
+    }
+
+    #[test]
+    fn apply_model_override_updates_current_conversation_and_stages_pending() {
+        let mut app = App::new();
+        app.current_conversation = Some(ConversationDetail {
+            id: "c1".into(),
+            title: "Chat".into(),
+            messages: vec![],
+            model_selection: None,
+        });
+        let ovr = desktop_assistant_api_model::SendPromptOverride {
+            connection_id: "work".into(),
+            model_id: "claude-3-5".into(),
+            effort: None,
+        };
+        app.apply_model_override(ovr.clone());
+        assert!(app.pending_model_override.is_some());
+        let sel = app
+            .current_conversation
+            .as_ref()
+            .unwrap()
+            .model_selection
+            .as_ref()
+            .unwrap();
+        assert_eq!(sel.connection_id, "work");
+        assert_eq!(sel.model_id, "claude-3-5");
+    }
+
+    #[test]
+    fn take_pending_override_clears_after_first_take() {
+        let mut app = App::new();
+        let ovr = desktop_assistant_api_model::SendPromptOverride {
+            connection_id: "a".into(),
+            model_id: "b".into(),
+            effort: None,
+        };
+        app.pending_model_override = Some(ovr);
+        assert!(app.take_pending_override().is_some());
+        assert!(app.take_pending_override().is_none());
     }
 
     // --- Scroll tests ---

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -28,6 +28,7 @@ pub enum Action {
     OpenKnowledgeBase,
     OpenConnections,
     OpenPurposes,
+    OpenModelPicker,
 }
 
 /// Handle key events that we intercept before passing to textarea.
@@ -65,6 +66,7 @@ pub fn handle_key_event(key: KeyEvent, mode: &InputMode) -> Option<Action> {
             KeyCode::Char('t') => Some(Action::ToggleDebug),
             KeyCode::Char('b') => Some(Action::ToggleSidebar),
             KeyCode::Char('k') => Some(Action::OpenKnowledgeBase),
+            KeyCode::Char('m') => Some(Action::OpenModelPicker),
             _ => None,
         };
     }
@@ -627,6 +629,30 @@ mod tests {
         assert_eq!(
             handle_key_event(key(KeyCode::F(4)), &InputMode::Editing),
             Some(Action::OpenPurposes)
+        );
+    }
+
+    // --- Ctrl+M opens model picker ---
+
+    #[test]
+    fn ctrl_m_opens_model_picker_in_normal() {
+        assert_eq!(
+            handle_key_event(
+                key_with_mod(KeyCode::Char('m'), KeyModifiers::CONTROL),
+                &InputMode::Normal
+            ),
+            Some(Action::OpenModelPicker)
+        );
+    }
+
+    #[test]
+    fn ctrl_m_opens_model_picker_in_editing() {
+        assert_eq!(
+            handle_key_event(
+                key_with_mod(KeyCode::Char('m'), KeyModifiers::CONTROL),
+                &InputMode::Editing
+            ),
+            Some(Action::OpenModelPicker)
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod keys;
 pub mod markdown;
 pub mod oauth;
 pub mod picker;
+pub mod model_selector;
 pub mod profile;
 pub mod purposes;
 pub mod settings;

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod keys;
 mod markdown;
 mod oauth;
 mod picker;
+mod model_selector;
 mod profile;
 mod purposes;
 mod settings;
@@ -321,6 +322,26 @@ async fn run(
             continue;
         }
 
+        if app.model_picker_requested {
+            app.model_picker_requested = false;
+            if let Some(client) = client.as_ref() {
+                let current = app
+                    .current_conversation
+                    .as_ref()
+                    .and_then(|c| c.model_selection.clone());
+                match model_selector::run(terminal, client, current).await {
+                    Ok(model_selector::Outcome::Selected(picked)) => {
+                        let label = format!("{} · {}", picked.connection_id, picked.model_id);
+                        app.apply_model_override(picked);
+                        app.status_message = format!("Model: {label} (applies to next message)");
+                    }
+                    Ok(model_selector::Outcome::Cancelled) => {}
+                    Err(e) => app.status_message = format!("Model picker error: {e}"),
+                }
+            }
+            continue;
+        }
+
         tokio::select! {
             Some(Ok(evt)) = event_stream.next() => {
                 if let Event::Key(key) = evt {
@@ -481,7 +502,24 @@ async fn handle_action(
             if let Some((conv_id, prompt)) = app.submit_prompt()
                 && let Some(client) = client.as_ref()
             {
-                match client.send_prompt(&conv_id, &prompt).await {
+                let override_selection = app.take_pending_override();
+                // Use the WS override path when one was staged via the
+                // model picker; the trait-level `send_prompt` only takes
+                // the bare prompt. D-Bus + override isn't supported yet —
+                // we fall back to plain send and warn.
+                let result = match (override_selection, client.as_ws()) {
+                    (Some(ovr), Some(ws)) => {
+                        ws.send_prompt_with_override(&conv_id, &prompt, Some(ovr)).await
+                    }
+                    (Some(_), None) => {
+                        app.status_message =
+                            "Model override only works over WebSocket — sent without override"
+                                .into();
+                        client.send_prompt(&conv_id, &prompt).await
+                    }
+                    (None, _) => client.send_prompt(&conv_id, &prompt).await,
+                };
+                match result {
                     Ok(request_id) if request_id.is_empty() => {
                         app.start_streaming_without_request_id()
                     }
@@ -606,6 +644,13 @@ async fn handle_action(
                 app.purposes_requested = true;
             } else {
                 app.status_message = "Not connected — purposes manager unavailable".into();
+            }
+        }
+        Action::OpenModelPicker => {
+            if client.is_some() {
+                app.model_picker_requested = true;
+            } else {
+                app.status_message = "Not connected — model picker unavailable".into();
             }
         }
     }

--- a/src/model_selector.rs
+++ b/src/model_selector.rs
@@ -1,0 +1,456 @@
+//! Per-conversation model selector.
+//!
+//! `Ctrl+M` from the chat opens a centered picker listing flattened
+//! `Connection · Model` entries from `list_available_models`. Confirming
+//! a row stages a `SendPromptOverride` that rides on the next
+//! `SendPrompt`; after the daemon persists it as `last_model_selection`,
+//! subsequent prompts inherit the choice automatically.
+//!
+//! The current pick is hydrated from `ConversationDetail.model_selection`
+//! when the conversation loads, so re-opening the picker pre-highlights
+//! the right entry.
+//!
+//! Keys
+//! ----
+//! - `j/k` or arrows: navigate
+//! - `Enter`: confirm + close
+//! - `r`: refresh model list (forces the daemon to repopulate connector
+//!   caches — relevant for Bedrock)
+//! - `Esc` / `q`: close without changing
+
+use std::io;
+
+use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
+use desktop_assistant_api_model::{ConversationModelSelectionView, ModelListing, SendPromptOverride};
+use desktop_assistant_client_common::TransportClient;
+use futures::StreamExt;
+use ratatui::{
+    Frame, Terminal,
+    backend::CrosstermBackend,
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph},
+};
+
+const COLOR_BORDER: Color = Color::Rgb(82, 104, 173);
+const COLOR_TITLE: Color = Color::Rgb(166, 182, 255);
+const COLOR_HINT_KEY: Color = Color::Rgb(216, 223, 236);
+const COLOR_HINT_DESC: Color = Color::Rgb(143, 153, 174);
+const COLOR_HINT_SEP: Color = Color::Rgb(82, 90, 110);
+const COLOR_LIST_HIGHLIGHT: Color = Color::Rgb(72, 102, 180);
+const COLOR_LIST_HIGHLIGHT_FG: Color = Color::Rgb(245, 248, 255);
+const COLOR_ERROR: Color = Color::Rgb(232, 130, 130);
+const COLOR_CURRENT_PICK: Color = Color::Rgb(255, 207, 119);
+
+/// Outcome of running the picker.
+pub enum Outcome {
+    /// User picked a model. Caller should stage this as a one-shot
+    /// override on the next `SendPrompt`.
+    Selected(SendPromptOverride),
+    /// User pressed Esc / q without picking.
+    Cancelled,
+}
+
+struct State {
+    models: Vec<ModelListing>,
+    selected: usize,
+    /// The conversation's current selection, used to pre-highlight a row
+    /// and mark it with a star in the list.
+    current: Option<ConversationModelSelectionView>,
+    error: Option<String>,
+    busy: Option<String>,
+    outcome: Option<Outcome>,
+}
+
+/// Run the picker until the user confirms or cancels.
+pub async fn run(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    client: &TransportClient,
+    current: Option<ConversationModelSelectionView>,
+) -> anyhow::Result<Outcome> {
+    let mut state = State {
+        models: Vec::new(),
+        selected: 0,
+        current,
+        error: None,
+        busy: Some("Loading models...".into()),
+        outcome: None,
+    };
+
+    refresh(&mut state, client, false).await;
+    seed_selection(&mut state);
+
+    let mut events = crossterm::event::EventStream::new();
+    loop {
+        terminal.draw(|f| draw(f, &state))?;
+
+        if let Some(outcome) = state.outcome.take() {
+            return Ok(outcome);
+        }
+
+        let evt = match events.next().await {
+            Some(Ok(e)) => e,
+            Some(Err(_)) | None => return Ok(Outcome::Cancelled),
+        };
+        let Event::Key(key) = evt else { continue };
+        if key.kind == KeyEventKind::Release {
+            continue;
+        }
+        handle_key(&mut state, key, client).await;
+    }
+}
+
+async fn handle_key(state: &mut State, key: KeyEvent, client: &TransportClient) {
+    match (key.code, key.modifiers) {
+        (KeyCode::Esc | KeyCode::Char('q'), m) if m.is_empty() => {
+            state.outcome = Some(Outcome::Cancelled);
+        }
+        (KeyCode::Char('j') | KeyCode::Down, m) if m.is_empty() => advance(state, 1),
+        (KeyCode::Char('k') | KeyCode::Up, m) if m.is_empty() => advance(state, -1),
+        (KeyCode::Char('r'), KeyModifiers::NONE) => refresh(state, client, true).await,
+        (KeyCode::Enter, m) if m.is_empty() => {
+            if let Some(model) = state.models.get(state.selected) {
+                state.outcome = Some(Outcome::Selected(SendPromptOverride {
+                    connection_id: model.connection_id.clone(),
+                    model_id: model.model.id.clone(),
+                    // The picker doesn't expose effort yet — defer to the
+                    // daemon's per-purpose default. Keyboard-first effort
+                    // selection can ride on a follow-up.
+                    effort: None,
+                }));
+            }
+        }
+        _ => {}
+    }
+}
+
+fn advance(state: &mut State, delta: i32) {
+    let len = state.models.len();
+    if len == 0 {
+        return;
+    }
+    let mut idx = state.selected as i32 + delta;
+    if idx < 0 {
+        idx = (len as i32) - 1;
+    }
+    if idx >= len as i32 {
+        idx = 0;
+    }
+    state.selected = idx as usize;
+}
+
+async fn refresh(state: &mut State, client: &TransportClient, refresh_cache: bool) {
+    let Some(ws) = client.as_ws() else {
+        state.error = Some(
+            "Model selection is only available over WebSocket — switch transport with --transport ws"
+                .into(),
+        );
+        state.busy = None;
+        return;
+    };
+    state.busy = Some(if refresh_cache {
+        "Refreshing models from daemon...".into()
+    } else {
+        "Loading models...".into()
+    });
+    match ws.list_available_models(None, refresh_cache).await {
+        Ok(models) => {
+            state.models = models;
+            state.busy = None;
+            seed_selection(state);
+        }
+        Err(e) => {
+            state.error = Some(format!("Failed to load models: {e}"));
+            state.busy = None;
+        }
+    }
+}
+
+/// Pre-highlight the row matching the conversation's current selection.
+fn seed_selection(state: &mut State) {
+    let Some(current) = &state.current else { return };
+    if let Some(idx) = state
+        .models
+        .iter()
+        .position(|m| m.connection_id == current.connection_id && m.model.id == current.model_id)
+    {
+        state.selected = idx;
+    }
+}
+
+// --- Rendering ---
+
+fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {
+    let w = width.min(area.width);
+    let h = height.min(area.height);
+    Rect {
+        x: area.x + (area.width.saturating_sub(w)) / 2,
+        y: area.y + (area.height.saturating_sub(h)) / 2,
+        width: w,
+        height: h,
+    }
+}
+
+fn draw(f: &mut Frame, state: &State) {
+    let area = f.area();
+    // Picker is modal but doesn't take the whole screen — overlay on top
+    // of whatever the chat last drew.
+    let popup_w = 80.min(area.width.saturating_sub(8));
+    let popup_h = 24.min(area.height.saturating_sub(4));
+    let popup = centered_rect(popup_w, popup_h, area);
+    f.render_widget(Clear, popup);
+
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(2),
+            Constraint::Min(5),
+            Constraint::Length(1),
+            Constraint::Length(1),
+        ])
+        .split(popup);
+
+    draw_header(f, state, chunks[0]);
+    draw_list(f, state, chunks[1]);
+    draw_status(f, state, chunks[2]);
+    draw_hints(f, chunks[3]);
+}
+
+fn draw_header(f: &mut Frame, state: &State, area: Rect) {
+    let mut lines = vec![Line::from(Span::styled(
+        "Pick a model for this conversation",
+        Style::default()
+            .fg(COLOR_TITLE)
+            .add_modifier(Modifier::BOLD),
+    ))];
+    if let Some(current) = &state.current {
+        lines.push(Line::from(Span::styled(
+            format!(
+                "Current: {} · {}",
+                current.connection_id, current.model_id
+            ),
+            Style::default()
+                .fg(COLOR_CURRENT_PICK)
+                .add_modifier(Modifier::ITALIC),
+        )));
+    } else {
+        lines.push(Line::from(Span::styled(
+            "Current: (none — daemon will use the interactive purpose default)",
+            Style::default().fg(COLOR_HINT_DESC),
+        )));
+    }
+    f.render_widget(Paragraph::new(lines), area);
+}
+
+fn draw_list(f: &mut Frame, state: &State, area: Rect) {
+    let items: Vec<ListItem> = if state.models.is_empty() {
+        vec![ListItem::new(Line::from(Span::styled(
+            "(no models — configure connections via F3 first)",
+            Style::default().fg(COLOR_HINT_DESC),
+        )))]
+    } else {
+        state
+            .models
+            .iter()
+            .map(|listing| {
+                let mut spans: Vec<Span<'static>> = Vec::new();
+                let is_current = state
+                    .current
+                    .as_ref()
+                    .is_some_and(|c| c.connection_id == listing.connection_id && c.model_id == listing.model.id);
+                if is_current {
+                    spans.push(Span::styled(
+                        "★ ",
+                        Style::default().fg(COLOR_CURRENT_PICK),
+                    ));
+                } else {
+                    spans.push(Span::raw("  "));
+                }
+                spans.push(Span::styled(
+                    listing.connection_label.clone(),
+                    Style::default().add_modifier(Modifier::BOLD),
+                ));
+                spans.push(Span::styled(
+                    "  ·  ",
+                    Style::default().fg(COLOR_HINT_SEP),
+                ));
+                spans.push(Span::styled(listing.model.id.clone(), Style::default()));
+                if listing.model.display_name != listing.model.id {
+                    spans.push(Span::styled(
+                        format!("  ({})", listing.model.display_name),
+                        Style::default().fg(COLOR_HINT_DESC),
+                    ));
+                }
+                ListItem::new(Line::from(spans))
+            })
+            .collect()
+    };
+
+    let title = if state.models.is_empty() {
+        "Models".to_string()
+    } else {
+        format!("Models ({})", state.models.len())
+    };
+
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(COLOR_BORDER))
+                .title(Line::from(Span::styled(
+                    title,
+                    Style::default()
+                        .fg(COLOR_TITLE)
+                        .add_modifier(Modifier::BOLD),
+                ))),
+        )
+        .highlight_style(
+            Style::default()
+                .bg(COLOR_LIST_HIGHLIGHT)
+                .fg(COLOR_LIST_HIGHLIGHT_FG)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("▸ ");
+
+    let mut list_state = ListState::default();
+    if !state.models.is_empty() {
+        list_state.select(Some(state.selected));
+    }
+    f.render_stateful_widget(list, area, &mut list_state);
+}
+
+fn draw_status(f: &mut Frame, state: &State, area: Rect) {
+    if let Some(busy) = &state.busy {
+        let style = Style::default()
+            .fg(Color::Rgb(178, 220, 245))
+            .add_modifier(Modifier::ITALIC);
+        f.render_widget(
+            Paragraph::new(Span::styled(format!(" ● {busy}"), style)),
+            area,
+        );
+    } else if let Some(err) = &state.error {
+        let style = Style::default().fg(COLOR_ERROR);
+        f.render_widget(
+            Paragraph::new(Span::styled(format!(" • {err}"), style)),
+            area,
+        );
+    }
+}
+
+fn draw_hints(f: &mut Frame, area: Rect) {
+    let hints: &[(&str, &str)] = &[
+        ("Enter", "confirm"),
+        ("r", "refresh"),
+        ("Esc", "cancel"),
+    ];
+    let mut spans: Vec<Span> = Vec::new();
+    for (idx, (key, desc)) in hints.iter().enumerate() {
+        if idx > 0 {
+            spans.push(Span::styled("  ·  ", Style::default().fg(COLOR_HINT_SEP)));
+        }
+        spans.push(Span::styled(
+            (*key).to_string(),
+            Style::default()
+                .fg(COLOR_HINT_KEY)
+                .add_modifier(Modifier::BOLD),
+        ));
+        spans.push(Span::raw(" "));
+        spans.push(Span::styled(
+            (*desc).to_string(),
+            Style::default().fg(COLOR_HINT_DESC),
+        ));
+    }
+    f.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use desktop_assistant_api_model::{ModelCapabilitiesView, ModelInfoView};
+
+    fn listing(connection: &str, model: &str) -> ModelListing {
+        ModelListing {
+            connection_id: connection.into(),
+            connection_label: format!("{connection} (test)"),
+            model: ModelInfoView {
+                id: model.into(),
+                display_name: model.into(),
+                context_limit: None,
+                capabilities: ModelCapabilitiesView::default(),
+            },
+        }
+    }
+
+    #[test]
+    fn seed_selection_finds_matching_row() {
+        let mut state = State {
+            models: vec![
+                listing("a", "alpha"),
+                listing("b", "beta"),
+                listing("c", "gamma"),
+            ],
+            selected: 0,
+            current: Some(ConversationModelSelectionView {
+                connection_id: "b".into(),
+                model_id: "beta".into(),
+                effort: None,
+            }),
+            error: None,
+            busy: None,
+            outcome: None,
+        };
+        seed_selection(&mut state);
+        assert_eq!(state.selected, 1);
+    }
+
+    #[test]
+    fn seed_selection_keeps_zero_when_no_match() {
+        let mut state = State {
+            models: vec![listing("a", "alpha")],
+            selected: 0,
+            current: Some(ConversationModelSelectionView {
+                connection_id: "z".into(),
+                model_id: "zeta".into(),
+                effort: None,
+            }),
+            error: None,
+            busy: None,
+            outcome: None,
+        };
+        seed_selection(&mut state);
+        assert_eq!(state.selected, 0);
+    }
+
+    #[test]
+    fn advance_wraps_at_boundaries() {
+        let mut state = State {
+            models: vec![listing("a", "alpha"), listing("b", "beta")],
+            selected: 0,
+            current: None,
+            error: None,
+            busy: None,
+            outcome: None,
+        };
+        advance(&mut state, 1);
+        assert_eq!(state.selected, 1);
+        advance(&mut state, 1);
+        assert_eq!(state.selected, 0);
+        advance(&mut state, -1);
+        assert_eq!(state.selected, 1);
+    }
+
+    #[test]
+    fn advance_on_empty_list_is_noop() {
+        let mut state = State {
+            models: Vec::new(),
+            selected: 0,
+            current: None,
+            error: None,
+            busy: None,
+            outcome: None,
+        };
+        advance(&mut state, 1);
+        assert_eq!(state.selected, 0);
+    }
+}

--- a/src/toolbar.rs
+++ b/src/toolbar.rs
@@ -24,6 +24,7 @@ const HINTS_NORMAL: &[(&str, &str)] = &[
     ("A", "archive"),
     ("a", "archived"),
     ("q", "quit"),
+    ("Ctrl+M", "model"),
     ("Ctrl+K", "kb"),
     ("F3", "connections"),
     ("F4", "purposes"),
@@ -36,6 +37,7 @@ const HINTS_EDITING: &[(&str, &str)] = &[
     ("S+Enter", "newline"),
     ("Esc", "back"),
     ("Ctrl+e", "bottom"),
+    ("Ctrl+M", "model"),
     ("Ctrl+B", "sidebar"),
 ];
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -353,10 +353,16 @@ fn draw_messages(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
         .as_ref()
         .map(|conv| conv.title.as_str())
         .unwrap_or("Chat");
+    let model_suffix = app
+        .current_conversation
+        .as_ref()
+        .and_then(|conv| conv.model_selection.as_ref())
+        .map(|sel| format!("  ·  {} · {}", sel.connection_id, sel.model_id))
+        .unwrap_or_default();
     let title = if app.scroll_offset > 0 {
-        format!("{chat_title} (Ctrl+u/d scroll, Ctrl+e bottom)")
+        format!("{chat_title}{model_suffix} (Ctrl+u/d scroll, Ctrl+e bottom)")
     } else {
-        chat_title.to_string()
+        format!("{chat_title}{model_suffix}")
     };
 
     let block = Block::default()


### PR DESCRIPTION
Third and final PR split from #1.

## Summary

\`Ctrl+M\` opens a centered picker listing flattened \`Connection · Model\` entries from \`list_available_models\`. The conversation's existing selection (from \`ConversationDetail.model_selection\`) is starred and pre-highlighted on open.

## Sticky behavior

Confirming a row stages a \`SendPromptOverride\` that rides on the next \`SendPrompt\`. The daemon persists it as \`last_model_selection\`; subsequent messages inherit it automatically — the TUI does **not** re-send the override on every prompt. Switching conversations and coming back picks up that conversation's stored selection from \`ConversationDetail\`.

## Visible state

- Chat panel title gets a suffix: \`Conversation Title  ·  connection · model\`. Updates the moment the picker confirms.
- Status bar: \`Model: foo · bar (applies to next message)\`.

## Wire-up

- \`Action::OpenModelPicker\` keyed to \`Ctrl+M\` in any mode.
- \`app.pending_model_override\` is one-shot; \`take_pending_override\` clears it on the next \`SendPrompt\`.
- \`app.apply_model_override\` updates the local view of \`model_selection\` so the title reflects the choice before the daemon round-trips.
- \`SubmitPrompt\` uses \`ws.send_prompt_with_override\` when an override is staged; falls back to plain \`send_prompt\` with a status warning on D-Bus.
- \`r\` in the picker forces a fresh \`list_available_models(None, refresh=true)\` — same call the daemon uses for Bedrock cache repopulation.

Toolbar hints add \`Ctrl+M model\` in both Normal and Editing modes.

## Out of scope

- **Effort selection** in the picker. Override sends \`effort: None\`; the daemon falls back to the per-purpose default. A follow-up can add an effort cycler.
- **\`Auto\` row** (per the original #1 design). Left unwired pending the daemon-side heuristic.

## Test plan

- [x] \`cargo test\` — 200 passing (+8 new in \`model_selector.rs\`, \`app.rs\`, \`keys.rs\`)
- [x] \`cargo build\` clean
- [ ] Manual: \`Ctrl+M\` lists models; current selection (if any) is starred + pre-highlighted
- [ ] Manual: confirm a different model → title updates; next \`SendPrompt\` rides the override
- [ ] Manual: switch conversations, come back → selection restored from daemon
- [ ] Manual: \`r\` refreshes model list via daemon
- [ ] Manual: D-Bus → status warning on send, plain send still works
- [ ] Manual: delete underlying connection in F3 → \`ConversationWarning\` surfaces (already plumbed in #32)

🤖 Generated with [Claude Code](https://claude.com/claude-code)