### PR TITLE
feat(cli): default to UDS; add --socket/--ws connection flags

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,6 +271,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -298,22 +299,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "base16ct"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
-
-[[package]]
-name = "base64ct"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bincode"
@@ -570,12 +559,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-oid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
-
-[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -663,18 +646,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-bigint"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
-dependencies = [
- "generic-array",
- "rand_core 0.6.4",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,33 +663,6 @@ checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
 dependencies = [
  "lab",
  "phf",
-]
-
-[[package]]
-name = "curve25519-dalek"
-version = "4.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "curve25519-dalek-derive",
- "digest",
- "fiat-crypto",
- "rustc_version",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -797,17 +741,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
-name = "der"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
-dependencies = [
- "const-oid",
- "pem-rfc7468",
- "zeroize",
-]
-
-[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -841,7 +774,7 @@ dependencies = [
 [[package]]
 name = "desktop-assistant-api-model"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#f3ba5bd88fa04ae211f3057c3eaf591c19188834"
+source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#15efad50fee76e57bbe2bb7d0617642997151dcf"
 dependencies = [
  "desktop-assistant-core",
  "serde",
@@ -851,7 +784,7 @@ dependencies = [
 [[package]]
 name = "desktop-assistant-auth-jwt"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#f3ba5bd88fa04ae211f3057c3eaf591c19188834"
+source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#15efad50fee76e57bbe2bb7d0617642997151dcf"
 dependencies = [
  "anyhow",
  "jsonwebtoken",
@@ -862,7 +795,7 @@ dependencies = [
 [[package]]
 name = "desktop-assistant-client-common"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#f3ba5bd88fa04ae211f3057c3eaf591c19188834"
+source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#15efad50fee76e57bbe2bb7d0617642997151dcf"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -882,7 +815,7 @@ dependencies = [
 [[package]]
 name = "desktop-assistant-core"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#f3ba5bd88fa04ae211f3057c3eaf591c19188834"
+source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#15efad50fee76e57bbe2bb7d0617642997151dcf"
 dependencies = [
  "async-trait",
  "backon",
@@ -903,7 +836,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
- "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -935,69 +867,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
-name = "ecdsa"
-version = "0.16.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
-dependencies = [
- "der",
- "digest",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
-]
-
-[[package]]
-name = "ed25519"
-version = "2.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
-dependencies = [
- "pkcs8",
- "signature",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
-dependencies = [
- "curve25519-dalek",
- "ed25519",
- "serde",
- "sha2",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
-
-[[package]]
-name = "elliptic-curve"
-version = "0.13.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
-dependencies = [
- "base16ct",
- "crypto-bigint",
- "digest",
- "ff",
- "generic-array",
- "group",
- "hkdf",
- "pem-rfc7468",
- "pkcs8",
- "rand_core 0.6.4",
- "sec1",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "encoding_rs"
@@ -1107,22 +980,6 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
-
-[[package]]
-name = "ff"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
-dependencies = [
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
-name = "fiat-crypto"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filedescriptor"
@@ -1305,7 +1162,6 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
- "zeroize",
 ]
 
 [[package]]
@@ -1358,17 +1214,6 @@ dependencies = [
  "futures-core",
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "group"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
-dependencies = [
- "ff",
- "rand_core 0.6.4",
- "subtle",
 ]
 
 [[package]]
@@ -1869,19 +1714,13 @@ version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
+ "aws-lc-rs",
  "base64",
- "ed25519-dalek",
  "getrandom 0.2.17",
- "hmac",
  "js-sys",
- "p256",
- "p384",
  "pem",
- "rand 0.8.6",
- "rsa",
  "serde",
  "serde_json",
- "sha2",
  "signature",
  "simple_asn1",
  "zeroize",
@@ -1921,9 +1760,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "leb128fmt"
@@ -1945,12 +1781,6 @@ checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
 dependencies = [
  "pkg-config",
 ]
-
-[[package]]
-name = "libm"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "line-clipping"
@@ -2146,22 +1976,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint-dig"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.6",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2225,7 +2039,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -2306,30 +2119,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "p256"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2",
-]
-
-[[package]]
-name = "p384"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "primeorder",
- "sha2",
-]
-
-[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2372,15 +2161,6 @@ checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64",
  "serde_core",
-]
-
-[[package]]
-name = "pem-rfc7468"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
-dependencies = [
- "base64ct",
 ]
 
 [[package]]
@@ -2502,27 +2282,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der",
- "pkcs8",
- "spki",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
-dependencies = [
- "der",
- "spki",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2593,15 +2352,6 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "primeorder"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
-dependencies = [
- "elliptic-curve",
 ]
 
 [[package]]
@@ -2993,16 +2743,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rfc6979"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
-dependencies = [
- "hmac",
- "subtle",
-]
-
-[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3012,28 +2752,8 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rsa"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
-dependencies = [
- "const-oid",
- "digest",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8",
- "rand_core 0.6.4",
- "signature",
- "spki",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -3138,7 +2858,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -3176,20 +2896,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "sec1"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
-dependencies = [
- "base16ct",
- "der",
- "generic-array",
- "pkcs8",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "secret-service"
@@ -3390,7 +3096,6 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
  "rand_core 0.6.4",
 ]
 
@@ -3454,22 +3159,6 @@ checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
-name = "spki"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
-dependencies = [
- "base64ct",
- "der",
 ]
 
 [[package]]
@@ -4075,6 +3764,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/src/connections.rs
+++ b/src/connections.rs
@@ -34,7 +34,7 @@ use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use desktop_assistant_api_model::{
     Command, CommandResult, ConnectionAvailability, ConnectionConfigView, ConnectionView,
 };
-use desktop_assistant_client_common::TransportClient;
+use desktop_assistant_client_common::{AssistantCommands, TransportClient};
 use futures::StreamExt;
 use ratatui::{
     Frame, Terminal,

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod toolbar;
 mod ui;
 
 use std::io;
+use std::path::PathBuf;
 
 use anyhow::Result;
 use clap::{CommandFactory, FromArgMatches, Parser, parser::ValueSource};
@@ -27,8 +28,8 @@ use crossterm::{
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
 use desktop_assistant_client_common::{
-    AssistantClient, ConnectionConfig, SignalEvent, TransportClient, TransportMode,
-    connect_transport, transport::transport_label,
+    AssistantClient, AssistantCommands, ConnectionConfig, SignalEvent, TransportClient,
+    TransportMode, connect_transport, transport::transport_label,
 };
 use futures::StreamExt;
 use ratatui::{Terminal, backend::CrosstermBackend};
@@ -49,6 +50,8 @@ const DEFAULT_WS_SUBJECT: &str = desktop_assistant_client_common::config::DEFAUL
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
 #[value(rename_all = "lower")]
 enum CliTransportMode {
+    /// Local Unix domain socket (the default).
+    Local,
     Ws,
     Dbus,
 }
@@ -56,13 +59,23 @@ enum CliTransportMode {
 #[derive(Debug, Parser)]
 #[command(name = "adele")]
 struct CliArgs {
+    /// Transport used when neither --socket nor --ws is given. Defaults to
+    /// the daemon's local Unix socket.
     #[arg(
         long,
         env = "DESKTOP_ASSISTANT_TUI_TRANSPORT",
         value_enum,
-        default_value_t = CliTransportMode::Ws
+        default_value_t = CliTransportMode::Local
     )]
     transport: CliTransportMode,
+    /// Connect over the daemon's local Unix socket. An optional PATH overrides
+    /// the default ($XDG_RUNTIME_DIR/adelie/sock). Mutually exclusive with --ws.
+    #[arg(long, value_name = "PATH", num_args = 0..=1, conflicts_with = "ws")]
+    socket: Option<Option<PathBuf>>,
+    /// Connect over WebSocket. An optional URL overrides --ws-url. Mutually
+    /// exclusive with --socket.
+    #[arg(long, value_name = "URL", num_args = 0..=1, conflicts_with = "socket")]
+    ws: Option<Option<String>>,
     #[arg(
         long = "ws-url",
         env = "DESKTOP_ASSISTANT_TUI_WS_URL",
@@ -97,9 +110,24 @@ impl From<CliArgs> for ConnectionConfig {
             }
         };
 
-        let transport_mode = match cli.transport {
-            CliTransportMode::Ws => TransportMode::Ws,
-            CliTransportMode::Dbus => TransportMode::Dbus,
+        // `--socket` and `--ws` are explicit selectors that override the
+        // (always-defaulted) `--transport`. clap makes them mutually
+        // exclusive, so at most one is `Some` here.
+        let (transport_mode, socket_path, ws_url) = if let Some(path) = cli.socket {
+            (TransportMode::Uds, path, ws_url)
+        } else if let Some(url) = cli.ws {
+            let resolved = match url {
+                Some(u) if !u.trim().is_empty() => u.trim().to_string(),
+                _ => ws_url,
+            };
+            (TransportMode::Ws, None, resolved)
+        } else {
+            let mode = match cli.transport {
+                CliTransportMode::Local => TransportMode::Uds,
+                CliTransportMode::Ws => TransportMode::Ws,
+                CliTransportMode::Dbus => TransportMode::Dbus,
+            };
+            (mode, None, ws_url)
         };
 
         Self {
@@ -109,6 +137,7 @@ impl From<CliArgs> for ConnectionConfig {
             ws_login_username: None,
             ws_login_password: None,
             ws_subject,
+            socket_path,
             ..Default::default()
         }
     }
@@ -188,7 +217,7 @@ fn schedule_reconnect(prev: Option<u64>) -> ReconnectState {
 /// flag or env var, in which case we skip the profile picker and connect
 /// using the provided values (matching pre-profile-picker behavior).
 fn any_explicit_connection_arg(matches: &clap::ArgMatches) -> bool {
-    ["transport", "ws_url", "ws_subject"]
+    ["transport", "socket", "ws", "ws_url", "ws_subject"]
         .iter()
         .any(|name| {
             matches!(
@@ -804,15 +833,74 @@ mod tests {
     }
 
     #[test]
-    fn clap_defaults_map_to_runtime_defaults() {
+    fn clap_default_with_no_flags_is_local_uds() {
         let cli = CliArgs::try_parse_from(args(&[])).unwrap();
         let config = ConnectionConfig::from(cli);
-        assert_eq!(config.transport_mode, TransportMode::Ws);
-        assert_eq!(config.ws_url, DEFAULT_WS_URL);
+        // UDS is now the default connector.
+        assert_eq!(config.transport_mode, TransportMode::Uds);
+        assert_eq!(config.socket_path, None); // None => daemon default socket
         assert_eq!(config.ws_subject, DEFAULT_WS_SUBJECT);
         assert_eq!(config.ws_jwt, None);
         assert_eq!(config.ws_login_username, None);
         assert_eq!(config.ws_login_password, None);
+    }
+
+    #[test]
+    fn socket_flag_without_value_selects_uds_default_path() {
+        let cli = CliArgs::try_parse_from(args(&["--socket"])).unwrap();
+        let config = ConnectionConfig::from(cli);
+        assert_eq!(config.transport_mode, TransportMode::Uds);
+        assert_eq!(config.socket_path, None);
+    }
+
+    #[test]
+    fn socket_flag_with_path_sets_socket_path() {
+        let cli = CliArgs::try_parse_from(args(&["--socket=/tmp/custom.sock"])).unwrap();
+        let config = ConnectionConfig::from(cli);
+        assert_eq!(config.transport_mode, TransportMode::Uds);
+        assert_eq!(config.socket_path, Some(PathBuf::from("/tmp/custom.sock")));
+    }
+
+    #[test]
+    fn ws_flag_with_url_selects_websocket() {
+        let cli = CliArgs::try_parse_from(args(&["--ws=wss://host/ws"])).unwrap();
+        let config = ConnectionConfig::from(cli);
+        assert_eq!(config.transport_mode, TransportMode::Ws);
+        assert_eq!(config.ws_url, "wss://host/ws");
+        assert_eq!(config.socket_path, None);
+    }
+
+    #[test]
+    fn ws_flag_without_value_falls_back_to_default_ws_url() {
+        let cli = CliArgs::try_parse_from(args(&["--ws"])).unwrap();
+        let config = ConnectionConfig::from(cli);
+        assert_eq!(config.transport_mode, TransportMode::Ws);
+        assert_eq!(config.ws_url, DEFAULT_WS_URL);
+    }
+
+    #[test]
+    fn socket_and_ws_are_mutually_exclusive() {
+        let error = CliArgs::try_parse_from(args(&["--socket", "--ws=wss://x/ws"]))
+            .expect_err("--socket and --ws must conflict");
+        assert!(error.to_string().contains("cannot be used with"));
+    }
+
+    #[test]
+    fn dbus_transport_still_selectable() {
+        // No regression: --transport dbus continues to map to D-Bus.
+        let cli = CliArgs::try_parse_from(args(&["--transport", "dbus"])).unwrap();
+        let config = ConnectionConfig::from(cli);
+        assert_eq!(config.transport_mode, TransportMode::Dbus);
+    }
+
+    #[test]
+    fn transport_ws_with_ws_url_still_works() {
+        // No regression: the explicit ws transport + --ws-url path.
+        let cli = CliArgs::try_parse_from(args(&["--transport", "ws", "--ws-url", "wss://h/ws"]))
+            .unwrap();
+        let config = ConnectionConfig::from(cli);
+        assert_eq!(config.transport_mode, TransportMode::Ws);
+        assert_eq!(config.ws_url, "wss://h/ws");
     }
 
     #[test]

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -138,7 +138,8 @@ impl FormState {
             password,
             had_stored_password: false,
             has_oauth_tokens: false,
-            transport: TransportMode::Ws,
+            // UDS is the default connector for local use.
+            transport: TransportMode::Uds,
         }
     }
 
@@ -247,6 +248,24 @@ fn single_line_textarea() -> TextArea<'static> {
     let mut ta = TextArea::default();
     ta.set_cursor_line_style(Style::default());
     ta
+}
+
+/// Forward cycle for the transport toggle: Local → WebSocket → D-Bus → Local.
+fn transport_next(t: TransportMode) -> TransportMode {
+    match t {
+        TransportMode::Uds => TransportMode::Ws,
+        TransportMode::Ws => TransportMode::Dbus,
+        TransportMode::Dbus => TransportMode::Uds,
+    }
+}
+
+/// Backward cycle (the reverse of [`transport_next`]).
+fn transport_prev(t: TransportMode) -> TransportMode {
+    match t {
+        TransportMode::Uds => TransportMode::Dbus,
+        TransportMode::Ws => TransportMode::Uds,
+        TransportMode::Dbus => TransportMode::Ws,
+    }
 }
 
 /// Run the picker until the user selects, creates, or quits.
@@ -412,14 +431,13 @@ fn handle_form_key(state: &mut PickerState, key: KeyEvent) {
                 Err(msg) => state.error = Some(msg),
             }
         }
-        // Transport field uses left/right or space to flip the toggle.
-        (KeyCode::Left | KeyCode::Right | KeyCode::Char(' '), _)
-            if state.form.focus == Field::Transport =>
-        {
-            state.form.transport = match state.form.transport {
-                TransportMode::Ws => TransportMode::Dbus,
-                TransportMode::Dbus => TransportMode::Ws,
-            };
+        // Transport field cycles Local → WebSocket → D-Bus with left/right
+        // (space steps forward).
+        (KeyCode::Right | KeyCode::Char(' '), _) if state.form.focus == Field::Transport => {
+            state.form.transport = transport_next(state.form.transport);
+        }
+        (KeyCode::Left, _) if state.form.focus == Field::Transport => {
+            state.form.transport = transport_prev(state.form.transport);
         }
         _ => match state.form.focus {
             Field::Name => {
@@ -551,6 +569,9 @@ fn apply_submission(state: &mut PickerState, submitted: SubmittedProfile) -> Res
         transport: submitted.transport,
         ws_url: submitted.ws_url,
         ws_subject: submitted.ws_subject,
+        // Saved Local profiles use the daemon's default socket; custom socket
+        // paths are a CLI-only concern (`adele --socket <path>`).
+        socket_path: None,
         username: submitted.username,
         has_password,
         has_jwt: submitted.has_oauth_tokens,
@@ -852,6 +873,8 @@ fn draw_transport_toggle(f: &mut Frame, area: Rect, state: &PickerState) {
     };
 
     let line = Line::from(vec![
+        render_chip("Local", state.form.transport == TransportMode::Uds),
+        Span::styled("  ", Style::default()),
         render_chip("WebSocket", state.form.transport == TransportMode::Ws),
         Span::styled("  ", Style::default()),
         render_chip("D-Bus", state.form.transport == TransportMode::Dbus),
@@ -1065,15 +1088,27 @@ mod tests {
     }
 
     #[test]
-    fn form_transport_toggles_with_arrow() {
+    fn new_form_defaults_to_local_transport() {
+        let state = make_state(vec![]);
+        assert_eq!(state.form.transport, TransportMode::Uds);
+    }
+
+    #[test]
+    fn form_transport_cycles_through_all_three_with_arrows() {
         let mut state = make_state(vec![]);
         state.mode = Mode::Form;
         state.form.focus = Field::Transport;
+        // Default is Local (UDS); Right steps forward through the cycle.
+        assert_eq!(state.form.transport, TransportMode::Uds);
+        handle_form_key(&mut state, key(KeyCode::Right));
         assert_eq!(state.form.transport, TransportMode::Ws);
         handle_form_key(&mut state, key(KeyCode::Right));
         assert_eq!(state.form.transport, TransportMode::Dbus);
+        handle_form_key(&mut state, key(KeyCode::Right));
+        assert_eq!(state.form.transport, TransportMode::Uds);
+        // Left steps backward.
         handle_form_key(&mut state, key(KeyCode::Left));
-        assert_eq!(state.form.transport, TransportMode::Ws);
+        assert_eq!(state.form.transport, TransportMode::Dbus);
     }
 
     #[test]

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -28,6 +28,11 @@ pub struct Profile {
     /// JWT subject claim. Only meaningful when `transport == Ws`.
     #[serde(default)]
     pub ws_subject: String,
+    /// Unix-domain-socket path. Only meaningful when `transport == Uds`;
+    /// `None` uses the daemon's default socket
+    /// (`$XDG_RUNTIME_DIR/adelie/sock`).
+    #[serde(default)]
+    pub socket_path: Option<PathBuf>,
     /// Username for password-based login. `None` means no username/password
     /// auth — fall back to JWT or anonymous.
     #[serde(default)]
@@ -58,6 +63,7 @@ impl Profile {
             transport,
             ws_url,
             ws_subject,
+            socket_path: None,
             username: None,
             has_password: false,
             has_jwt: false,
@@ -85,6 +91,7 @@ impl Profile {
             ws_jwt: jwt,
             ws_login_username: self.username.clone(),
             ws_login_password: password,
+            socket_path: self.socket_path.clone(),
             ..Default::default()
         }
     }
@@ -102,6 +109,10 @@ impl Profile {
         let detail = match self.transport {
             TransportMode::Ws => self.ws_url.clone(),
             TransportMode::Dbus => "D-Bus".to_string(),
+            TransportMode::Uds => match &self.socket_path {
+                Some(path) => format!("local · {}", path.display()),
+                None => "Local socket".to_string(),
+            },
         };
         if detail.is_empty() {
             self.name.clone()
@@ -189,6 +200,7 @@ mod transport_mode_serde {
         let token = match value {
             TransportMode::Ws => "ws",
             TransportMode::Dbus => "dbus",
+            TransportMode::Uds => "local",
         };
         s.serialize_str(token)
     }
@@ -198,6 +210,7 @@ mod transport_mode_serde {
         match token.as_str() {
             "ws" => Ok(TransportMode::Ws),
             "dbus" => Ok(TransportMode::Dbus),
+            "local" | "uds" => Ok(TransportMode::Uds),
             other => Err(serde::de::Error::custom(format!(
                 "unknown transport mode {other:?}"
             ))),
@@ -286,5 +299,47 @@ mod tests {
         assert!(cfg.ws_jwt.is_none());
         assert!(cfg.ws_login_username.is_none());
         assert!(cfg.ws_login_password.is_none());
+    }
+
+    #[test]
+    fn uds_transport_serializes_as_local_token_and_round_trips() {
+        let mut p = Profile::new(
+            "Home".into(),
+            TransportMode::Uds,
+            String::new(),
+            String::new(),
+        );
+        p.socket_path = Some(PathBuf::from("/run/user/1000/adelie/sock"));
+        let json = serde_json::to_string(&p).unwrap();
+        assert!(json.contains("\"transport\":\"local\""));
+        let back: Profile = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, p);
+    }
+
+    #[test]
+    fn uds_token_accepts_both_local_and_uds_spellings() {
+        for token in ["local", "uds"] {
+            let json = format!(
+                r#"{{"id":"1","name":"X","transport":"{token}","ws_url":"","ws_subject":""}}"#
+            );
+            let p: Profile = serde_json::from_str(&json).unwrap();
+            assert_eq!(p.transport, TransportMode::Uds);
+            // Absent socket_path defaults to None (use the daemon's default).
+            assert!(p.socket_path.is_none());
+        }
+    }
+
+    #[test]
+    fn to_connection_config_carries_socket_path_for_uds() {
+        let mut p = Profile::new(
+            "Home".into(),
+            TransportMode::Uds,
+            String::new(),
+            String::new(),
+        );
+        p.socket_path = Some(PathBuf::from("/tmp/custom.sock"));
+        let cfg = p.to_connection_config();
+        assert_eq!(cfg.transport_mode, TransportMode::Uds);
+        assert_eq!(cfg.socket_path, Some(PathBuf::from("/tmp/custom.sock")));
     }
 }

--- a/src/purposes.rs
+++ b/src/purposes.rs
@@ -32,7 +32,7 @@ use desktop_assistant_api_model::{
     Command, CommandResult, ConnectionView, EffortLevel, ModelListing, PurposeConfigView,
     PurposeKindApi, PurposesView,
 };
-use desktop_assistant_client_common::TransportClient;
+use desktop_assistant_client_common::{AssistantCommands, TransportClient};
 use futures::StreamExt;
 use ratatui::{
     Frame, Terminal,


### PR DESCRIPTION
Closes #54

Makes the daemon's local Unix socket the default connector for the TUI and adds explicit `--socket` / `--ws` selectors (issue #54 plus the "UDS as default connector" follow-up).

## How

- `--socket [PATH]` selects UDS (optional PATH overrides `$XDG_RUNTIME_DIR/adelie/sock`); `--ws [URL]` selects WebSocket. Mutually exclusive. `--transport` now defaults to `local`, so `adele` with no flags connects over UDS.
- `Profile` serde gains the `"local"` token + optional `socket_path`; `to_connection_config` threads it through. The picker's transport toggle becomes 3-way (Local / WebSocket / D-Bus) and new profiles default to **Local**. Saved Local profiles use the default socket; custom paths are CLI-only via `--socket <path>`.
- D-Bus and the explicit `--transport ws` / `--ws-url` paths are unchanged.

## Tests (spec-driven, edge + failure modes)

No-flag default → UDS; `--socket` and `--socket=/path`; `--ws=url` and bare `--ws` fallback; `--socket` + `--ws` conflict errors; `--transport dbus`; `--transport ws --ws-url`; profile serde round-trip for `local` (accepts both `"local"`/`"uds"`); picker default-to-Local + 3-way cycle. Full `cargo test` green (516 tests).

## Dependency hygiene (side effect)

Bumping the client-common git dep to current main (for `TransportMode::Uds`, adelie-ai/desktop-assistant#159) also pulls in the `jsonwebtoken → aws_lc_rs` switch (adelie-ai/desktop-assistant#143), dropping the `rsa` + pure-Rust elliptic-curve stack (27 crates, incl. RUSTSEC-2023-0071) from the tui's dependency graph.

## Pre-existing drift (out of scope)

This PR's new code is `cargo fmt` + clippy clean. The crate has pre-existing fmt/clippy drift under the current toolchain (no pin, no CI), tracked in #58 — intentionally not bundled here to keep the diff reviewable.

The tasks-pane grouping originally bundled in #54 is split into #57 (blocked on desktop-assistant #160 → #158).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
