### PR TITLE
Evict terminal rows from task pane on TaskCompleted

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -191,21 +191,10 @@ impl App {
 
     /// Stage a `CancelBackgroundTask` for the highlighted task. Returns
     /// the task id so the caller can fire the command. `None` when
-    /// nothing is selected or the task is already terminal.
+    /// nothing is selected — terminal rows are evicted from the pane,
+    /// so a selected row is always cancellable.
     pub fn request_cancel_selected_task(&mut self) -> Option<TaskId> {
         let row = self.tasks.selected_row()?;
-        // Don't fire cancellations against terminal states — the
-        // daemon would reject them anyway and we'd spin in the status
-        // bar.
-        if matches!(
-            row.status,
-            desktop_assistant_api_model::TaskStatus::Completed
-                | desktop_assistant_api_model::TaskStatus::Failed
-                | desktop_assistant_api_model::TaskStatus::Cancelled
-        ) {
-            self.status_message = format!("Task {} is already terminal", row.id);
-            return None;
-        }
         let id = row.id.clone();
         self.pending_task_cancel = Some(id.clone());
         self.status_message = format!("Cancelling {id}...");
@@ -1358,8 +1347,7 @@ mod tests {
         app.tasks
             .apply_task_started(standalone_view("t-1", "conv-x", "Researcher"));
         app.tasks.selected = Some(desktop_assistant_api_model::TaskId("t-1".into()));
-        app.tasks
-            .apply_task_completed("t-1", desktop_assistant_api_model::TaskStatus::Completed, None);
+        app.tasks.apply_task_completed("t-1");
 
         assert!(
             !app.tasks

--- a/src/app.rs
+++ b/src/app.rs
@@ -1349,18 +1349,26 @@ mod tests {
     }
 
     #[test]
-    fn cancelling_a_terminal_task_is_a_noop() {
+    fn cancelling_after_task_completes_finds_nothing_because_row_was_evicted() {
+        // With terminal-row eviction, a completed task disappears from
+        // the pane. A subsequent cancel request finds no selected row
+        // and returns silently — there is no "already terminal" branch
+        // to hit because terminal rows can't exist.
         let mut app = App::new();
         app.tasks
             .apply_task_started(standalone_view("t-1", "conv-x", "Researcher"));
+        app.tasks.selected = Some(desktop_assistant_api_model::TaskId("t-1".into()));
         app.tasks
             .apply_task_completed("t-1", desktop_assistant_api_model::TaskStatus::Completed, None);
-        app.tasks.selected = Some(desktop_assistant_api_model::TaskId("t-1".into()));
 
+        assert!(
+            !app.tasks
+                .tasks
+                .contains_key(&desktop_assistant_api_model::TaskId("t-1".into()))
+        );
         let id = app.request_cancel_selected_task();
         assert!(id.is_none());
         assert!(app.pending_task_cancel.is_none());
-        assert!(app.status_message.contains("already terminal"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -419,14 +419,14 @@ async fn run(
                     SignalEvent::TaskLogAppended { id, entry } => {
                         app.tasks.apply_task_log_appended(&id, entry);
                     }
-                    SignalEvent::TaskCompleted { id, status, last_error } => {
+                    SignalEvent::TaskCompleted { id, .. } => {
                         // Clear the cancel spinner if we were waiting on this
-                        // task. The terminal status (`Cancelled`/`Completed`/
-                        // `Failed`) is the authoritative resolution.
+                        // task; the terminal event is the authoritative
+                        // resolution.
                         if app.pending_task_cancel.as_ref().map(|t| t.0.as_str()) == Some(id.as_str()) {
                             app.pending_task_cancel = None;
                         }
-                        app.tasks.apply_task_completed(&id, status, last_error);
+                        app.tasks.apply_task_completed(&id);
                     }
                 }
             }

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -585,22 +585,66 @@ mod tests {
     }
 
     #[test]
-    fn task_completed_event_updates_status_badge() {
+    fn task_completed_event_removes_row() {
         let mut pane = TaskPane::new();
         pane.apply_task_started(view("t-1", "Researcher", TaskStatus::Running));
         pane.apply_task_completed("t-1", TaskStatus::Completed, None);
-        let row = pane.tasks.get(&TaskId("t-1".into())).unwrap();
-        assert!(matches!(row.status, TaskStatus::Completed));
+        assert!(!pane.tasks.contains_key(&TaskId("t-1".into())));
     }
 
     #[test]
-    fn task_completed_with_failure_records_last_error() {
+    fn task_failed_event_removes_row() {
         let mut pane = TaskPane::new();
         pane.apply_task_started(view("t-1", "Researcher", TaskStatus::Running));
         pane.apply_task_completed("t-1", TaskStatus::Failed, Some("LLM timed out".into()));
-        let row = pane.tasks.get(&TaskId("t-1".into())).unwrap();
-        assert!(matches!(row.status, TaskStatus::Failed));
-        assert_eq!(row.last_error.as_deref(), Some("LLM timed out"));
+        assert!(!pane.tasks.contains_key(&TaskId("t-1".into())));
+    }
+
+    #[test]
+    fn task_cancelled_event_removes_row() {
+        let mut pane = TaskPane::new();
+        pane.apply_task_started(view("t-1", "Researcher", TaskStatus::Running));
+        pane.apply_task_completed("t-1", TaskStatus::Cancelled, None);
+        assert!(!pane.tasks.contains_key(&TaskId("t-1".into())));
+    }
+
+    #[test]
+    fn task_completed_drops_log_buffer() {
+        let mut pane = TaskPane::new();
+        pane.apply_task_started(view("t-1", "Researcher", TaskStatus::Running));
+        pane.apply_task_log_appended("t-1", log(1, "hello"));
+        pane.apply_task_log_appended("t-1", log(2, "world"));
+        pane.apply_task_completed("t-1", TaskStatus::Completed, None);
+        assert!(!pane.task_logs.contains_key(&TaskId("t-1".into())));
+    }
+
+    #[test]
+    fn task_completed_advances_selection_when_selected_row_evicted() {
+        let mut pane = TaskPane::new();
+        pane.apply_task_started(view("t-1", "Alpha", TaskStatus::Running));
+        pane.apply_task_started(view("t-2", "Beta", TaskStatus::Running));
+        pane.selected = Some(TaskId("t-1".into()));
+        pane.apply_task_completed("t-1", TaskStatus::Completed, None);
+        assert_eq!(pane.selected.as_ref(), Some(&TaskId("t-2".into())));
+    }
+
+    #[test]
+    fn task_completed_clears_selection_when_last_row_evicted() {
+        let mut pane = TaskPane::new();
+        pane.apply_task_started(view("t-1", "Solo", TaskStatus::Running));
+        pane.selected = Some(TaskId("t-1".into()));
+        pane.apply_task_completed("t-1", TaskStatus::Completed, None);
+        assert!(pane.selected.is_none());
+    }
+
+    #[test]
+    fn task_completed_leaves_other_selection_alone() {
+        let mut pane = TaskPane::new();
+        pane.apply_task_started(view("t-1", "Alpha", TaskStatus::Running));
+        pane.apply_task_started(view("t-2", "Beta", TaskStatus::Running));
+        pane.selected = Some(TaskId("t-2".into()));
+        pane.apply_task_completed("t-1", TaskStatus::Completed, None);
+        assert_eq!(pane.selected.as_ref(), Some(&TaskId("t-2".into())));
     }
 
     #[test]

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -164,19 +164,12 @@ impl TaskPane {
         }
     }
 
-    pub fn apply_task_completed(
-        &mut self,
-        id: &str,
-        status: TaskStatus,
-        last_error: Option<String>,
-    ) {
+    pub fn apply_task_completed(&mut self, id: &str) {
         let key = TaskId(id.to_string());
-        if let Some(row) = self.tasks.get_mut(&key) {
-            row.status = status;
-            row.last_error = last_error;
-            // `ended_at` is set lazily on the next snapshot; the daemon
-            // is the authoritative source. We don't fabricate a
-            // timestamp here.
+        let removed = self.tasks.remove(&key).is_some();
+        self.task_logs.remove(&key);
+        if removed && self.selected.as_ref() == Some(&key) {
+            self.normalize_selection();
         }
     }
 
@@ -588,7 +581,7 @@ mod tests {
     fn task_completed_event_removes_row() {
         let mut pane = TaskPane::new();
         pane.apply_task_started(view("t-1", "Researcher", TaskStatus::Running));
-        pane.apply_task_completed("t-1", TaskStatus::Completed, None);
+        pane.apply_task_completed("t-1");
         assert!(!pane.tasks.contains_key(&TaskId("t-1".into())));
     }
 
@@ -596,7 +589,7 @@ mod tests {
     fn task_failed_event_removes_row() {
         let mut pane = TaskPane::new();
         pane.apply_task_started(view("t-1", "Researcher", TaskStatus::Running));
-        pane.apply_task_completed("t-1", TaskStatus::Failed, Some("LLM timed out".into()));
+        pane.apply_task_completed("t-1");
         assert!(!pane.tasks.contains_key(&TaskId("t-1".into())));
     }
 
@@ -604,7 +597,7 @@ mod tests {
     fn task_cancelled_event_removes_row() {
         let mut pane = TaskPane::new();
         pane.apply_task_started(view("t-1", "Researcher", TaskStatus::Running));
-        pane.apply_task_completed("t-1", TaskStatus::Cancelled, None);
+        pane.apply_task_completed("t-1");
         assert!(!pane.tasks.contains_key(&TaskId("t-1".into())));
     }
 
@@ -614,7 +607,7 @@ mod tests {
         pane.apply_task_started(view("t-1", "Researcher", TaskStatus::Running));
         pane.apply_task_log_appended("t-1", log(1, "hello"));
         pane.apply_task_log_appended("t-1", log(2, "world"));
-        pane.apply_task_completed("t-1", TaskStatus::Completed, None);
+        pane.apply_task_completed("t-1");
         assert!(!pane.task_logs.contains_key(&TaskId("t-1".into())));
     }
 
@@ -624,7 +617,7 @@ mod tests {
         pane.apply_task_started(view("t-1", "Alpha", TaskStatus::Running));
         pane.apply_task_started(view("t-2", "Beta", TaskStatus::Running));
         pane.selected = Some(TaskId("t-1".into()));
-        pane.apply_task_completed("t-1", TaskStatus::Completed, None);
+        pane.apply_task_completed("t-1");
         assert_eq!(pane.selected.as_ref(), Some(&TaskId("t-2".into())));
     }
 
@@ -633,7 +626,7 @@ mod tests {
         let mut pane = TaskPane::new();
         pane.apply_task_started(view("t-1", "Solo", TaskStatus::Running));
         pane.selected = Some(TaskId("t-1".into()));
-        pane.apply_task_completed("t-1", TaskStatus::Completed, None);
+        pane.apply_task_completed("t-1");
         assert!(pane.selected.is_none());
     }
 
@@ -643,7 +636,7 @@ mod tests {
         pane.apply_task_started(view("t-1", "Alpha", TaskStatus::Running));
         pane.apply_task_started(view("t-2", "Beta", TaskStatus::Running));
         pane.selected = Some(TaskId("t-2".into()));
-        pane.apply_task_completed("t-1", TaskStatus::Completed, None);
+        pane.apply_task_completed("t-1");
         assert_eq!(pane.selected.as_ref(), Some(&TaskId("t-2".into())));
     }
 
@@ -679,7 +672,7 @@ mod tests {
     #[test]
     fn task_completed_for_unknown_id_is_benign() {
         let mut pane = TaskPane::new();
-        pane.apply_task_completed("missing", TaskStatus::Completed, None);
+        pane.apply_task_completed("missing");
         assert!(pane.tasks.is_empty());
     }
 


### PR DESCRIPTION
## Summary

- `TaskPane::apply_task_completed` now removes the row (and its log buffer) from the local cache instead of mutating its status in place.
- Drops the now-unused `status` / `last_error` parameters from `apply_task_completed` — only one caller (`main.rs`) and it doesn't need them.
- Removes the dead "already terminal" branch in `request_cancel_selected_task` since a selected row can no longer be terminal.

The daemon already filters terminal tasks out of `ListBackgroundTasks(include_finished: false)` for the initial snapshot, so without UI-side removal the pane accumulated colored badges for every finished task until reconnect.

Two commits: failing tests first (TDD), implementation second.

## Test plan

- [x] `cargo test` — 254 passing, 0 failing
- [ ] Manual: send several chat messages with the TUI open; confirm `Ctrl+P` shows only in-flight tasks and that completed/failed/cancelled rows disappear immediately on completion
- [ ] Manual: with a subagent in flight, select it, observe it complete — selection should advance to a sibling row (or clear if it was the only one)

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)