### PR TITLE
feat: process manager pane (#45)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,10 +287,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
+ "gloo-timers",
+ "tokio",
+]
+
+[[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bincode"
@@ -547,6 +570,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -634,6 +663,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -651,6 +692,33 @@ checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
 dependencies = [
  "lab",
  "phf",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -729,6 +797,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -762,7 +841,7 @@ dependencies = [
 [[package]]
 name = "desktop-assistant-api-model"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#d199fc9e39f8cb575fbe50b8178a5ae12dc13b00"
+source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=feat%2Fclient-common-task-signals#f2cb612edf3cb57d67dfb72c96323c71a8ac8863"
 dependencies = [
  "desktop-assistant-core",
  "serde",
@@ -770,9 +849,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "desktop-assistant-auth-jwt"
+version = "0.1.0"
+source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=feat%2Fclient-common-task-signals#f2cb612edf3cb57d67dfb72c96323c71a8ac8863"
+dependencies = [
+ "anyhow",
+ "jsonwebtoken",
+ "serde",
+ "uuid",
+]
+
+[[package]]
 name = "desktop-assistant-client-common"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#d199fc9e39f8cb575fbe50b8178a5ae12dc13b00"
+source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=feat%2Fclient-common-task-signals#f2cb612edf3cb57d67dfb72c96323c71a8ac8863"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -780,7 +870,7 @@ dependencies = [
  "futures",
  "reqwest 0.13.3",
  "rustls",
- "rustls-pemfile",
+ "rustls-pki-types",
  "serde_json",
  "tokio",
  "tokio-tungstenite",
@@ -792,14 +882,17 @@ dependencies = [
 [[package]]
 name = "desktop-assistant-core"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#d199fc9e39f8cb575fbe50b8178a5ae12dc13b00"
+source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=feat%2Fclient-common-task-signals#f2cb612edf3cb57d67dfb72c96323c71a8ac8863"
 dependencies = [
  "async-trait",
+ "backon",
  "chrono",
+ "desktop-assistant-auth-jwt",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 
@@ -810,6 +903,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -841,10 +935,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -895,7 +1048,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -954,6 +1107,22 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filedescriptor"
@@ -1136,6 +1305,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1176,6 +1346,29 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -1671,6 +1864,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "10.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+dependencies = [
+ "base64",
+ "ed25519-dalek",
+ "getrandom 0.2.17",
+ "hmac",
+ "js-sys",
+ "p256",
+ "p384",
+ "pem",
+ "rand 0.8.6",
+ "rsa",
+ "serde",
+ "serde_json",
+ "sha2",
+ "signature",
+ "simple_asn1",
+ "zeroize",
+]
+
+[[package]]
 name = "kasuari"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1704,6 +1921,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -1725,6 +1945,12 @@ checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
 dependencies = [
  "pkg-config",
 ]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "line-clipping"
@@ -1892,7 +2118,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1917,6 +2143,22 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.6",
+ "smallvec",
+ "zeroize",
 ]
 
 [[package]]
@@ -1983,6 +2225,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2063,6 +2306,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2096,6 +2363,25 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -2216,6 +2502,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2286,6 +2593,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -2379,7 +2695,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2677,6 +2993,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2688,6 +3014,26 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2715,7 +3061,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2747,15 +3093,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2783,7 +3120,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2839,6 +3176,20 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "secret-service"
@@ -3034,6 +3385,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3054,6 +3415,18 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
 
 [[package]]
 name = "siphasher"
@@ -3081,6 +3454,22 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
 ]
 
 [[package]]
@@ -3222,7 +3611,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4025,7 +4414,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4110,7 +4499,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-targets",
 ]
 
 [[package]]
@@ -4119,16 +4508,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -4146,31 +4526,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -4180,22 +4543,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4204,22 +4555,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4228,22 +4567,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4252,22 +4579,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,7 +841,7 @@ dependencies = [
 [[package]]
 name = "desktop-assistant-api-model"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=feat%2Fclient-common-task-signals#f2cb612edf3cb57d67dfb72c96323c71a8ac8863"
+source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#f3ba5bd88fa04ae211f3057c3eaf591c19188834"
 dependencies = [
  "desktop-assistant-core",
  "serde",
@@ -851,7 +851,7 @@ dependencies = [
 [[package]]
 name = "desktop-assistant-auth-jwt"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=feat%2Fclient-common-task-signals#f2cb612edf3cb57d67dfb72c96323c71a8ac8863"
+source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#f3ba5bd88fa04ae211f3057c3eaf591c19188834"
 dependencies = [
  "anyhow",
  "jsonwebtoken",
@@ -862,7 +862,7 @@ dependencies = [
 [[package]]
 name = "desktop-assistant-client-common"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=feat%2Fclient-common-task-signals#f2cb612edf3cb57d67dfb72c96323c71a8ac8863"
+source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#f3ba5bd88fa04ae211f3057c3eaf591c19188834"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -882,7 +882,7 @@ dependencies = [
 [[package]]
 name = "desktop-assistant-core"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=feat%2Fclient-common-task-signals#f2cb612edf3cb57d67dfb72c96323c71a8ac8863"
+source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#f3ba5bd88fa04ae211f3057c3eaf591c19188834"
 dependencies = [
  "async-trait",
  "backon",
@@ -1048,7 +1048,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2118,7 +2118,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3061,7 +3061,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3120,7 +3120,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3611,7 +3611,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4414,7 +4414,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,5 +31,5 @@ url = "2"
 # Shared protocol + transport crates live in the desktop-assistant repo.
 # Cargo resolves the package by name from that workspace; Cargo.lock pins
 # the exact revision for reproducibility.
-desktop-assistant-client-common = { git = "https://github.com/adelie-ai/desktop-assistant.git", branch = "feat/client-common-task-signals" }
-desktop-assistant-api-model = { git = "https://github.com/adelie-ai/desktop-assistant.git", branch = "feat/client-common-task-signals" }
+desktop-assistant-client-common = { git = "https://github.com/adelie-ai/desktop-assistant.git", branch = "main" }
+desktop-assistant-api-model = { git = "https://github.com/adelie-ai/desktop-assistant.git", branch = "main" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,5 +31,5 @@ url = "2"
 # Shared protocol + transport crates live in the desktop-assistant repo.
 # Cargo resolves the package by name from that workspace; Cargo.lock pins
 # the exact revision for reproducibility.
-desktop-assistant-client-common = { git = "https://github.com/adelie-ai/desktop-assistant.git", branch = "main" }
-desktop-assistant-api-model = { git = "https://github.com/adelie-ai/desktop-assistant.git", branch = "main" }
+desktop-assistant-client-common = { git = "https://github.com/adelie-ai/desktop-assistant.git", branch = "feat/client-common-task-signals" }
+desktop-assistant-api-model = { git = "https://github.com/adelie-ai/desktop-assistant.git", branch = "feat/client-common-task-signals" }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,9 @@
 pub use desktop_assistant_client_common::{ChatMessage, ConversationDetail, ConversationSummary};
+use desktop_assistant_api_model::TaskId;
 use ratatui::style::Style;
 use ratatui_textarea::{CursorMove, DataCursor, TextArea};
+
+use crate::tasks::TaskPane;
 
 fn new_textarea() -> TextArea<'static> {
     let mut ta = TextArea::default();
@@ -112,6 +115,16 @@ pub struct App {
     /// conversation's `last_model_selection`, so subsequent prompts pick
     /// it up automatically.
     pub pending_model_override: Option<desktop_assistant_api_model::SendPromptOverride>,
+    /// Process-manager (background tasks) state. Always present but
+    /// only rendered when `tasks.visible == true`. Populated at connect
+    /// time via `ListBackgroundTasks` + `SubscribeBackgroundTasks` and
+    /// kept fresh by `SignalEvent::Task*` variants in the main loop.
+    pub tasks: TaskPane,
+    /// Pending request id of an in-flight `CancelBackgroundTask`. The
+    /// terminal `TaskCompleted { status: Cancelled }` event is what
+    /// actually closes the loop; this is purely so the status bar can
+    /// say "cancelling t-1..." while we wait.
+    pub pending_task_cancel: Option<TaskId>,
 }
 
 impl App {
@@ -141,7 +154,62 @@ impl App {
             purposes_requested: false,
             model_picker_requested: false,
             pending_model_override: None,
+            tasks: TaskPane::new(),
+            pending_task_cancel: None,
         }
+    }
+
+    // --- Tasks-pane glue ---
+    //
+    // The actual mutation logic lives in `TaskPane`; these methods exist
+    // so main.rs can drive UI actions ("toggle the pane", "switch to the
+    // conversation linked to the selected task") without having to reach
+    // through `app.tasks` for every operation.
+
+    /// Toggle the process-manager overlay.
+    pub fn toggle_tasks_pane(&mut self) {
+        self.tasks.toggle();
+    }
+
+    /// Select the conversation linked to the currently-highlighted task,
+    /// closing the pane on success. Returns the conversation id so the
+    /// caller can fetch the conversation detail from the daemon. `None`
+    /// when the selected task has no linked conversation (or nothing is
+    /// selected).
+    pub fn jump_to_selected_task_conversation(&mut self) -> Option<String> {
+        let row = self.tasks.selected_row()?;
+        let conv_id = row.conversation_id.clone()?;
+        // Move sidebar selection to the linked conversation if it's
+        // present in the local list. Loading the detail itself is
+        // main's responsibility (it needs the WS client).
+        if let Some(idx) = self.conversations.iter().position(|c| c.id == conv_id) {
+            self.selected_conversation = Some(idx);
+        }
+        self.tasks.visible = false;
+        Some(conv_id)
+    }
+
+    /// Stage a `CancelBackgroundTask` for the highlighted task. Returns
+    /// the task id so the caller can fire the command. `None` when
+    /// nothing is selected or the task is already terminal.
+    pub fn request_cancel_selected_task(&mut self) -> Option<TaskId> {
+        let row = self.tasks.selected_row()?;
+        // Don't fire cancellations against terminal states — the
+        // daemon would reject them anyway and we'd spin in the status
+        // bar.
+        if matches!(
+            row.status,
+            desktop_assistant_api_model::TaskStatus::Completed
+                | desktop_assistant_api_model::TaskStatus::Failed
+                | desktop_assistant_api_model::TaskStatus::Cancelled
+        ) {
+            self.status_message = format!("Task {} is already terminal", row.id);
+            return None;
+        }
+        let id = row.id.clone();
+        self.pending_task_cancel = Some(id.clone());
+        self.status_message = format!("Cancelling {id}...");
+        Some(id)
     }
 
     /// Apply the user's model picker selection to local state so the
@@ -1133,5 +1201,144 @@ mod tests {
         app.textarea.insert_str("hello");
         app.submit_prompt();
         assert_eq!(app.scroll_offset, 0);
+    }
+
+    // --- Tasks pane integration ---
+
+    fn standalone_view(id: &str, conv_id: &str, title: &str) -> desktop_assistant_api_model::TaskView {
+        desktop_assistant_api_model::TaskView {
+            id: desktop_assistant_api_model::TaskId(id.into()),
+            kind: desktop_assistant_api_model::TaskKind::Standalone {
+                name: title.into(),
+                conversation_id: conv_id.into(),
+            },
+            status: desktop_assistant_api_model::TaskStatus::Running,
+            started_at: 1,
+            ended_at: None,
+            last_error: None,
+            parent: None,
+            children: Vec::new(),
+            title: title.into(),
+            progress_hint: None,
+        }
+    }
+
+    #[test]
+    fn keybind_toggles_pane_visibility() {
+        let mut app = App::new();
+        assert!(!app.tasks.visible);
+        app.toggle_tasks_pane();
+        assert!(app.tasks.visible);
+        app.toggle_tasks_pane();
+        assert!(!app.tasks.visible);
+    }
+
+    #[test]
+    fn pressing_enter_on_selection_switches_to_linked_conversation() {
+        let mut app = App::new();
+        app.set_conversations(vec![
+            ConversationSummary {
+                id: "conv-1".into(),
+                title: "Other".into(),
+                message_count: 0,
+                archived: false,
+            },
+            ConversationSummary {
+                id: "conv-x".into(),
+                title: "Linked".into(),
+                message_count: 0,
+                archived: false,
+            },
+        ]);
+        app.tasks
+            .apply_task_started(standalone_view("t-1", "conv-x", "Researcher"));
+        app.tasks.visible = true;
+        app.tasks.selected = Some(desktop_assistant_api_model::TaskId("t-1".into()));
+
+        let conv = app.jump_to_selected_task_conversation();
+        assert_eq!(conv.as_deref(), Some("conv-x"));
+        assert_eq!(app.selected_conversation, Some(1));
+        assert!(!app.tasks.visible);
+    }
+
+    #[test]
+    fn jump_to_selected_task_conversation_returns_id_even_when_not_in_sidebar() {
+        // The conversation may have been archived out of the visible
+        // sidebar list. We still return its id so main.rs can fetch the
+        // detail; the sidebar selection just stays where it was.
+        let mut app = App::new();
+        app.tasks
+            .apply_task_started(standalone_view("t-1", "archived-conv", "Researcher"));
+        app.tasks.selected = Some(desktop_assistant_api_model::TaskId("t-1".into()));
+
+        let conv = app.jump_to_selected_task_conversation();
+        assert_eq!(conv.as_deref(), Some("archived-conv"));
+        assert_eq!(app.selected_conversation, None);
+    }
+
+    #[test]
+    fn pressing_c_on_selection_requests_cancel_command() {
+        let mut app = App::new();
+        app.tasks
+            .apply_task_started(standalone_view("t-1", "conv-x", "Researcher"));
+        app.tasks.selected = Some(desktop_assistant_api_model::TaskId("t-1".into()));
+
+        let id = app.request_cancel_selected_task();
+        assert_eq!(
+            id,
+            Some(desktop_assistant_api_model::TaskId("t-1".into()))
+        );
+        assert_eq!(
+            app.pending_task_cancel,
+            Some(desktop_assistant_api_model::TaskId("t-1".into()))
+        );
+        assert!(app.status_message.starts_with("Cancelling"));
+    }
+
+    #[test]
+    fn cancelling_a_terminal_task_is_a_noop() {
+        let mut app = App::new();
+        app.tasks
+            .apply_task_started(standalone_view("t-1", "conv-x", "Researcher"));
+        app.tasks
+            .apply_task_completed("t-1", desktop_assistant_api_model::TaskStatus::Completed, None);
+        app.tasks.selected = Some(desktop_assistant_api_model::TaskId("t-1".into()));
+
+        let id = app.request_cancel_selected_task();
+        assert!(id.is_none());
+        assert!(app.pending_task_cancel.is_none());
+        assert!(app.status_message.contains("already terminal"));
+    }
+
+    #[test]
+    fn cancel_with_no_selection_is_a_noop() {
+        let mut app = App::new();
+        let id = app.request_cancel_selected_task();
+        assert!(id.is_none());
+    }
+
+    #[test]
+    fn business_outcome_user_sees_their_spawned_standalone_agent_in_the_list_with_correct_title() {
+        // End-to-end happy path: the daemon emits a `TaskStarted` event
+        // for a user-initiated standalone agent. The TUI's pane must
+        // contain a row with the agent's title, its conversation id,
+        // and Running status — without any further round-trip.
+        let mut app = App::new();
+        let view = standalone_view("t-42", "spawned-conv", "Researcher: pricing data");
+        app.tasks.apply_task_started(view);
+
+        let row = app
+            .tasks
+            .tasks
+            .get(&desktop_assistant_api_model::TaskId("t-42".into()))
+            .expect("row should be present after TaskStarted");
+        assert_eq!(row.title, "Researcher: pricing data");
+        assert_eq!(row.conversation_id.as_deref(), Some("spawned-conv"));
+        assert!(matches!(
+            row.status,
+            desktop_assistant_api_model::TaskStatus::Running
+        ));
+        // The running badge should now reflect the count.
+        assert_eq!(crate::tasks::running_badge(&app.tasks), "(1 running)");
     }
 }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -29,11 +29,33 @@ pub enum Action {
     OpenConnections,
     OpenPurposes,
     OpenModelPicker,
+    /// Toggle the process-manager (tasks) overlay. Currently bound to
+    /// `Ctrl+P` ("process manager") since `Ctrl+T` is already used for
+    /// the debug-view toggle and a chord-style `g t` would require a
+    /// new key-state machine that none of the existing bindings use.
+    ToggleTasksPane,
+    /// Tasks-pane navigation: move highlighted task selection. Only
+    /// active when the pane is visible.
+    NextTask,
+    PreviousTask,
+    /// Cancel the highlighted task (sends `CancelBackgroundTask`).
+    CancelSelectedTask,
+    /// Jump to the conversation linked to the highlighted task.
+    OpenSelectedTaskConversation,
 }
 
 /// Handle key events that we intercept before passing to textarea.
 /// Returns None for keys that should be forwarded to textarea.input().
-pub fn handle_key_event(key: KeyEvent, mode: &InputMode) -> Option<Action> {
+///
+/// `tasks_pane_visible` modifies behavior when the process-manager overlay
+/// is up: `j`/`k`/`c`/`Enter` route to task navigation/cancel/open-conv
+/// instead of the normal-mode conversation actions. The pane is opened
+/// and closed by `Ctrl+P`, which is honored from any mode.
+pub fn handle_key_event(
+    key: KeyEvent,
+    mode: &InputMode,
+    tasks_pane_visible: bool,
+) -> Option<Action> {
     let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
     let alt = key.modifiers.contains(KeyModifiers::ALT);
 
@@ -67,8 +89,39 @@ pub fn handle_key_event(key: KeyEvent, mode: &InputMode) -> Option<Action> {
             KeyCode::Char('b') => Some(Action::ToggleSidebar),
             KeyCode::Char('k') => Some(Action::OpenKnowledgeBase),
             KeyCode::Char('m') => Some(Action::OpenModelPicker),
+            // Ctrl+P toggles the process-manager pane. Available from
+            // any non-renaming mode so the user can pop it open while
+            // editing a prompt to glance at running subagents.
+            KeyCode::Char('p') => Some(Action::ToggleTasksPane),
             _ => None,
         };
+    }
+
+    // When the tasks pane is open, intercept normal-mode-style keys for
+    // pane navigation regardless of editing/normal mode. Esc and the
+    // toggle shortcut close it; we let the toggle through above.
+    if tasks_pane_visible {
+        if key.code == KeyCode::Esc && key.modifiers.is_empty() {
+            return Some(Action::ToggleTasksPane);
+        }
+        match (key.code, key.modifiers) {
+            (KeyCode::Char('j') | KeyCode::Down, m) if m.is_empty() => {
+                return Some(Action::NextTask);
+            }
+            (KeyCode::Char('k') | KeyCode::Up, m) if m.is_empty() => {
+                return Some(Action::PreviousTask);
+            }
+            (KeyCode::Char('c'), m) if m.is_empty() => {
+                return Some(Action::CancelSelectedTask);
+            }
+            (KeyCode::Enter, m) if m.is_empty() => {
+                return Some(Action::OpenSelectedTaskConversation);
+            }
+            _ => {}
+        }
+        // While the pane is open, other keys are swallowed (we don't
+        // want `i` to drop you into edit mode, etc.).
+        return None;
     }
 
     match mode {
@@ -159,7 +212,7 @@ mod tests {
     #[test]
     fn normal_q_quits() {
         assert_eq!(
-            handle_key_event(key(KeyCode::Char('q')), &InputMode::Normal),
+            handle_key_event(key(KeyCode::Char('q')), &InputMode::Normal, false),
             Some(Action::Quit)
         );
     }
@@ -167,7 +220,7 @@ mod tests {
     #[test]
     fn normal_j_next() {
         assert_eq!(
-            handle_key_event(key(KeyCode::Char('j')), &InputMode::Normal),
+            handle_key_event(key(KeyCode::Char('j')), &InputMode::Normal, false),
             Some(Action::NextConversation)
         );
     }
@@ -175,7 +228,7 @@ mod tests {
     #[test]
     fn normal_down_next() {
         assert_eq!(
-            handle_key_event(key(KeyCode::Down), &InputMode::Normal),
+            handle_key_event(key(KeyCode::Down), &InputMode::Normal, false),
             Some(Action::NextConversation)
         );
     }
@@ -183,7 +236,7 @@ mod tests {
     #[test]
     fn normal_k_previous() {
         assert_eq!(
-            handle_key_event(key(KeyCode::Char('k')), &InputMode::Normal),
+            handle_key_event(key(KeyCode::Char('k')), &InputMode::Normal, false),
             Some(Action::PreviousConversation)
         );
     }
@@ -191,7 +244,7 @@ mod tests {
     #[test]
     fn normal_up_previous() {
         assert_eq!(
-            handle_key_event(key(KeyCode::Up), &InputMode::Normal),
+            handle_key_event(key(KeyCode::Up), &InputMode::Normal, false),
             Some(Action::PreviousConversation)
         );
     }
@@ -199,7 +252,7 @@ mod tests {
     #[test]
     fn normal_enter_opens() {
         assert_eq!(
-            handle_key_event(key(KeyCode::Enter), &InputMode::Normal),
+            handle_key_event(key(KeyCode::Enter), &InputMode::Normal, false),
             Some(Action::OpenConversation)
         );
     }
@@ -207,7 +260,7 @@ mod tests {
     #[test]
     fn normal_char_newline_is_ignored() {
         assert_eq!(
-            handle_key_event(key(KeyCode::Char('\n')), &InputMode::Normal),
+            handle_key_event(key(KeyCode::Char('\n')), &InputMode::Normal, false),
             None
         );
     }
@@ -215,7 +268,7 @@ mod tests {
     #[test]
     fn normal_d_deletes() {
         assert_eq!(
-            handle_key_event(key(KeyCode::Char('d')), &InputMode::Normal),
+            handle_key_event(key(KeyCode::Char('d')), &InputMode::Normal, false),
             Some(Action::DeleteConversation)
         );
     }
@@ -223,7 +276,7 @@ mod tests {
     #[test]
     fn normal_n_new_conversation() {
         assert_eq!(
-            handle_key_event(key(KeyCode::Char('n')), &InputMode::Normal),
+            handle_key_event(key(KeyCode::Char('n')), &InputMode::Normal, false),
             Some(Action::NewConversation)
         );
     }
@@ -231,7 +284,7 @@ mod tests {
     #[test]
     fn normal_i_enter_edit() {
         assert_eq!(
-            handle_key_event(key(KeyCode::Char('i')), &InputMode::Normal),
+            handle_key_event(key(KeyCode::Char('i')), &InputMode::Normal, false),
             Some(Action::EnterEditMode)
         );
     }
@@ -239,7 +292,7 @@ mod tests {
     #[test]
     fn normal_unknown_key_ignored() {
         assert_eq!(
-            handle_key_event(key(KeyCode::Char('x')), &InputMode::Normal),
+            handle_key_event(key(KeyCode::Char('x')), &InputMode::Normal, false),
             None
         );
     }
@@ -247,10 +300,7 @@ mod tests {
     #[test]
     fn normal_ctrl_modifier_ignored() {
         assert_eq!(
-            handle_key_event(
-                key_with_mod(KeyCode::Char('q'), KeyModifiers::CONTROL),
-                &InputMode::Normal
-            ),
+            handle_key_event(key_with_mod(KeyCode::Char('q'), KeyModifiers::CONTROL), &InputMode::Normal, false),
             None
         );
     }
@@ -258,10 +308,7 @@ mod tests {
     #[test]
     fn normal_alt_modifier_ignored() {
         assert_eq!(
-            handle_key_event(
-                key_with_mod(KeyCode::Char('j'), KeyModifiers::ALT),
-                &InputMode::Normal
-            ),
+            handle_key_event(key_with_mod(KeyCode::Char('j'), KeyModifiers::ALT), &InputMode::Normal, false),
             None
         );
     }
@@ -271,7 +318,7 @@ mod tests {
     #[test]
     fn editing_escape_exits() {
         assert_eq!(
-            handle_key_event(key(KeyCode::Esc), &InputMode::Editing),
+            handle_key_event(key(KeyCode::Esc), &InputMode::Editing, false),
             Some(Action::ExitEditMode)
         );
     }
@@ -279,7 +326,7 @@ mod tests {
     #[test]
     fn editing_enter_submits_prompt() {
         assert_eq!(
-            handle_key_event(key(KeyCode::Enter), &InputMode::Editing),
+            handle_key_event(key(KeyCode::Enter), &InputMode::Editing, false),
             Some(Action::SubmitPrompt)
         );
     }
@@ -287,10 +334,7 @@ mod tests {
     #[test]
     fn editing_shift_enter_inserts_newline() {
         assert_eq!(
-            handle_key_event(
-                key_with_mod(KeyCode::Enter, KeyModifiers::SHIFT),
-                &InputMode::Editing
-            ),
+            handle_key_event(key_with_mod(KeyCode::Enter, KeyModifiers::SHIFT), &InputMode::Editing, false),
             Some(Action::InsertNewline)
         );
     }
@@ -298,10 +342,7 @@ mod tests {
     #[test]
     fn editing_newline_char_is_forwarded_to_textarea() {
         assert_eq!(
-            handle_key_event(
-                key_with_mod(KeyCode::Char('\n'), KeyModifiers::NONE),
-                &InputMode::Editing
-            ),
+            handle_key_event(key_with_mod(KeyCode::Char('\n'), KeyModifiers::NONE), &InputMode::Editing, false),
             Some(Action::InsertNewline)
         );
     }
@@ -309,10 +350,7 @@ mod tests {
     #[test]
     fn editing_carriage_return_char_is_forwarded_to_textarea() {
         assert_eq!(
-            handle_key_event(
-                key_with_mod(KeyCode::Char('\r'), KeyModifiers::NONE),
-                &InputMode::Editing
-            ),
+            handle_key_event(key_with_mod(KeyCode::Char('\r'), KeyModifiers::NONE), &InputMode::Editing, false),
             Some(Action::InsertNewline)
         );
     }
@@ -320,10 +358,7 @@ mod tests {
     #[test]
     fn editing_ctrl_j_inserts_newline() {
         assert_eq!(
-            handle_key_event(
-                key_with_mod(KeyCode::Char('j'), KeyModifiers::CONTROL),
-                &InputMode::Editing
-            ),
+            handle_key_event(key_with_mod(KeyCode::Char('j'), KeyModifiers::CONTROL), &InputMode::Editing, false),
             Some(Action::InsertNewline)
         );
     }
@@ -331,10 +366,7 @@ mod tests {
     #[test]
     fn editing_alt_enter_is_forwarded_to_textarea() {
         assert_eq!(
-            handle_key_event(
-                key_with_mod(KeyCode::Enter, KeyModifiers::ALT),
-                &InputMode::Editing
-            ),
+            handle_key_event(key_with_mod(KeyCode::Enter, KeyModifiers::ALT), &InputMode::Editing, false),
             None
         );
     }
@@ -343,7 +375,7 @@ mod tests {
     fn editing_char_forwarded_to_textarea() {
         // Regular chars should return None so they get forwarded to textarea
         assert_eq!(
-            handle_key_event(key(KeyCode::Char('a')), &InputMode::Editing),
+            handle_key_event(key(KeyCode::Char('a')), &InputMode::Editing, false),
             None
         );
     }
@@ -351,7 +383,7 @@ mod tests {
     #[test]
     fn editing_backspace_forwarded_to_textarea() {
         assert_eq!(
-            handle_key_event(key(KeyCode::Backspace), &InputMode::Editing),
+            handle_key_event(key(KeyCode::Backspace), &InputMode::Editing, false),
             None
         );
     }
@@ -359,19 +391,19 @@ mod tests {
     #[test]
     fn editing_arrows_forwarded_to_textarea() {
         assert_eq!(
-            handle_key_event(key(KeyCode::Left), &InputMode::Editing),
+            handle_key_event(key(KeyCode::Left), &InputMode::Editing, false),
             None
         );
         assert_eq!(
-            handle_key_event(key(KeyCode::Right), &InputMode::Editing),
+            handle_key_event(key(KeyCode::Right), &InputMode::Editing, false),
             None
         );
         assert_eq!(
-            handle_key_event(key(KeyCode::Up), &InputMode::Editing),
+            handle_key_event(key(KeyCode::Up), &InputMode::Editing, false),
             None
         );
         assert_eq!(
-            handle_key_event(key(KeyCode::Down), &InputMode::Editing),
+            handle_key_event(key(KeyCode::Down), &InputMode::Editing, false),
             None
         );
     }
@@ -381,10 +413,7 @@ mod tests {
     #[test]
     fn ctrl_u_scrolls_up() {
         assert_eq!(
-            handle_key_event(
-                key_with_mod(KeyCode::Char('u'), KeyModifiers::CONTROL),
-                &InputMode::Normal
-            ),
+            handle_key_event(key_with_mod(KeyCode::Char('u'), KeyModifiers::CONTROL), &InputMode::Normal, false),
             Some(Action::ScrollUp)
         );
     }
@@ -392,10 +421,7 @@ mod tests {
     #[test]
     fn ctrl_d_scrolls_down() {
         assert_eq!(
-            handle_key_event(
-                key_with_mod(KeyCode::Char('d'), KeyModifiers::CONTROL),
-                &InputMode::Normal
-            ),
+            handle_key_event(key_with_mod(KeyCode::Char('d'), KeyModifiers::CONTROL), &InputMode::Normal, false),
             Some(Action::ScrollDown)
         );
     }
@@ -403,10 +429,7 @@ mod tests {
     #[test]
     fn ctrl_e_scrolls_to_bottom() {
         assert_eq!(
-            handle_key_event(
-                key_with_mod(KeyCode::Char('e'), KeyModifiers::CONTROL),
-                &InputMode::Normal
-            ),
+            handle_key_event(key_with_mod(KeyCode::Char('e'), KeyModifiers::CONTROL), &InputMode::Normal, false),
             Some(Action::ScrollToBottom)
         );
     }
@@ -414,10 +437,7 @@ mod tests {
     #[test]
     fn ctrl_u_works_in_editing_mode() {
         assert_eq!(
-            handle_key_event(
-                key_with_mod(KeyCode::Char('u'), KeyModifiers::CONTROL),
-                &InputMode::Editing
-            ),
+            handle_key_event(key_with_mod(KeyCode::Char('u'), KeyModifiers::CONTROL), &InputMode::Editing, false),
             Some(Action::ScrollUp)
         );
     }
@@ -425,10 +445,7 @@ mod tests {
     #[test]
     fn ctrl_d_works_in_editing_mode() {
         assert_eq!(
-            handle_key_event(
-                key_with_mod(KeyCode::Char('d'), KeyModifiers::CONTROL),
-                &InputMode::Editing
-            ),
+            handle_key_event(key_with_mod(KeyCode::Char('d'), KeyModifiers::CONTROL), &InputMode::Editing, false),
             Some(Action::ScrollDown)
         );
     }
@@ -436,7 +453,7 @@ mod tests {
     #[test]
     fn normal_pageup_scrolls_up() {
         assert_eq!(
-            handle_key_event(key(KeyCode::PageUp), &InputMode::Normal),
+            handle_key_event(key(KeyCode::PageUp), &InputMode::Normal, false),
             Some(Action::ScrollUp)
         );
     }
@@ -444,7 +461,7 @@ mod tests {
     #[test]
     fn normal_pagedown_scrolls_down() {
         assert_eq!(
-            handle_key_event(key(KeyCode::PageDown), &InputMode::Normal),
+            handle_key_event(key(KeyCode::PageDown), &InputMode::Normal, false),
             Some(Action::ScrollDown)
         );
     }
@@ -454,7 +471,7 @@ mod tests {
     #[test]
     fn normal_r_begins_rename() {
         assert_eq!(
-            handle_key_event(key(KeyCode::Char('r')), &InputMode::Normal),
+            handle_key_event(key(KeyCode::Char('r')), &InputMode::Normal, false),
             Some(Action::BeginRename)
         );
     }
@@ -462,7 +479,7 @@ mod tests {
     #[test]
     fn renaming_enter_submits() {
         assert_eq!(
-            handle_key_event(key(KeyCode::Enter), &InputMode::Renaming),
+            handle_key_event(key(KeyCode::Enter), &InputMode::Renaming, false),
             Some(Action::SubmitRename)
         );
     }
@@ -470,7 +487,7 @@ mod tests {
     #[test]
     fn renaming_esc_cancels() {
         assert_eq!(
-            handle_key_event(key(KeyCode::Esc), &InputMode::Renaming),
+            handle_key_event(key(KeyCode::Esc), &InputMode::Renaming, false),
             Some(Action::CancelRename)
         );
     }
@@ -479,11 +496,11 @@ mod tests {
     fn renaming_chars_forwarded_to_textarea() {
         // Regular chars and editing keys must reach the rename textarea.
         assert_eq!(
-            handle_key_event(key(KeyCode::Char('a')), &InputMode::Renaming),
+            handle_key_event(key(KeyCode::Char('a')), &InputMode::Renaming, false),
             None
         );
         assert_eq!(
-            handle_key_event(key(KeyCode::Backspace), &InputMode::Renaming),
+            handle_key_event(key(KeyCode::Backspace), &InputMode::Renaming, false),
             None
         );
     }
@@ -493,17 +510,11 @@ mod tests {
         // Ctrl+a/e/u/k are textarea editing shortcuts in rename mode and
         // must NOT be intercepted as scroll commands.
         assert_eq!(
-            handle_key_event(
-                key_with_mod(KeyCode::Char('u'), KeyModifiers::CONTROL),
-                &InputMode::Renaming
-            ),
+            handle_key_event(key_with_mod(KeyCode::Char('u'), KeyModifiers::CONTROL), &InputMode::Renaming, false),
             None
         );
         assert_eq!(
-            handle_key_event(
-                key_with_mod(KeyCode::Char('a'), KeyModifiers::CONTROL),
-                &InputMode::Renaming
-            ),
+            handle_key_event(key_with_mod(KeyCode::Char('a'), KeyModifiers::CONTROL), &InputMode::Renaming, false),
             None
         );
     }
@@ -513,10 +524,7 @@ mod tests {
     #[test]
     fn ctrl_t_toggles_debug_in_normal() {
         assert_eq!(
-            handle_key_event(
-                key_with_mod(KeyCode::Char('t'), KeyModifiers::CONTROL),
-                &InputMode::Normal
-            ),
+            handle_key_event(key_with_mod(KeyCode::Char('t'), KeyModifiers::CONTROL), &InputMode::Normal, false),
             Some(Action::ToggleDebug)
         );
     }
@@ -524,10 +532,7 @@ mod tests {
     #[test]
     fn ctrl_t_toggles_debug_in_editing() {
         assert_eq!(
-            handle_key_event(
-                key_with_mod(KeyCode::Char('t'), KeyModifiers::CONTROL),
-                &InputMode::Editing
-            ),
+            handle_key_event(key_with_mod(KeyCode::Char('t'), KeyModifiers::CONTROL), &InputMode::Editing, false),
             Some(Action::ToggleDebug)
         );
     }
@@ -537,10 +542,7 @@ mod tests {
     #[test]
     fn ctrl_b_toggles_sidebar_in_normal() {
         assert_eq!(
-            handle_key_event(
-                key_with_mod(KeyCode::Char('b'), KeyModifiers::CONTROL),
-                &InputMode::Normal
-            ),
+            handle_key_event(key_with_mod(KeyCode::Char('b'), KeyModifiers::CONTROL), &InputMode::Normal, false),
             Some(Action::ToggleSidebar)
         );
     }
@@ -548,10 +550,7 @@ mod tests {
     #[test]
     fn ctrl_b_toggles_sidebar_in_editing() {
         assert_eq!(
-            handle_key_event(
-                key_with_mod(KeyCode::Char('b'), KeyModifiers::CONTROL),
-                &InputMode::Editing
-            ),
+            handle_key_event(key_with_mod(KeyCode::Char('b'), KeyModifiers::CONTROL), &InputMode::Editing, false),
             Some(Action::ToggleSidebar)
         );
     }
@@ -561,7 +560,7 @@ mod tests {
     #[test]
     fn f2_triggers_switch_in_normal() {
         assert_eq!(
-            handle_key_event(key(KeyCode::F(2)), &InputMode::Normal),
+            handle_key_event(key(KeyCode::F(2)), &InputMode::Normal, false),
             Some(Action::SwitchConnection)
         );
     }
@@ -569,7 +568,7 @@ mod tests {
     #[test]
     fn f2_triggers_switch_in_editing() {
         assert_eq!(
-            handle_key_event(key(KeyCode::F(2)), &InputMode::Editing),
+            handle_key_event(key(KeyCode::F(2)), &InputMode::Editing, false),
             Some(Action::SwitchConnection)
         );
     }
@@ -579,10 +578,7 @@ mod tests {
     #[test]
     fn ctrl_k_opens_kb_in_normal() {
         assert_eq!(
-            handle_key_event(
-                key_with_mod(KeyCode::Char('k'), KeyModifiers::CONTROL),
-                &InputMode::Normal
-            ),
+            handle_key_event(key_with_mod(KeyCode::Char('k'), KeyModifiers::CONTROL), &InputMode::Normal, false),
             Some(Action::OpenKnowledgeBase)
         );
     }
@@ -590,10 +586,7 @@ mod tests {
     #[test]
     fn ctrl_k_opens_kb_in_editing() {
         assert_eq!(
-            handle_key_event(
-                key_with_mod(KeyCode::Char('k'), KeyModifiers::CONTROL),
-                &InputMode::Editing
-            ),
+            handle_key_event(key_with_mod(KeyCode::Char('k'), KeyModifiers::CONTROL), &InputMode::Editing, false),
             Some(Action::OpenKnowledgeBase)
         );
     }
@@ -603,7 +596,7 @@ mod tests {
     #[test]
     fn f3_opens_connections_in_normal() {
         assert_eq!(
-            handle_key_event(key(KeyCode::F(3)), &InputMode::Normal),
+            handle_key_event(key(KeyCode::F(3)), &InputMode::Normal, false),
             Some(Action::OpenConnections)
         );
     }
@@ -611,7 +604,7 @@ mod tests {
     #[test]
     fn f3_opens_connections_in_editing() {
         assert_eq!(
-            handle_key_event(key(KeyCode::F(3)), &InputMode::Editing),
+            handle_key_event(key(KeyCode::F(3)), &InputMode::Editing, false),
             Some(Action::OpenConnections)
         );
     }
@@ -619,7 +612,7 @@ mod tests {
     #[test]
     fn f4_opens_purposes_in_normal() {
         assert_eq!(
-            handle_key_event(key(KeyCode::F(4)), &InputMode::Normal),
+            handle_key_event(key(KeyCode::F(4)), &InputMode::Normal, false),
             Some(Action::OpenPurposes)
         );
     }
@@ -627,7 +620,7 @@ mod tests {
     #[test]
     fn f4_opens_purposes_in_editing() {
         assert_eq!(
-            handle_key_event(key(KeyCode::F(4)), &InputMode::Editing),
+            handle_key_event(key(KeyCode::F(4)), &InputMode::Editing, false),
             Some(Action::OpenPurposes)
         );
     }
@@ -637,10 +630,7 @@ mod tests {
     #[test]
     fn ctrl_m_opens_model_picker_in_normal() {
         assert_eq!(
-            handle_key_event(
-                key_with_mod(KeyCode::Char('m'), KeyModifiers::CONTROL),
-                &InputMode::Normal
-            ),
+            handle_key_event(key_with_mod(KeyCode::Char('m'), KeyModifiers::CONTROL), &InputMode::Normal, false),
             Some(Action::OpenModelPicker)
         );
     }
@@ -648,11 +638,130 @@ mod tests {
     #[test]
     fn ctrl_m_opens_model_picker_in_editing() {
         assert_eq!(
-            handle_key_event(
-                key_with_mod(KeyCode::Char('m'), KeyModifiers::CONTROL),
-                &InputMode::Editing
-            ),
+            handle_key_event(key_with_mod(KeyCode::Char('m'), KeyModifiers::CONTROL), &InputMode::Editing, false),
             Some(Action::OpenModelPicker)
+        );
+    }
+
+    // --- Ctrl+P toggles tasks pane (process-manager) ---
+
+    #[test]
+    fn ctrl_p_toggles_tasks_pane_in_normal() {
+        assert_eq!(
+            handle_key_event(
+                key_with_mod(KeyCode::Char('p'), KeyModifiers::CONTROL),
+                &InputMode::Normal,
+                false
+            ),
+            Some(Action::ToggleTasksPane)
+        );
+    }
+
+    #[test]
+    fn ctrl_p_toggles_tasks_pane_in_editing() {
+        assert_eq!(
+            handle_key_event(
+                key_with_mod(KeyCode::Char('p'), KeyModifiers::CONTROL),
+                &InputMode::Editing,
+                false
+            ),
+            Some(Action::ToggleTasksPane)
+        );
+    }
+
+    #[test]
+    fn ctrl_p_also_closes_pane_when_open() {
+        // Toggle is symmetric: the same shortcut closes the pane.
+        assert_eq!(
+            handle_key_event(
+                key_with_mod(KeyCode::Char('p'), KeyModifiers::CONTROL),
+                &InputMode::Normal,
+                true
+            ),
+            Some(Action::ToggleTasksPane)
+        );
+    }
+
+    // --- Tasks-pane key routing when visible ---
+
+    #[test]
+    fn tasks_pane_visible_routes_j_to_next_task() {
+        assert_eq!(
+            handle_key_event(key(KeyCode::Char('j')), &InputMode::Normal, true),
+            Some(Action::NextTask)
+        );
+    }
+
+    #[test]
+    fn tasks_pane_visible_routes_k_to_previous_task() {
+        assert_eq!(
+            handle_key_event(key(KeyCode::Char('k')), &InputMode::Normal, true),
+            Some(Action::PreviousTask)
+        );
+    }
+
+    #[test]
+    fn tasks_pane_visible_routes_down_to_next_task() {
+        assert_eq!(
+            handle_key_event(key(KeyCode::Down), &InputMode::Normal, true),
+            Some(Action::NextTask)
+        );
+    }
+
+    #[test]
+    fn tasks_pane_visible_routes_up_to_previous_task() {
+        assert_eq!(
+            handle_key_event(key(KeyCode::Up), &InputMode::Normal, true),
+            Some(Action::PreviousTask)
+        );
+    }
+
+    #[test]
+    fn tasks_pane_visible_routes_c_to_cancel_task() {
+        // When the pane is open, `c` cancels the highlighted task
+        // rather than being passed through (and `c` does nothing in
+        // normal mode today, so this isn't shadowing anything).
+        assert_eq!(
+            handle_key_event(key(KeyCode::Char('c')), &InputMode::Normal, true),
+            Some(Action::CancelSelectedTask)
+        );
+    }
+
+    #[test]
+    fn tasks_pane_visible_routes_enter_to_open_conversation() {
+        assert_eq!(
+            handle_key_event(key(KeyCode::Enter), &InputMode::Normal, true),
+            Some(Action::OpenSelectedTaskConversation)
+        );
+    }
+
+    #[test]
+    fn tasks_pane_visible_routes_esc_to_close_pane() {
+        // Esc is a discoverable second way to close the pane.
+        assert_eq!(
+            handle_key_event(key(KeyCode::Esc), &InputMode::Normal, true),
+            Some(Action::ToggleTasksPane)
+        );
+    }
+
+    #[test]
+    fn tasks_pane_visible_swallows_unmapped_keys_in_editing_mode() {
+        // While the pane is open, regular typing in editing mode is
+        // suppressed — otherwise `i` would still drop into edit and
+        // start typing into a hidden textarea.
+        assert_eq!(
+            handle_key_event(key(KeyCode::Char('x')), &InputMode::Editing, true),
+            None
+        );
+    }
+
+    #[test]
+    fn tasks_pane_visible_still_lets_f2_through() {
+        // Function keys for global navigation should still work; only
+        // mode-level keys are intercepted.
+        assert_eq!(
+            handle_key_event(key(KeyCode::F(2)), &InputMode::Normal, true),
+            Some(Action::SwitchConnection)
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,5 +10,6 @@ pub mod model_selector;
 pub mod profile;
 pub mod purposes;
 pub mod settings;
+pub mod tasks;
 pub mod toolbar;
 pub mod ui;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ mod model_selector;
 mod profile;
 mod purposes;
 mod settings;
+mod tasks;
 mod toolbar;
 mod ui;
 
@@ -267,6 +268,7 @@ async fn run(
                 Ok(convs) => app.set_conversations(convs),
                 Err(e) => app.status_message = format!("Error loading conversations: {e}"),
             }
+            init_background_tasks(&mut app, &transport_client).await;
             app.status_message = transport_label(config);
             client = Some(transport_client);
             signal_rx = rx;
@@ -355,7 +357,7 @@ async fn run(
                     if key.kind == KeyEventKind::Release {
                         continue;
                     }
-                    if let Some(action) = handle_key_event(key, &app.mode) {
+                    if let Some(action) = handle_key_event(key, &app.mode, app.tasks.visible) {
                         handle_action(&mut app, &client, action).await;
                     } else {
                         match app.mode {
@@ -403,6 +405,29 @@ async fn run(
                         // with the per-conversation model selector (#1).
                         app.status_message = format!("Warning: {warning:?}");
                     }
+                    // --- Background task events (issue #45 / desktop-assistant#114) ---
+                    //
+                    // Each event is forwarded verbatim into `app.tasks`. The
+                    // map's invariants are enforced inside `TaskPane` so this
+                    // call site stays one-liner-thin.
+                    SignalEvent::TaskStarted { task } => {
+                        app.tasks.apply_task_started(task);
+                    }
+                    SignalEvent::TaskProgress { id, progress_hint } => {
+                        app.tasks.apply_task_progress(&id, progress_hint);
+                    }
+                    SignalEvent::TaskLogAppended { id, entry } => {
+                        app.tasks.apply_task_log_appended(&id, entry);
+                    }
+                    SignalEvent::TaskCompleted { id, status, last_error } => {
+                        // Clear the cancel spinner if we were waiting on this
+                        // task. The terminal status (`Cancelled`/`Completed`/
+                        // `Failed`) is the authoritative resolution.
+                        if app.pending_task_cancel.as_ref().map(|t| t.0.as_str()) == Some(id.as_str()) {
+                            app.pending_task_cancel = None;
+                        }
+                        app.tasks.apply_task_completed(&id, status, last_error);
+                    }
                 }
             }
             _ = async {
@@ -422,6 +447,7 @@ async fn run(
                             Ok(convs) => app.set_conversations(convs),
                             Err(e) => app.status_message = format!("Error loading conversations: {e}"),
                         }
+                        init_background_tasks(&mut app, &transport_client).await;
                         client = Some(transport_client);
                         signal_rx = rx;
                         reconnect = ReconnectState::Connected;
@@ -660,6 +686,85 @@ async fn handle_action(
                 app.status_message = "Not connected — model picker unavailable".into();
             }
         }
+        Action::ToggleTasksPane => {
+            app.toggle_tasks_pane();
+            app.status_message = if app.tasks.visible {
+                "Tasks pane open (j/k navigate · c cancel · Enter open conv · Ctrl+P close)"
+                    .into()
+            } else {
+                "Tasks pane closed".into()
+            };
+        }
+        Action::NextTask => app.tasks.move_selection(1),
+        Action::PreviousTask => app.tasks.move_selection(-1),
+        Action::CancelSelectedTask => {
+            if let Some(id) = app.request_cancel_selected_task()
+                && let Some(client) = client.as_ref()
+                && let Some(ws) = client.as_ws()
+            {
+                let cmd = desktop_assistant_api_model::Command::CancelBackgroundTask {
+                    id: id.0.clone(),
+                };
+                match ws.send_command(cmd).await {
+                    Ok(_) => {
+                        // Status will move to "Cancelling..." then resolve
+                        // when `TaskCompleted { status: Cancelled }` arrives.
+                    }
+                    Err(e) => {
+                        app.status_message = format!("Cancel failed: {e}");
+                        app.pending_task_cancel = None;
+                    }
+                }
+            }
+        }
+        Action::OpenSelectedTaskConversation => {
+            if let Some(conv_id) = app.jump_to_selected_task_conversation()
+                && let Some(client) = client.as_ref()
+            {
+                match client.get_conversation(&conv_id).await {
+                    Ok(detail) => {
+                        app.load_conversation(detail);
+                    }
+                    Err(e) => app.status_message = format!("Open conversation error: {e}"),
+                }
+            }
+        }
+    }
+}
+
+/// Populate the tasks pane with a daemon snapshot and subscribe to live
+/// events. Failure is non-fatal — the chat still works without the
+/// process-manager pane, so we surface a status hint and move on.
+///
+/// Both commands only exist over WS today. Over D-Bus the call quietly
+/// no-ops; the pane will simply stay empty.
+async fn init_background_tasks(
+    app: &mut App,
+    client: &desktop_assistant_client_common::TransportClient,
+) {
+    let Some(ws) = client.as_ws() else {
+        return;
+    };
+    let list = desktop_assistant_api_model::Command::ListBackgroundTasks {
+        include_finished: false,
+        limit: None,
+    };
+    match ws.send_command(list).await {
+        Ok(desktop_assistant_api_model::CommandResult::BackgroundTasks(tasks)) => {
+            app.tasks.set_initial(tasks);
+        }
+        Ok(other) => {
+            app.status_message = format!("Unexpected ListBackgroundTasks response: {other:?}");
+        }
+        Err(e) => {
+            app.status_message = format!("Tasks snapshot failed: {e}");
+        }
+    }
+    if let Err(e) = ws
+        .send_command(desktop_assistant_api_model::Command::SubscribeBackgroundTasks)
+        .await
+    {
+        app.status_message = format!("Tasks subscribe failed: {e}");
     }
 }
 

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -1,0 +1,409 @@
+//! Process-manager pane (skeleton — failing tests first).
+//!
+//! See the issue-45 implementation commit for the full module. This
+//! initial skeleton exists only so the tests below can reference types
+//! and methods; every public method is unimplemented until the next
+//! commit lands.
+
+use std::collections::{BTreeMap, HashMap, VecDeque};
+
+use desktop_assistant_api_model::{TaskId, TaskLogEntry, TaskStatus, TaskView};
+use ratatui::{Frame, layout::Rect};
+
+pub const LOG_CAP: usize = 500;
+
+#[derive(Debug, Clone)]
+pub struct TaskRow {
+    pub id: TaskId,
+    pub title: String,
+    pub status: TaskStatus,
+    pub started_at: i64,
+    pub ended_at: Option<i64>,
+    pub last_error: Option<String>,
+    pub parent: Option<TaskId>,
+    pub progress_hint: Option<String>,
+    pub conversation_id: Option<String>,
+}
+
+impl TaskRow {
+    pub fn from_view(_view: &TaskView) -> Self {
+        unimplemented!("filled in by the issue-45 implementation commit")
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct TaskPane {
+    pub tasks: BTreeMap<TaskId, TaskRow>,
+    pub task_logs: HashMap<TaskId, VecDeque<TaskLogEntry>>,
+    pub selected: Option<TaskId>,
+    pub visible: bool,
+}
+
+impl TaskPane {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn toggle(&mut self) {
+        unimplemented!("filled in by the issue-45 implementation commit")
+    }
+
+    pub fn set_initial(&mut self, _views: Vec<TaskView>) {
+        unimplemented!("filled in by the issue-45 implementation commit")
+    }
+
+    pub fn apply_task_started(&mut self, _view: TaskView) {
+        unimplemented!("filled in by the issue-45 implementation commit")
+    }
+
+    pub fn apply_task_progress(&mut self, _id: &str, _progress_hint: Option<String>) {
+        unimplemented!("filled in by the issue-45 implementation commit")
+    }
+
+    pub fn apply_task_log_appended(&mut self, _id: &str, _entry: TaskLogEntry) {
+        unimplemented!("filled in by the issue-45 implementation commit")
+    }
+
+    pub fn apply_task_completed(
+        &mut self,
+        _id: &str,
+        _status: TaskStatus,
+        _last_error: Option<String>,
+    ) {
+        unimplemented!("filled in by the issue-45 implementation commit")
+    }
+
+    pub fn running_count(&self) -> usize {
+        unimplemented!("filled in by the issue-45 implementation commit")
+    }
+
+    pub fn move_selection(&mut self, _delta: i32) {
+        unimplemented!("filled in by the issue-45 implementation commit")
+    }
+
+    pub fn selected_row(&self) -> Option<&TaskRow> {
+        unimplemented!("filled in by the issue-45 implementation commit")
+    }
+
+    pub fn selected_logs_vec(&self) -> Vec<TaskLogEntry> {
+        unimplemented!("filled in by the issue-45 implementation commit")
+    }
+}
+
+pub fn draw_overlay(_f: &mut Frame, _pane: &TaskPane, _area: Rect) {
+    unimplemented!("filled in by the issue-45 implementation commit")
+}
+
+pub fn running_badge(_pane: &TaskPane) -> String {
+    unimplemented!("filled in by the issue-45 implementation commit")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use desktop_assistant_api_model::{
+        LogCategory, LogLevel, TaskId, TaskKind, TaskLogEntry, TaskStatus, TaskView,
+    };
+    use ratatui::{Terminal, backend::TestBackend};
+
+    fn view(id: &str, title: &str, status: TaskStatus) -> TaskView {
+        TaskView {
+            id: TaskId(id.into()),
+            kind: TaskKind::Standalone {
+                name: title.into(),
+                conversation_id: format!("conv-{id}"),
+            },
+            status,
+            started_at: 1,
+            ended_at: None,
+            last_error: None,
+            parent: None,
+            children: Vec::new(),
+            title: title.into(),
+            progress_hint: None,
+        }
+    }
+
+    fn log(seq: u64, msg: &str) -> TaskLogEntry {
+        TaskLogEntry {
+            seq,
+            timestamp: 1,
+            level: LogLevel::Info,
+            category: LogCategory::Status,
+            message: msg.into(),
+            data: None,
+        }
+    }
+
+    fn render_to_buffer(pane: &TaskPane, w: u16, h: u16) -> String {
+        let backend = TestBackend::new(w, h);
+        let mut term = Terminal::new(backend).unwrap();
+        term.draw(|f| {
+            draw_overlay(f, pane, f.area());
+        })
+        .unwrap();
+        let buf = term.backend().buffer().clone();
+        buf.content.iter().map(|c| c.symbol()).collect()
+    }
+
+    // --- State tests ----------------------------------------------------
+
+    #[test]
+    fn task_started_event_adds_row_to_pane() {
+        let mut pane = TaskPane::new();
+        pane.apply_task_started(view("t-1", "Researcher", TaskStatus::Running));
+        assert_eq!(pane.tasks.len(), 1);
+        let row = pane.tasks.get(&TaskId("t-1".into())).unwrap();
+        assert_eq!(row.title, "Researcher");
+        assert!(matches!(row.status, TaskStatus::Running));
+    }
+
+    #[test]
+    fn task_completed_event_updates_status_badge() {
+        let mut pane = TaskPane::new();
+        pane.apply_task_started(view("t-1", "Researcher", TaskStatus::Running));
+        pane.apply_task_completed("t-1", TaskStatus::Completed, None);
+        let row = pane.tasks.get(&TaskId("t-1".into())).unwrap();
+        assert!(matches!(row.status, TaskStatus::Completed));
+    }
+
+    #[test]
+    fn task_completed_with_failure_records_last_error() {
+        let mut pane = TaskPane::new();
+        pane.apply_task_started(view("t-1", "Researcher", TaskStatus::Running));
+        pane.apply_task_completed("t-1", TaskStatus::Failed, Some("LLM timed out".into()));
+        let row = pane.tasks.get(&TaskId("t-1".into())).unwrap();
+        assert!(matches!(row.status, TaskStatus::Failed));
+        assert_eq!(row.last_error.as_deref(), Some("LLM timed out"));
+    }
+
+    #[test]
+    fn task_progress_updates_hint() {
+        let mut pane = TaskPane::new();
+        pane.apply_task_started(view("t-1", "Researcher", TaskStatus::Running));
+        pane.apply_task_progress("t-1", Some("step 2/5".into()));
+        assert_eq!(
+            pane.tasks
+                .get(&TaskId("t-1".into()))
+                .unwrap()
+                .progress_hint
+                .as_deref(),
+            Some("step 2/5"),
+        );
+    }
+
+    #[test]
+    fn task_progress_for_unknown_id_is_benign() {
+        let mut pane = TaskPane::new();
+        pane.apply_task_progress("unknown", Some("x".into()));
+        assert!(pane.tasks.is_empty());
+    }
+
+    #[test]
+    fn task_log_appended_for_unknown_id_buffers_anyway() {
+        let mut pane = TaskPane::new();
+        pane.apply_task_log_appended("t-1", log(1, "hello"));
+        assert_eq!(pane.task_logs.get(&TaskId("t-1".into())).unwrap().len(), 1);
+    }
+
+    #[test]
+    fn task_completed_for_unknown_id_is_benign() {
+        let mut pane = TaskPane::new();
+        pane.apply_task_completed("missing", TaskStatus::Completed, None);
+        assert!(pane.tasks.is_empty());
+    }
+
+    #[test]
+    fn log_ring_caps_at_500_entries() {
+        let mut pane = TaskPane::new();
+        for i in 0..600u64 {
+            pane.apply_task_log_appended("t-1", log(i, &format!("e{i}")));
+        }
+        let buf = pane.task_logs.get(&TaskId("t-1".into())).unwrap();
+        assert_eq!(buf.len(), LOG_CAP);
+        assert_eq!(buf.front().unwrap().seq, 100);
+        assert_eq!(buf.back().unwrap().seq, 599);
+    }
+
+    #[test]
+    fn rapid_event_burst_preserves_ordering() {
+        let mut pane = TaskPane::new();
+        pane.apply_task_started(view("t-1", "Burst", TaskStatus::Running));
+        for i in 0..200u64 {
+            pane.apply_task_log_appended("t-1", log(i, &format!("e{i}")));
+        }
+        let buf = pane.task_logs.get(&TaskId("t-1".into())).unwrap();
+        let seqs: Vec<u64> = buf.iter().map(|e| e.seq).collect();
+        assert_eq!(seqs.first().copied(), Some(0));
+        assert_eq!(seqs.last().copied(), Some(199));
+        for w in seqs.windows(2) {
+            assert!(w[0] < w[1], "out-of-order seq in burst: {seqs:?}");
+        }
+    }
+
+    #[test]
+    fn set_initial_replaces_full_set_and_preserves_selection_if_present() {
+        let mut pane = TaskPane::new();
+        pane.set_initial(vec![
+            view("t-1", "First", TaskStatus::Running),
+            view("t-2", "Second", TaskStatus::Running),
+        ]);
+        pane.selected = Some(TaskId("t-2".into()));
+        pane.set_initial(vec![
+            view("t-2", "Second", TaskStatus::Completed),
+            view("t-3", "Third", TaskStatus::Running),
+        ]);
+        assert_eq!(pane.tasks.len(), 2);
+        assert_eq!(pane.selected.as_ref(), Some(&TaskId("t-2".into())));
+        assert!(!pane.tasks.contains_key(&TaskId("t-1".into())));
+    }
+
+    #[test]
+    fn set_initial_picks_first_when_selection_gone() {
+        let mut pane = TaskPane::new();
+        pane.set_initial(vec![view("t-1", "First", TaskStatus::Running)]);
+        pane.selected = Some(TaskId("gone".into()));
+        pane.set_initial(vec![view("t-2", "Second", TaskStatus::Running)]);
+        assert_eq!(pane.selected.as_ref(), Some(&TaskId("t-2".into())));
+    }
+
+    #[test]
+    fn toggle_flips_visibility_and_picks_first_selection() {
+        let mut pane = TaskPane::new();
+        pane.apply_task_started(view("t-1", "A", TaskStatus::Running));
+        pane.apply_task_started(view("t-2", "B", TaskStatus::Running));
+        pane.selected = None;
+        assert!(!pane.visible);
+        pane.toggle();
+        assert!(pane.visible);
+        assert_eq!(pane.selected.as_ref(), Some(&TaskId("t-1".into())));
+        pane.toggle();
+        assert!(!pane.visible);
+    }
+
+    #[test]
+    fn move_selection_wraps_at_boundaries() {
+        let mut pane = TaskPane::new();
+        pane.apply_task_started(view("t-1", "A", TaskStatus::Running));
+        pane.apply_task_started(view("t-2", "B", TaskStatus::Running));
+        pane.apply_task_started(view("t-3", "C", TaskStatus::Running));
+        pane.selected = Some(TaskId("t-1".into()));
+        pane.move_selection(1);
+        assert_eq!(pane.selected.as_ref(), Some(&TaskId("t-2".into())));
+        pane.move_selection(1);
+        assert_eq!(pane.selected.as_ref(), Some(&TaskId("t-3".into())));
+        pane.move_selection(1);
+        assert_eq!(pane.selected.as_ref(), Some(&TaskId("t-1".into())));
+        pane.move_selection(-1);
+        assert_eq!(pane.selected.as_ref(), Some(&TaskId("t-3".into())));
+    }
+
+    #[test]
+    fn move_selection_on_empty_is_noop() {
+        let mut pane = TaskPane::new();
+        pane.move_selection(1);
+        assert!(pane.selected.is_none());
+    }
+
+    #[test]
+    fn running_count_only_counts_pending_and_running() {
+        let mut pane = TaskPane::new();
+        pane.apply_task_started(view("t-1", "A", TaskStatus::Running));
+        pane.apply_task_started(view("t-2", "B", TaskStatus::Pending));
+        pane.apply_task_started(view("t-3", "C", TaskStatus::Completed));
+        pane.apply_task_started(view("t-4", "D", TaskStatus::Failed));
+        pane.apply_task_started(view("t-5", "E", TaskStatus::Cancelled));
+        assert_eq!(pane.running_count(), 2);
+    }
+
+    #[test]
+    fn task_row_from_view_extracts_conversation_id_for_standalone() {
+        let row = TaskRow::from_view(&view("t-1", "X", TaskStatus::Running));
+        assert_eq!(row.conversation_id.as_deref(), Some("conv-t-1"));
+    }
+
+    #[test]
+    fn task_row_from_view_extracts_conversation_id_for_subagent() {
+        let v = TaskView {
+            id: TaskId("t-1".into()),
+            kind: TaskKind::Subagent {
+                parent_task_id: TaskId("parent".into()),
+                conversation_id: "subagent-conv".into(),
+                name: "child".into(),
+            },
+            status: TaskStatus::Running,
+            started_at: 1,
+            ended_at: None,
+            last_error: None,
+            parent: Some(TaskId("parent".into())),
+            children: Vec::new(),
+            title: "child".into(),
+            progress_hint: None,
+        };
+        let row = TaskRow::from_view(&v);
+        assert_eq!(row.conversation_id.as_deref(), Some("subagent-conv"));
+        assert_eq!(row.parent.as_ref(), Some(&TaskId("parent".into())));
+    }
+
+    #[test]
+    fn running_badge_empty_when_zero_running() {
+        let pane = TaskPane::new();
+        assert_eq!(running_badge(&pane), "");
+    }
+
+    #[test]
+    fn running_badge_renders_count_when_running() {
+        let mut pane = TaskPane::new();
+        pane.apply_task_started(view("t-1", "A", TaskStatus::Running));
+        pane.apply_task_started(view("t-2", "B", TaskStatus::Running));
+        pane.apply_task_started(view("t-3", "C", TaskStatus::Completed));
+        assert_eq!(running_badge(&pane), "(2 running)");
+    }
+
+    // --- Render tests ---------------------------------------------------
+
+    #[test]
+    fn tasks_pane_renders_empty_state_when_no_tasks() {
+        let pane = TaskPane::new();
+        let dump = render_to_buffer(&pane, 80, 24);
+        assert!(dump.contains("Tasks (0 running)"));
+        assert!(dump.contains("no background tasks"));
+    }
+
+    #[test]
+    fn tasks_pane_renders_three_running_tasks_with_status_badges() {
+        let mut pane = TaskPane::new();
+        pane.apply_task_started(view("aaaaaaaa", "Alpha", TaskStatus::Running));
+        pane.apply_task_started(view("bbbbbbbb", "Beta", TaskStatus::Pending));
+        pane.apply_task_started(view("cccccccc", "Gamma", TaskStatus::Completed));
+        let dump = render_to_buffer(&pane, 120, 24);
+        assert!(dump.contains("Alpha"), "no Alpha in dump:\n{dump}");
+        assert!(dump.contains("Beta"));
+        assert!(dump.contains("Gamma"));
+        assert!(dump.contains("RUN"));
+        assert!(dump.contains("PEND"));
+        assert!(dump.contains("OK"));
+    }
+
+    #[test]
+    fn tasks_pane_shows_log_entries_for_selected_task() {
+        let mut pane = TaskPane::new();
+        pane.apply_task_started(view("t-1", "Loggy", TaskStatus::Running));
+        pane.selected = Some(TaskId("t-1".into()));
+        pane.apply_task_log_appended("t-1", log(1, "first log line"));
+        pane.apply_task_log_appended("t-1", log(2, "second log line"));
+        let dump = render_to_buffer(&pane, 120, 24);
+        assert!(
+            dump.contains("first log line"),
+            "first log missing:\n{dump}"
+        );
+        assert!(dump.contains("second log line"));
+    }
+
+    #[test]
+    fn tasks_pane_renders_at_small_widths_without_panic() {
+        let mut pane = TaskPane::new();
+        pane.apply_task_started(view("t-1", "Title that is fairly long", TaskStatus::Running));
+        let _ = render_to_buffer(&pane, 40, 12);
+    }
+}

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -1,17 +1,59 @@
-//! Process-manager pane (skeleton — failing tests first).
+//! Process-manager pane.
 //!
-//! See the issue-45 implementation commit for the full module. This
-//! initial skeleton exists only so the tests below can reference types
-//! and methods; every public method is unimplemented until the next
-//! commit lands.
+//! Overlay that lists background tasks (subagents and user-initiated
+//! standalone agents) emitted by the daemon's background-task registry
+//! (`desktop-assistant#110` / `#114`). Modeled on `connections.rs`:
+//! state lives in a dedicated struct, rendering is local, and `main`
+//! routes keys and events to it.
+//!
+//! Lifecycle
+//! ---------
+//!
+//! 1. On WS connect, main sends `ListBackgroundTasks` once for the
+//!    initial snapshot, then `SubscribeBackgroundTasks` for live
+//!    updates.
+//! 2. `SignalEvent::Task*` variants are forwarded into `TaskPane` via
+//!    `apply_task_*` methods; the maps are the single source of truth.
+//! 3. The pane is keyboard-toggled (`Ctrl+P`). When closed, a small
+//!    "(N running)" badge appears in the status bar.
+//!
+//! Layout (when open)
+//! ------------------
+//!
+//! ```text
+//! +-------------------------- Tasks (3 running) ---------------------------+
+//! | ▸ a1b2c3  Researcher: pricing  RUN   12s  ↳p=t-xyz |  18:42:01 INFO    |
+//! |   d4e5f6  Subagent: parser     OK    1m                LLM: response   |
+//! |   …                                                |  18:42:03 INFO    |
+//! |                                                    |  tool: search()   |
+//! +----------------------------------------------------+-------------------+
+//! ```
+//!
+//! Logs are capped at 500 entries per task (UI-side); the daemon also
+//! caps the in-memory log buffer.
 
 use std::collections::{BTreeMap, HashMap, VecDeque};
 
-use desktop_assistant_api_model::{TaskId, TaskLogEntry, TaskStatus, TaskView};
-use ratatui::{Frame, layout::Rect};
+use desktop_assistant_api_model::{
+    LogLevel, TaskId, TaskKind, TaskLogEntry, TaskStatus, TaskView,
+};
+use ratatui::{
+    Frame,
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap},
+};
 
+/// Per-task UI log cap. The daemon also caps its buffer; this is a
+/// belt-and-suspenders limit on the TUI side so an over-chatty task
+/// can't OOM us if the daemon's cap is raised.
 pub const LOG_CAP: usize = 500;
 
+/// Lightweight projection of `TaskView` for the list row. We keep most
+/// fields verbatim and add a denormalized `conversation_id` so the
+/// `Enter` -> jump-to-conversation path doesn't have to destructure
+/// `TaskKind` every time.
 #[derive(Debug, Clone)]
 pub struct TaskRow {
     pub id: TaskId,
@@ -22,20 +64,50 @@ pub struct TaskRow {
     pub last_error: Option<String>,
     pub parent: Option<TaskId>,
     pub progress_hint: Option<String>,
+    /// Linked conversation id for `Enter` to jump to. Present for every
+    /// `TaskKind` variant (all three carry a conversation), but kept
+    /// `Option<_>` so future variants can opt out.
     pub conversation_id: Option<String>,
 }
 
 impl TaskRow {
-    pub fn from_view(_view: &TaskView) -> Self {
-        unimplemented!("filled in by the issue-45 implementation commit")
+    pub fn from_view(view: &TaskView) -> Self {
+        let conversation_id = match &view.kind {
+            TaskKind::Conversation { conversation_id }
+            | TaskKind::Standalone {
+                conversation_id, ..
+            }
+            | TaskKind::Subagent {
+                conversation_id, ..
+            } => Some(conversation_id.clone()),
+        };
+        Self {
+            id: view.id.clone(),
+            title: view.title.clone(),
+            status: view.status,
+            started_at: view.started_at,
+            ended_at: view.ended_at,
+            last_error: view.last_error.clone(),
+            parent: view.parent.clone(),
+            progress_hint: view.progress_hint.clone(),
+            conversation_id,
+        }
     }
 }
 
 #[derive(Debug, Default)]
 pub struct TaskPane {
+    /// Ordered map by task id so iteration order is stable and tests
+    /// don't have to sort. The daemon assigns roughly monotonic ids
+    /// so newest-first ordering happens to fall out naturally; if we
+    /// need a different ordering we can compute it at render time.
     pub tasks: BTreeMap<TaskId, TaskRow>,
+    /// Per-task ring of recent log entries, capped at `LOG_CAP`. A
+    /// `VecDeque` lets us drop the oldest entry in O(1) when full.
     pub task_logs: HashMap<TaskId, VecDeque<TaskLogEntry>>,
+    /// Currently-highlighted task in the list.
     pub selected: Option<TaskId>,
+    /// Whether the overlay is currently rendered.
     pub visible: bool,
 }
 
@@ -44,58 +116,412 @@ impl TaskPane {
         Self::default()
     }
 
+    /// Toggle pane visibility. Selection is preserved across toggles;
+    /// when opening with no selection we pick the first task so j/k
+    /// have somewhere to start from.
     pub fn toggle(&mut self) {
-        unimplemented!("filled in by the issue-45 implementation commit")
+        self.visible = !self.visible;
+        if self.visible && self.selected.is_none() {
+            self.selected = self.tasks.keys().next().cloned();
+        }
     }
 
-    pub fn set_initial(&mut self, _views: Vec<TaskView>) {
-        unimplemented!("filled in by the issue-45 implementation commit")
+    /// Replace the entire task set with a snapshot (response to
+    /// `ListBackgroundTasks`). Preserves the current selection if the
+    /// task still exists; otherwise picks the first task.
+    pub fn set_initial(&mut self, views: Vec<TaskView>) {
+        self.tasks.clear();
+        for v in views {
+            self.tasks.insert(v.id.clone(), TaskRow::from_view(&v));
+        }
+        self.normalize_selection();
     }
 
-    pub fn apply_task_started(&mut self, _view: TaskView) {
-        unimplemented!("filled in by the issue-45 implementation commit")
+    pub fn apply_task_started(&mut self, view: TaskView) {
+        let row = TaskRow::from_view(&view);
+        self.tasks.insert(view.id.clone(), row);
+        if self.selected.is_none() {
+            self.selected = Some(view.id);
+        }
     }
 
-    pub fn apply_task_progress(&mut self, _id: &str, _progress_hint: Option<String>) {
-        unimplemented!("filled in by the issue-45 implementation commit")
+    pub fn apply_task_progress(&mut self, id: &str, progress_hint: Option<String>) {
+        let key = TaskId(id.to_string());
+        if let Some(row) = self.tasks.get_mut(&key) {
+            row.progress_hint = progress_hint;
+        }
+        // Unknown id -> drop silently. Per the spec a `TaskProgress`
+        // event for a task we never saw `TaskStarted` for is benign
+        // (could be a race during connect, before the snapshot lands).
     }
 
-    pub fn apply_task_log_appended(&mut self, _id: &str, _entry: TaskLogEntry) {
-        unimplemented!("filled in by the issue-45 implementation commit")
+    pub fn apply_task_log_appended(&mut self, id: &str, entry: TaskLogEntry) {
+        let key = TaskId(id.to_string());
+        let buf = self.task_logs.entry(key).or_default();
+        buf.push_back(entry);
+        while buf.len() > LOG_CAP {
+            buf.pop_front();
+        }
     }
 
     pub fn apply_task_completed(
         &mut self,
-        _id: &str,
-        _status: TaskStatus,
-        _last_error: Option<String>,
+        id: &str,
+        status: TaskStatus,
+        last_error: Option<String>,
     ) {
-        unimplemented!("filled in by the issue-45 implementation commit")
+        let key = TaskId(id.to_string());
+        if let Some(row) = self.tasks.get_mut(&key) {
+            row.status = status;
+            row.last_error = last_error;
+            // `ended_at` is set lazily on the next snapshot; the daemon
+            // is the authoritative source. We don't fabricate a
+            // timestamp here.
+        }
     }
 
     pub fn running_count(&self) -> usize {
-        unimplemented!("filled in by the issue-45 implementation commit")
+        self.tasks
+            .values()
+            .filter(|r| matches!(r.status, TaskStatus::Pending | TaskStatus::Running))
+            .count()
     }
 
-    pub fn move_selection(&mut self, _delta: i32) {
-        unimplemented!("filled in by the issue-45 implementation commit")
+    /// Move the selection cursor up/down through the task list. Wraps
+    /// at the ends; no-op on an empty list.
+    pub fn move_selection(&mut self, delta: i32) {
+        if self.tasks.is_empty() {
+            self.selected = None;
+            return;
+        }
+        let ids: Vec<TaskId> = self.tasks.keys().cloned().collect();
+        let idx = self
+            .selected
+            .as_ref()
+            .and_then(|sel| ids.iter().position(|k| k == sel))
+            .map(|p| p as i32)
+            .unwrap_or(0);
+        let len = ids.len() as i32;
+        let new = ((idx + delta) % len + len) % len;
+        self.selected = ids.get(new as usize).cloned();
     }
 
     pub fn selected_row(&self) -> Option<&TaskRow> {
-        unimplemented!("filled in by the issue-45 implementation commit")
+        self.selected.as_ref().and_then(|id| self.tasks.get(id))
     }
 
+    /// Return the full log buffer for the selected task as a `Vec` for
+    /// rendering. Allocates per draw; if it ever shows up in profiles
+    /// we can keep a contiguous backing buffer.
     pub fn selected_logs_vec(&self) -> Vec<TaskLogEntry> {
-        unimplemented!("filled in by the issue-45 implementation commit")
+        match self.selected.as_ref() {
+            Some(id) => self
+                .task_logs
+                .get(id)
+                .map(|v| v.iter().cloned().collect())
+                .unwrap_or_default(),
+            None => Vec::new(),
+        }
+    }
+
+    fn normalize_selection(&mut self) {
+        if self
+            .selected
+            .as_ref()
+            .map(|id| !self.tasks.contains_key(id))
+            .unwrap_or(true)
+        {
+            self.selected = self.tasks.keys().next().cloned();
+        }
     }
 }
 
-pub fn draw_overlay(_f: &mut Frame, _pane: &TaskPane, _area: Rect) {
-    unimplemented!("filled in by the issue-45 implementation commit")
+// --- Rendering --------------------------------------------------------
+
+const COLOR_BORDER: Color = Color::Rgb(82, 104, 173);
+const COLOR_TITLE: Color = Color::Rgb(166, 182, 255);
+const COLOR_HINT_DESC: Color = Color::Rgb(143, 153, 174);
+const COLOR_LIST_HIGHLIGHT: Color = Color::Rgb(72, 102, 180);
+const COLOR_LIST_HIGHLIGHT_FG: Color = Color::Rgb(245, 248, 255);
+const COLOR_OK: Color = Color::Rgb(132, 218, 193);
+const COLOR_ERROR: Color = Color::Rgb(232, 130, 130);
+const COLOR_WARN: Color = Color::Rgb(232, 200, 130);
+const COLOR_RUN: Color = Color::Rgb(122, 163, 255);
+const COLOR_PEND: Color = Color::Rgb(178, 138, 220);
+
+fn status_chip(status: TaskStatus) -> Span<'static> {
+    let (label, color) = match status {
+        TaskStatus::Pending => ("PEND", COLOR_PEND),
+        TaskStatus::Running => ("RUN ", COLOR_RUN),
+        TaskStatus::Completed => ("OK  ", COLOR_OK),
+        TaskStatus::Failed => ("FAIL", COLOR_ERROR),
+        TaskStatus::Cancelled => ("CXL ", COLOR_WARN),
+    };
+    Span::styled(
+        format!(" {label} "),
+        Style::default()
+            .fg(Color::Black)
+            .bg(color)
+            .add_modifier(Modifier::BOLD),
+    )
 }
 
-pub fn running_badge(_pane: &TaskPane) -> String {
-    unimplemented!("filled in by the issue-45 implementation commit")
+fn level_color(level: LogLevel) -> Color {
+    match level {
+        LogLevel::Info => COLOR_OK,
+        LogLevel::Warn => COLOR_WARN,
+        LogLevel::Error => COLOR_ERROR,
+    }
+}
+
+fn short_id(id: &TaskId) -> String {
+    // Show the first 8 chars (or fewer) — uuids are 36 chars and the
+    // full id is too noisy for a list row. The full id is still
+    // available via the daemon for any drill-down.
+    id.0.chars().take(8).collect()
+}
+
+/// Render the task age as a compact `12s` / `3m` / `1h` string.
+///
+/// Uses `ended_at` when the task is terminal, otherwise the difference
+/// to "now". We don't pass `now` in; it's derived from `SystemTime` so
+/// the badge updates as the user looks at the screen. For unit tests we
+/// keep this pure and pass `now_ms`.
+fn age_label(row: &TaskRow, now_ms: i64) -> String {
+    let end = row.ended_at.unwrap_or(now_ms);
+    let delta = end.saturating_sub(row.started_at).max(0) / 1000;
+    if delta < 60 {
+        format!("{delta}s")
+    } else if delta < 3_600 {
+        format!("{}m", delta / 60)
+    } else if delta < 86_400 {
+        format!("{}h", delta / 3_600)
+    } else {
+        format!("{}d", delta / 86_400)
+    }
+}
+
+fn now_ms() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+/// Render the pane as a centered overlay over `area`. The caller should
+/// already have drawn the chat panel underneath; we render `Clear` over
+/// our bounding box so the chat doesn't bleed through.
+pub fn draw_overlay(f: &mut Frame, pane: &TaskPane, area: Rect) {
+    // 90% width, 80% height — leaves chat visible at the edges so the
+    // user remembers what they're working on.
+    let popup_w = (area.width as u32 * 90 / 100) as u16;
+    let popup_h = (area.height as u32 * 80 / 100) as u16;
+    let popup_w = popup_w.max(40).min(area.width);
+    let popup_h = popup_h.max(8).min(area.height);
+    let popup = Rect {
+        x: area.x + (area.width.saturating_sub(popup_w)) / 2,
+        y: area.y + (area.height.saturating_sub(popup_h)) / 2,
+        width: popup_w,
+        height: popup_h,
+    };
+
+    f.render_widget(Clear, popup);
+
+    let title_line = Line::from(vec![
+        Span::styled(
+            format!("Tasks ({} running)", pane.running_count()),
+            Style::default()
+                .fg(COLOR_TITLE)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            "  —  j/k navigate · c cancel · Enter open conv · Ctrl+P close",
+            Style::default().fg(COLOR_HINT_DESC),
+        ),
+    ]);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(COLOR_BORDER))
+        .title(title_line);
+    let inner = block.inner(popup);
+    f.render_widget(block, popup);
+
+    if pane.tasks.is_empty() {
+        let empty = Paragraph::new(Line::from(Span::styled(
+            "(no background tasks — they will appear here as the daemon spawns them)",
+            Style::default().fg(COLOR_HINT_DESC),
+        )))
+        .wrap(Wrap { trim: true });
+        f.render_widget(empty, inner);
+        return;
+    }
+
+    let split = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+        .split(inner);
+
+    draw_task_list(f, pane, split[0]);
+    draw_task_logs(f, pane, split[1]);
+}
+
+fn draw_task_list(f: &mut Frame, pane: &TaskPane, area: Rect) {
+    let ids: Vec<&TaskId> = pane.tasks.keys().collect();
+    let selected_idx = pane
+        .selected
+        .as_ref()
+        .and_then(|sel| ids.iter().position(|id| *id == sel));
+
+    let now = now_ms();
+    let items: Vec<ListItem<'static>> = pane
+        .tasks
+        .values()
+        .map(|row| {
+            let parent_indicator = if row.parent.is_some() {
+                Span::styled(" ↳", Style::default().fg(COLOR_HINT_DESC))
+            } else {
+                Span::raw("  ")
+            };
+            let progress = row
+                .progress_hint
+                .as_deref()
+                .map(|p| format!("  ·  {p}"))
+                .unwrap_or_default();
+            let age = age_label(row, now);
+            let mut spans: Vec<Span<'static>> = vec![
+                status_chip(row.status),
+                Span::raw(" "),
+                Span::styled(
+                    short_id(&row.id),
+                    Style::default()
+                        .fg(Color::White)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(
+                    format!("  {age:>4}"),
+                    Style::default().fg(COLOR_HINT_DESC),
+                ),
+                parent_indicator,
+                Span::raw(" "),
+                Span::styled(row.title.clone(), Style::default().fg(Color::White)),
+            ];
+            if !progress.is_empty() {
+                spans.push(Span::styled(progress, Style::default().fg(COLOR_HINT_DESC)));
+            }
+            if let Some(err) = &row.last_error {
+                spans.push(Span::styled(
+                    format!("  ·  {err}"),
+                    Style::default()
+                        .fg(COLOR_ERROR)
+                        .add_modifier(Modifier::ITALIC),
+                ));
+            }
+            ListItem::new(Line::from(spans))
+        })
+        .collect();
+
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(COLOR_BORDER))
+                .title(Line::from(Span::styled(
+                    "Background tasks",
+                    Style::default()
+                        .fg(COLOR_TITLE)
+                        .add_modifier(Modifier::BOLD),
+                ))),
+        )
+        .highlight_style(
+            Style::default()
+                .bg(COLOR_LIST_HIGHLIGHT)
+                .fg(COLOR_LIST_HIGHLIGHT_FG)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("▸ ");
+
+    let mut state = ListState::default();
+    state.select(selected_idx);
+    f.render_stateful_widget(list, area, &mut state);
+}
+
+fn draw_task_logs(f: &mut Frame, pane: &TaskPane, area: Rect) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(COLOR_BORDER))
+        .title(Line::from(Span::styled(
+            "Logs",
+            Style::default()
+                .fg(COLOR_TITLE)
+                .add_modifier(Modifier::BOLD),
+        )));
+    let inner = block.inner(area);
+    f.render_widget(block, area);
+
+    let logs = pane.selected_logs_vec();
+    if logs.is_empty() {
+        let empty = Paragraph::new(Line::from(Span::styled(
+            "(no log entries yet)",
+            Style::default().fg(COLOR_HINT_DESC),
+        )));
+        f.render_widget(empty, inner);
+        return;
+    }
+
+    let lines: Vec<Line<'static>> = logs
+        .iter()
+        .flat_map(|entry| {
+            // Multi-line messages get split across paragraph lines so
+            // long tool outputs are readable without word-wrap weirdness.
+            let head = Span::styled(
+                format!("[{:>4}] ", entry.seq),
+                Style::default().fg(COLOR_HINT_DESC),
+            );
+            let level_label = format!("{:?}", entry.level).to_uppercase();
+            let level_span = Span::styled(
+                format!("{level_label:5}"),
+                Style::default()
+                    .fg(level_color(entry.level))
+                    .add_modifier(Modifier::BOLD),
+            );
+            let category_span = Span::styled(
+                format!(" {:?} ", entry.category).to_lowercase(),
+                Style::default().fg(COLOR_HINT_DESC),
+            );
+            let mut out: Vec<Line<'static>> = Vec::new();
+            let mut first = true;
+            for chunk in entry.message.split('\n') {
+                if first {
+                    out.push(Line::from(vec![
+                        head.clone(),
+                        level_span.clone(),
+                        category_span.clone(),
+                        Span::raw(chunk.to_string()),
+                    ]));
+                    first = false;
+                } else {
+                    out.push(Line::from(Span::raw(format!("        {chunk}"))));
+                }
+            }
+            out
+        })
+        .collect();
+
+    let p = Paragraph::new(lines).wrap(Wrap { trim: false });
+    f.render_widget(p, inner);
+}
+
+/// "(N running)" badge text for the status bar when the pane is closed.
+/// Returns an empty string when N is zero so the badge is invisible at
+/// rest.
+pub fn running_badge(pane: &TaskPane) -> String {
+    let n = pane.running_count();
+    if n == 0 {
+        String::new()
+    } else {
+        format!("({n} running)")
+    }
 }
 
 #[cfg(test)]
@@ -405,5 +831,60 @@ mod tests {
         let mut pane = TaskPane::new();
         pane.apply_task_started(view("t-1", "Title that is fairly long", TaskStatus::Running));
         let _ = render_to_buffer(&pane, 40, 12);
+    }
+
+    // --- age_label tests -----------------------------------------------
+
+    fn row_with_start(start_ms: i64, end_ms: Option<i64>) -> TaskRow {
+        TaskRow {
+            id: TaskId("x".into()),
+            title: "".into(),
+            status: TaskStatus::Running,
+            started_at: start_ms,
+            ended_at: end_ms,
+            last_error: None,
+            parent: None,
+            progress_hint: None,
+            conversation_id: None,
+        }
+    }
+
+    #[test]
+    fn age_label_under_one_minute_renders_seconds() {
+        let row = row_with_start(0, None);
+        assert_eq!(age_label(&row, 12_000), "12s");
+    }
+
+    #[test]
+    fn age_label_minutes_at_or_above_60_seconds() {
+        let row = row_with_start(0, None);
+        assert_eq!(age_label(&row, 120_000), "2m");
+    }
+
+    #[test]
+    fn age_label_hours_at_or_above_one_hour() {
+        let row = row_with_start(0, None);
+        assert_eq!(age_label(&row, 7_200_000), "2h");
+    }
+
+    #[test]
+    fn age_label_days_at_or_above_one_day() {
+        let row = row_with_start(0, None);
+        assert_eq!(age_label(&row, 2 * 86_400 * 1_000), "2d");
+    }
+
+    #[test]
+    fn age_label_uses_ended_at_when_terminal() {
+        let row = row_with_start(0, Some(10_000));
+        // Now is way past, but ended_at pins the age at 10s.
+        assert_eq!(age_label(&row, 1_000_000), "10s");
+    }
+
+    #[test]
+    fn age_label_negative_delta_clamps_to_zero() {
+        // Clock skew protection: if ended_at < started_at we don't
+        // render "-5s" or panic.
+        let row = row_with_start(100, Some(50));
+        assert_eq!(age_label(&row, 0), "0s");
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -66,6 +66,12 @@ pub fn draw(f: &mut Frame, app: &mut App) {
     if matches!(app.mode, InputMode::Renaming) {
         draw_rename_popup(f, app, f.area());
     }
+
+    // Tasks pane overlays on top of the chat (and any rename popup —
+    // it's strictly modal). Rendered last so it's on top.
+    if app.tasks.visible {
+        crate::tasks::draw_overlay(f, &app.tasks, f.area());
+    }
 }
 
 fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {
@@ -417,16 +423,30 @@ fn draw_input(f: &mut Frame, app: &mut App, area: ratatui::layout::Rect) {
 }
 
 fn draw_status_bar(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
-    if app.status_message.is_empty() {
+    let badge = if app.tasks.visible {
+        String::new()
+    } else {
+        crate::tasks::running_badge(&app.tasks)
+    };
+    if app.status_message.is_empty() && badge.is_empty() {
         return;
     }
-    let status = Paragraph::new(Line::from(vec![
-        Span::styled(" • ", Style::default().fg(COLOR_STATUS_DIM)),
-        Span::styled(
-            app.status_message.as_str(),
-            Style::default().fg(Color::White),
-        ),
-    ]));
+    let mut spans: Vec<Span> = Vec::with_capacity(4);
+    spans.push(Span::styled(" • ", Style::default().fg(COLOR_STATUS_DIM)));
+    spans.push(Span::styled(
+        app.status_message.as_str(),
+        Style::default().fg(Color::White),
+    ));
+    if !badge.is_empty() {
+        spans.push(Span::raw("  "));
+        spans.push(Span::styled(
+            badge,
+            Style::default()
+                .fg(Color::Rgb(122, 163, 255))
+                .add_modifier(Modifier::BOLD),
+        ));
+    }
+    let status = Paragraph::new(Line::from(spans));
     f.render_widget(status, area);
 }
 


### PR DESCRIPTION
Closes #45

Part of adelie-ai/desktop-assistant#117 epic.

## Summary

Implements the process-manager overlay (`Ctrl+P`) that lists background
tasks (subagents + user-initiated standalone agents) emitted by the
daemon's background-task registry. Wires the new
`SignalEvent::Task*` variants into the existing signal channel,
populates the pane via `ListBackgroundTasks`+`SubscribeBackgroundTasks`
on connect, and supports cancel + jump-to-conversation from the
selection.

## Depends on

- adelie-ai/desktop-assistant#137 (small additive: adds
  `SignalEvent::Task*` variants to `client-common`'s
  `map_event_to_signal`). Pinned via Cargo.toml branch reference;
  needs to merge first.

## Keybind choice

`Ctrl+P` ("process manager"). `Ctrl+T` is already used for the
debug-view toggle and a chord `g t` would have required a new key-state
machine that none of the existing bindings use today.

While the pane is visible:

- `j/k` (or arrows) navigate the task list
- `c` requests `CancelBackgroundTask` for the selected task
- `Enter` jumps to the linked conversation (and closes the pane)
- `Esc` or `Ctrl+P` close the pane
- Other normal-mode keys (`i`, `q`, etc.) are swallowed so they don't
  fire through to the hidden chat

When the pane is closed, a small `(N running)` badge appears in the
status bar.

## What's in scope

- `src/tasks.rs` — new module with `TaskPane`, `TaskRow`,
  `draw_overlay`, `running_badge`, `age_label`. State methods:
  `apply_task_started/_progress/_log_appended/_completed`,
  `set_initial`, `toggle`, `move_selection`, `running_count`,
  `selected_row`, `selected_logs_vec`.
- `src/app.rs` — `App.tasks: TaskPane`, plus `toggle_tasks_pane`,
  `jump_to_selected_task_conversation`, `request_cancel_selected_task`.
- `src/keys.rs` — five new `Action` variants and a
  `tasks_pane_visible: bool` parameter on `handle_key_event`.
- `src/main.rs` — wires `SignalEvent::Task*` into `app.tasks`, adds
  `init_background_tasks` for initial snapshot + subscribe (called at
  initial connect and on each reconnect), and handles the new action
  variants.
- `src/ui.rs` — overlays the pane and renders the running badge.

## What's out of scope

- Spawning standalone agents from the UI (separate follow-up once the
  API stabilizes — issue mentions this explicitly).
- Drill-down into the subagent's own conversation messages — `Enter`
  already gets you to that conversation; no new view needed.
- Tests against a real daemon (mocked via `TaskPane.apply_task_*` calls
  and `TestBackend` for render).

## Per-event resilience

- `TaskProgress` / `TaskCompleted` for unknown task ids are dropped
  silently (race during connect before the snapshot lands; benign).
- `TaskLogAppended` for unknown task ids buffers the entry anyway, so
  when the late `TaskStarted` arrives, logs are already in place.
- A 600-entry burst is reduced to the most recent 500 (`log_ring_caps_at_500_entries`).
- A 200-entry rapid burst keeps strictly increasing seq order
  (`rapid_event_burst_preserves_ordering`).

## Test plan

Every test listed in the issue plus extras for the wiring:

State / behavior tests:

- [x] `task_started_event_adds_row_to_pane`
- [x] `task_completed_event_updates_status_badge`
- [x] `task_completed_with_failure_records_last_error`
- [x] `task_progress_updates_hint`
- [x] `task_progress_for_unknown_id_is_benign`
- [x] `task_log_appended_for_unknown_id_buffers_anyway`
- [x] `task_completed_for_unknown_id_is_benign`
- [x] `log_ring_caps_at_500_entries`
- [x] `rapid_event_burst_preserves_ordering`
- [x] `set_initial_replaces_full_set_and_preserves_selection_if_present`
- [x] `set_initial_picks_first_when_selection_gone`
- [x] `toggle_flips_visibility_and_picks_first_selection`
- [x] `move_selection_wraps_at_boundaries`
- [x] `move_selection_on_empty_is_noop`
- [x] `running_count_only_counts_pending_and_running`
- [x] `task_row_from_view_extracts_conversation_id_for_standalone`
- [x] `task_row_from_view_extracts_conversation_id_for_subagent`
- [x] `running_badge_empty_when_zero_running`
- [x] `running_badge_renders_count_when_running`

Render tests:

- [x] `tasks_pane_renders_empty_state_when_no_tasks`
- [x] `tasks_pane_renders_three_running_tasks_with_status_badges`
- [x] `tasks_pane_shows_log_entries_for_selected_task`
- [x] `tasks_pane_renders_at_small_widths_without_panic`
- [x] `age_label_*` (six cases: seconds / minutes / hours / days /
      clamped / uses-ended-at)

Key routing tests:

- [x] `ctrl_p_toggles_tasks_pane_in_normal` / `_in_editing`
- [x] `ctrl_p_also_closes_pane_when_open`
- [x] `tasks_pane_visible_routes_{j,k,down,up,c,enter,esc}_to_*`
- [x] `tasks_pane_visible_swallows_unmapped_keys_in_editing_mode`
- [x] `tasks_pane_visible_still_lets_f2_through`

App glue tests:

- [x] `keybind_toggles_pane_visibility`
- [x] `pressing_enter_on_selection_switches_to_linked_conversation`
- [x] `jump_to_selected_task_conversation_returns_id_even_when_not_in_sidebar`
- [x] `pressing_c_on_selection_requests_cancel_command`
- [x] `cancelling_a_terminal_task_is_a_noop`
- [x] `cancel_with_no_selection_is_a_noop`
- [x] `business_outcome_user_sees_their_spawned_standalone_agent_in_the_list_with_correct_title`

Verification:

- [x] `cargo test` — 248/248 pass
- [x] `cargo build` — clean
- [x] `cargo clippy --all-targets` — zero warnings on new code
      (pre-existing warnings unchanged; warning count actually
      dropped from 18 to 11 because the new code wires up methods
      previously detected as dead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)