### PR TITLE
feat(tui): migrate credentials to keyring-core 1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,7 +12,7 @@ dependencies = [
  "desktop-assistant-api-model",
  "desktop-assistant-client-common",
  "futures",
- "keyring",
+ "keyring-core",
  "oauth2",
  "open",
  "pulldown-cmark",
@@ -25,6 +25,7 @@ dependencies = [
  "syntect",
  "tokio",
  "url",
+ "zbus-secret-service-keyring-store",
 ]
 
 [[package]]
@@ -146,6 +147,20 @@ dependencies = [
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
 ]
 
 [[package]]
@@ -704,35 +719,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
-name = "dbus"
-version = "0.9.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
-dependencies = [
- "libc",
- "libdbus-sys",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "dbus-secret-service"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
-dependencies = [
- "aes",
- "block-padding",
- "cbc",
- "dbus",
- "fastrand",
- "hkdf",
- "num",
- "once_cell",
- "sha2",
- "zeroize",
-]
-
-[[package]]
 name = "deltae"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -807,7 +793,7 @@ dependencies = [
  "tokio-tungstenite",
  "tracing",
  "uuid",
- "zbus 5.15.0",
+ "zbus",
 ]
 
 [[package]]
@@ -1736,15 +1722,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "keyring"
-version = "3.6.3"
+name = "keyring-core"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+checksum = "fb1e621458ca9c51aa110bd0339d4751a056b9576bf1253aee1aa560dda0fc9d"
 dependencies = [
- "dbus-secret-service",
  "log",
- "secret-service",
- "zeroize",
 ]
 
 [[package]]
@@ -1770,15 +1753,6 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
-
-[[package]]
-name = "libdbus-sys"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
-dependencies = [
- "pkg-config",
-]
 
 [[package]]
 name = "line-clipping"
@@ -2260,12 +2234,6 @@ dependencies = [
  "fastrand",
  "futures-io",
 ]
-
-[[package]]
-name = "pkg-config"
-version = "0.3.33"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plist"
@@ -2879,21 +2847,21 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "secret-service"
-version = "4.0.0"
+version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4d35ad99a181be0a60ffcbe85d680d98f87bdc4d7644ade319b87076b9dbfd4"
+checksum = "9a62d7f86047af0077255a29494136b9aaaf697c76ff70b8e49cded4e2623c14"
 dependencies = [
  "aes",
  "cbc",
  "futures-util",
  "generic-array",
+ "getrandom 0.2.17",
  "hkdf",
  "num",
  "once_cell",
- "rand 0.8.6",
  "serde",
  "sha2",
- "zbus 4.4.0",
+ "zbus",
 ]
 
 [[package]]
@@ -4315,16 +4283,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
-name = "xdg-home"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "yaml-rust"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4358,45 +4316,19 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
-dependencies = [
- "async-broadcast",
- "async-process",
- "async-recursion",
- "async-trait",
- "enumflags2",
- "event-listener",
- "futures-core",
- "futures-sink",
- "futures-util",
- "hex",
- "nix",
- "ordered-stream",
- "rand 0.8.6",
- "serde",
- "serde_repr",
- "sha1",
- "static_assertions",
- "tracing",
- "uds_windows",
- "windows-sys 0.52.0",
- "xdg-home",
- "zbus_macros 4.4.0",
- "zbus_names 3.0.0",
- "zvariant 4.2.0",
-]
-
-[[package]]
-name = "zbus"
 version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3bcbf15c8708d7fc1be0c993622e0a5cbd5e8b52bfa40afa4c3e0cd8d724ac1"
 dependencies = [
  "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
  "async-recursion",
+ "async-task",
  "async-trait",
+ "blocking",
  "enumflags2",
  "event-listener",
  "futures-core",
@@ -4413,22 +4345,20 @@ dependencies = [
  "uuid",
  "windows-sys 0.61.2",
  "winnow",
- "zbus_macros 5.15.0",
- "zbus_names 4.3.2",
- "zvariant 5.11.0",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
 ]
 
 [[package]]
-name = "zbus_macros"
-version = "4.4.0"
+name = "zbus-secret-service-keyring-store"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+checksum = "4ccede190ba363386a24e8021c7f3848393976609ec9f5d1f8c6c09ef37075b4"
 dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "zvariant_utils 2.1.0",
+ "keyring-core",
+ "secret-service",
+ "zbus",
 ]
 
 [[package]]
@@ -4441,20 +4371,9 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "zbus_names 4.3.2",
- "zvariant 5.11.0",
- "zvariant_utils 3.3.1",
-]
-
-[[package]]
-name = "zbus_names"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
-dependencies = [
- "serde",
- "static_assertions",
- "zvariant 4.2.0",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
 ]
 
 [[package]]
@@ -4465,7 +4384,7 @@ checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
 dependencies = [
  "serde",
  "winnow",
- "zvariant 5.11.0",
+ "zvariant",
 ]
 
 [[package]]
@@ -4570,19 +4489,6 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zvariant"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
-dependencies = [
- "endi",
- "enumflags2",
- "serde",
- "static_assertions",
- "zvariant_derive 4.2.0",
-]
-
-[[package]]
-name = "zvariant"
 version = "5.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c1567a6ec68df868cbbfde844cfc6d81649fe5109a62b116b19fabd53e618ee"
@@ -4591,21 +4497,8 @@ dependencies = [
  "enumflags2",
  "serde",
  "winnow",
- "zvariant_derive 5.11.0",
- "zvariant_utils 3.3.1",
-]
-
-[[package]]
-name = "zvariant_derive"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "zvariant_utils 2.1.0",
+ "zvariant_derive",
+ "zvariant_utils",
 ]
 
 [[package]]
@@ -4618,18 +4511,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "zvariant_utils 3.3.1",
-]
-
-[[package]]
-name = "zvariant_utils"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "zvariant_utils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,8 @@ clap = { version = "4", features = ["derive", "env"] }
 ratatui = { version = "0.30", features = ["unstable-rendered-line-info"] }
 crossterm = { version = "0.29", features = ["event-stream"] }
 futures = "0.3"
-keyring = { version = "3", features = ["sync-secret-service", "crypto-rust"] }
+keyring-core = "1"
+zbus-secret-service-keyring-store = { version = "1", features = ["rt-tokio-crypto-rust"] }
 oauth2 = "5"
 open = "5"
 pulldown-cmark = { version = "0.13", default-features = false }

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -7,7 +7,7 @@
 
 use std::{env, io};
 
-use keyring::Entry;
+use keyring_core::Entry;
 
 const SERVICE: &str = "adele-tui";
 
@@ -45,50 +45,98 @@ fn keyring_disabled() -> bool {
         .is_some_and(|v| matches!(v.as_str(), "1" | "true" | "yes"))
 }
 
+/// Run a blocking Secret Service operation without starving the async runtime.
+///
+/// keyring-core's Secret Service store drives D-Bus over zbus's *blocking*
+/// API, which must not run directly on an async worker thread. On a
+/// multi-thread runtime we hand the work to `block_in_place`; off a runtime
+/// (or on a current-thread runtime) we run inline.
+fn run_keyring_blocking<T>(operation: impl FnOnce() -> T) -> T {
+    use tokio::runtime::{Handle, RuntimeFlavor};
+    match Handle::try_current() {
+        Ok(handle) if handle.runtime_flavor() == RuntimeFlavor::MultiThread => {
+            tokio::task::block_in_place(operation)
+        }
+        _ => operation(),
+    }
+}
+
+/// Register the system Secret Service as keyring-core's default credential
+/// store. Best-effort: if it's unavailable (headless / no session bus) we warn
+/// and continue — credential calls then surface errors and callers fall back.
+/// Runs at startup before raw mode, so stderr is the visible channel here (the
+/// TUI has no tracing subscriber).
+pub fn init_store() {
+    if keyring_disabled() {
+        return;
+    }
+    run_keyring_blocking(|| match zbus_secret_service_keyring_store::Store::new() {
+        Ok(store) => keyring_core::set_default_store(store),
+        Err(error) => eprintln!("adele-tui: Secret Service unavailable; keyring disabled: {error}"),
+    });
+}
+
 pub fn store(profile_id: &str, kind: CredentialKind, secret: &str) -> io::Result<()> {
     if keyring_disabled() {
         return Err(io::Error::other("keyring disabled via env"));
     }
-    let key = account_key(profile_id, kind);
-    let entry = Entry::new(SERVICE, &key).map_err(map_err)?;
-    entry.set_password(secret).map_err(map_err)
+    run_keyring_blocking(|| {
+        let key = account_key(profile_id, kind);
+        let entry = Entry::new(SERVICE, &key).map_err(map_err)?;
+        entry.set_password(secret).map_err(map_err)
+    })
 }
 
 pub fn retrieve(profile_id: &str, kind: CredentialKind) -> io::Result<String> {
     if keyring_disabled() {
         return Err(io::Error::other("keyring disabled via env"));
     }
-    let key = account_key(profile_id, kind);
-    let entry = Entry::new(SERVICE, &key).map_err(map_err)?;
-    entry.get_password().map_err(map_err)
+    run_keyring_blocking(|| {
+        let key = account_key(profile_id, kind);
+        let entry = Entry::new(SERVICE, &key).map_err(map_err)?;
+        entry.get_password().map_err(map_err)
+    })
 }
 
 pub fn delete(profile_id: &str, kind: CredentialKind) -> io::Result<()> {
     if keyring_disabled() {
         return Ok(()); // Treat disabled keyring as a no-op for deletes.
     }
-    let key = account_key(profile_id, kind);
-    let entry = Entry::new(SERVICE, &key).map_err(map_err)?;
-    match entry.delete_credential() {
-        Ok(()) => Ok(()),
-        // Missing entries are not an error for the caller's purposes.
-        Err(keyring::Error::NoEntry) => Ok(()),
-        Err(e) => Err(map_err(e)),
-    }
+    run_keyring_blocking(|| {
+        let key = account_key(profile_id, kind);
+        let entry = Entry::new(SERVICE, &key).map_err(map_err)?;
+        match entry.delete_credential() {
+            Ok(()) => Ok(()),
+            // Missing entries are not an error for the caller's purposes.
+            Err(keyring_core::Error::NoEntry) => Ok(()),
+            Err(e) => Err(map_err(e)),
+        }
+    })
 }
 
-fn map_err(err: keyring::Error) -> io::Error {
+fn map_err(err: keyring_core::Error) -> io::Error {
     io::Error::other(err.to_string())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
+    use std::sync::{Mutex, Once};
 
     /// Serializes env-var mutation across the tests in this module so the
     /// parallel test runner doesn't race on `ADELE_TUI_DISABLE_KEYRING`.
     static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Registers an in-memory mock as keyring-core's default store exactly once
+    /// for the whole test binary, so the real store path (`Entry`, `store`,
+    /// `retrieve`, `delete`) is exercised without a session bus.
+    static MOCK_STORE: Once = Once::new();
+
+    fn init_mock_store() {
+        MOCK_STORE.call_once(|| {
+            keyring_core::set_default_store(keyring_core::mock::Store::new().unwrap());
+        });
+    }
 
     fn with_env_disabled<F: FnOnce()>(f: F) {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
@@ -102,6 +150,22 @@ mod tests {
                 Some(v) => env::set_var(ENV_DISABLE, v),
                 None => env::remove_var(ENV_DISABLE),
             }
+        }
+    }
+
+    /// Runs `f` with the keyring guaranteed ENABLED (env var removed),
+    /// holding `ENV_LOCK` so a concurrent disabled-test can't make the real
+    /// store calls early-return. Restores the prior env value afterwards.
+    fn with_env_enabled<F: FnOnce()>(f: F) {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prior = env::var(ENV_DISABLE).ok();
+        // SAFETY: held under ENV_LOCK so no other test in this module
+        // mutates the same var concurrently.
+        unsafe { env::remove_var(ENV_DISABLE) };
+        f();
+        if let Some(v) = prior {
+            // SAFETY: still held under ENV_LOCK.
+            unsafe { env::set_var(ENV_DISABLE, v) };
         }
     }
 
@@ -131,6 +195,30 @@ mod tests {
     fn delete_is_noop_when_disabled() {
         with_env_disabled(|| {
             assert!(delete("test-id", CredentialKind::Password).is_ok());
+        });
+    }
+
+    #[test]
+    fn store_then_retrieve_round_trips_secret() {
+        init_mock_store();
+        with_env_enabled(|| {
+            // Unique profile id so concurrent store-path tests don't collide.
+            let profile = "roundtrip-store-retrieve";
+            store(profile, CredentialKind::Jwt, "s3cret").unwrap();
+            assert_eq!(retrieve(profile, CredentialKind::Jwt).unwrap(), "s3cret");
+            // Clean up so reruns in the same process start fresh.
+            delete(profile, CredentialKind::Jwt).unwrap();
+        });
+    }
+
+    #[test]
+    fn retrieve_absent_key_returns_err() {
+        init_mock_store();
+        with_env_enabled(|| {
+            let profile = "roundtrip-absent-key";
+            // Ensure no leftover from a prior run in this process.
+            delete(profile, CredentialKind::Password).unwrap();
+            assert!(retrieve(profile, CredentialKind::Password).is_err());
         });
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,6 +158,8 @@ async fn main() -> Result<()> {
         .install_default()
         .expect("install rustls ring crypto provider");
 
+    credentials::init_store();
+
     let matches = CliArgs::command().get_matches();
     let cli = CliArgs::from_arg_matches(&matches)?;
     let cli_explicit = any_explicit_connection_arg(&matches);


### PR DESCRIPTION
## Migrate `adele-tui` credentials to `keyring-core` 1.0

`keyring 3.x → 4.x` is not a version bump — v4 is a sample CLI app, not a library. This moves the TUI to **`keyring-core` 1.0** (runtime-registered store) + **`zbus-secret-service-keyring-store`** (`rt-tokio-crypto-rust`; pure-Rust crypto, no libdbus C dep). Mirrors the daemon migration (adelie-ai/desktop-assistant#164 / #149).

### Changes
- `Cargo.toml` — `keyring = "3"` → `keyring-core = "1"` + `zbus-secret-service-keyring-store` (`rt-tokio-crypto-rust`).
- `src/credentials.rs` — port `Entry`/`Error` to `keyring_core`; register the Secret Service store via `init_store()` (best-effort, respects the existing `ADELE_TUI_DISABLE_KEYRING` opt-out, warns + continues when headless); wrap `store`/`retrieve`/`delete` in a runtime-aware `run_keyring_blocking` so the blocking zbus calls don't stall the tokio runtime.
- `src/main.rs` — call `credentials::init_store()` once at startup (after the rustls provider install, before raw mode).

### Testing
- `cargo test` — all pass, including two new store-path tests against `keyring_core::mock::Store` (round-trip; absent key → `Err`). A `with_env_enabled` guard holds the module's `ENV_LOCK` so the new tests can't race the existing disabled-keyring tests on the env var.
- `cargo clippy --all-targets` — zero warnings on the changed files. (Pre-existing lints elsewhere are the unrelated adele-tui#58 drift, left as-is.)
- CVE scan (OSV.dev) of the new dependency set — 0 findings (same crate versions vetted in desktop-assistant#164: keyring-core 1.0.0, zbus-secret-service-keyring-store 1.0.0, secret-service 5.1.0).

### Manual verification before merge
⚠️ Reading credentials **previously written by keyring v3**: keyring-core's store keys on `service` + `username` and the Secret Service matches on attribute subsets, so legacy items should be found — but this should be confirmed against a real session bus on upgrade. Worst case is a one-time re-login.

Closes #60
