### PR TITLE
refactor: adopt client-common Connector + transport-generic management (drop as_ws)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1474,7 +1474,7 @@ dependencies = [
 [[package]]
 name = "desktop-assistant-api-model"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#15efad50fee76e57bbe2bb7d0617642997151dcf"
+source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#a6283e350e46bb903436741d26b2a47ef93ec793"
 dependencies = [
  "desktop-assistant-core",
  "serde",
@@ -1484,7 +1484,7 @@ dependencies = [
 [[package]]
 name = "desktop-assistant-auth-jwt"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#15efad50fee76e57bbe2bb7d0617642997151dcf"
+source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#a6283e350e46bb903436741d26b2a47ef93ec793"
 dependencies = [
  "anyhow",
  "jsonwebtoken",
@@ -1495,7 +1495,7 @@ dependencies = [
 [[package]]
 name = "desktop-assistant-client-common"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#15efad50fee76e57bbe2bb7d0617642997151dcf"
+source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#a6283e350e46bb903436741d26b2a47ef93ec793"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1515,7 +1515,7 @@ dependencies = [
 [[package]]
 name = "desktop-assistant-core"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#15efad50fee76e57bbe2bb7d0617642997151dcf"
+source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#a6283e350e46bb903436741d26b2a47ef93ec793"
 dependencies = [
  "async-trait",
  "backon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1474,7 +1474,7 @@ dependencies = [
 [[package]]
 name = "desktop-assistant-api-model"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#a6283e350e46bb903436741d26b2a47ef93ec793"
+source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#40cdb5f69c14e39fa8f0d7f917ec215f8d1beb31"
 dependencies = [
  "desktop-assistant-core",
  "serde",
@@ -1484,7 +1484,7 @@ dependencies = [
 [[package]]
 name = "desktop-assistant-auth-jwt"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#a6283e350e46bb903436741d26b2a47ef93ec793"
+source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#40cdb5f69c14e39fa8f0d7f917ec215f8d1beb31"
 dependencies = [
  "anyhow",
  "jsonwebtoken",
@@ -1495,7 +1495,7 @@ dependencies = [
 [[package]]
 name = "desktop-assistant-client-common"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#a6283e350e46bb903436741d26b2a47ef93ec793"
+source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#40cdb5f69c14e39fa8f0d7f917ec215f8d1beb31"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1515,7 +1515,7 @@ dependencies = [
 [[package]]
 name = "desktop-assistant-core"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#a6283e350e46bb903436741d26b2a47ef93ec793"
+source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#40cdb5f69c14e39fa8f0d7f917ec215f8d1beb31"
 dependencies = [
  "async-trait",
  "backon",

--- a/src/connections.rs
+++ b/src/connections.rs
@@ -34,7 +34,7 @@ use crossterm::event::{Event, KeyCode, KeyEvent, KeyEventKind, KeyModifiers};
 use desktop_assistant_api_model::{
     Command, CommandResult, ConnectionAvailability, ConnectionConfigView, ConnectionView,
 };
-use desktop_assistant_client_common::{AssistantCommands, TransportClient};
+use desktop_assistant_client_common::TransportClient;
 use futures::StreamExt;
 use ratatui::{
     Frame, Terminal,
@@ -501,16 +501,17 @@ async fn save_edit(state: &mut State, client: &TransportClient) {
     }
 }
 
-/// Send a `Command` over the transport. Today only the WS transport
-/// exposes a generic `send_command` — D-Bus is used for a fixed set of
-/// methods. We surface a clear error in that case rather than silently
-/// no-op'ing.
+/// Send a `Command` over the transport. The shared command channel
+/// (`as_commands`) exposes a generic `send_command` over both socket
+/// transports (UDS + WS); D-Bus speaks a fixed set of typed methods and so
+/// has no command channel. We surface a clear error in that case rather than
+/// silently no-op'ing.
 async fn send(client: &TransportClient, command: Command) -> anyhow::Result<CommandResult> {
-    if let Some(ws) = client.as_ws() {
-        ws.send_command(command).await
+    if let Some(commands) = client.as_commands() {
+        commands.send_command(command).await
     } else {
         anyhow::bail!(
-            "Connection management is only available over WebSocket — switch transport with --transport ws"
+            "Connection management isn't available over D-Bus — switch transport with --transport ws or the local socket"
         )
     }
 }
@@ -883,6 +884,10 @@ mod tests {
             display_label: format!("{id} ({ty})"),
             availability: ConnectionAvailability::Ok,
             has_credentials: true,
+            // Echoed non-secret config (added upstream after the view shipped);
+            // the TUI's edit form pre-fills from `id`/`connector_type` only, so
+            // these tests don't exercise it.
+            config: None,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,8 +35,7 @@ use crossterm::{
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
 use desktop_assistant_client_common::{
-    AssistantClient, AssistantCommands, ConnectionConfig, SignalEvent, TransportClient,
-    TransportMode, connect_transport, transport::transport_label,
+    AssistantClient, ConnectionConfig, Connector, SignalEvent, TransportClient, TransportMode,
 };
 use futures::StreamExt;
 use ratatui::{Terminal, backend::CrosstermBackend};
@@ -295,22 +294,29 @@ async fn run(
     let settings = Settings::load();
     app.show_debug = settings.show_debug;
 
-    let mut client: Option<TransportClient> = None;
+    // The `Connector` owns the transport AND the signal stream, pumping every
+    // `SignalEvent` to its subscribers from a dedicated task (client-common
+    // #203). The TUI holds the connector (so reconnect/disconnect can drop and
+    // rebuild it) plus one `subscribe()`d receiver that feeds the `select!`
+    // loop. Before there's a live connection both are the not-connected
+    // sentinels: `connector = None` and a closed `signal_rx`.
+    let mut connector: Option<Connector> = None;
     let mut signal_rx: UnboundedReceiver<SignalEvent> = unbounded_channel().1;
     let mut reconnect = ReconnectState::Connected;
 
     // Initial connect — on failure, fall straight into the backoff loop
-    // instead of running with no client.
-    match connect_transport(config).await {
-        Ok((transport_client, rx)) => {
-            match transport_client.list_conversations().await {
+    // instead of running with no connection.
+    match Connector::connect(config).await {
+        Ok(conn) => {
+            // Subscribe before any prompt so no early streaming chunk is lost.
+            signal_rx = conn.subscribe();
+            match conn.client().list_conversations().await {
                 Ok(convs) => app.set_conversations(convs),
                 Err(e) => app.status_message = format!("Error loading conversations: {e}"),
             }
-            init_background_tasks(&mut app, &transport_client).await;
-            app.status_message = transport_label(config);
-            client = Some(transport_client);
-            signal_rx = rx;
+            init_background_tasks(&mut app, conn.client()).await;
+            app.status_message = conn.label().to_string();
+            connector = Some(conn);
         }
         Err(e) => {
             reconnect = schedule_reconnect(None);
@@ -362,8 +368,8 @@ async fn run(
 
         if app.kb_requested {
             app.kb_requested = false;
-            if let Some(client) = client.as_ref()
-                && let Err(e) = kb::run(terminal, client).await
+            if let Some(conn) = connector.as_ref()
+                && let Err(e) = kb::run(terminal, conn.client()).await
             {
                 app.status_message = format!("KB error: {e}");
             }
@@ -374,8 +380,8 @@ async fn run(
 
         if app.connections_requested {
             app.connections_requested = false;
-            if let Some(client) = client.as_ref()
-                && let Err(e) = connections::run(terminal, client).await
+            if let Some(conn) = connector.as_ref()
+                && let Err(e) = connections::run(terminal, conn.client()).await
             {
                 app.status_message = format!("Connections error: {e}");
             }
@@ -384,8 +390,8 @@ async fn run(
 
         if app.purposes_requested {
             app.purposes_requested = false;
-            if let Some(client) = client.as_ref()
-                && let Err(e) = purposes::run(terminal, client).await
+            if let Some(conn) = connector.as_ref()
+                && let Err(e) = purposes::run(terminal, conn.client()).await
             {
                 app.status_message = format!("Purposes error: {e}");
             }
@@ -394,7 +400,8 @@ async fn run(
 
         if app.model_picker_requested {
             app.model_picker_requested = false;
-            if let Some(client) = client.as_ref() {
+            if let Some(conn) = connector.as_ref() {
+                let client = conn.client();
                 let current = app
                     .current_conversation
                     .as_ref()
@@ -428,7 +435,7 @@ async fn run(
                                 &dictation_tx,
                             );
                         } else {
-                            handle_action(&mut app, &client, action).await;
+                            handle_action(&mut app, &connector, action).await;
                         }
                     } else {
                         match app.mode {
@@ -476,7 +483,10 @@ async fn run(
                         app.update_conversation_title(&conversation_id, &title);
                     }
                     SignalEvent::Disconnected { reason } => {
-                        client = None;
+                        // Drop the connector (closing its transport + fanout
+                        // task) and reset to the not-connected sentinel receiver
+                        // so the backoff loop owns reconnection.
+                        connector = None;
                         signal_rx = unbounded_channel().1;
                         reconnect = schedule_reconnect(None);
                         app.status_message = format!(
@@ -513,6 +523,9 @@ async fn run(
                         }
                         app.tasks.apply_task_completed(&id);
                     }
+                    // The TUI has no scratchpad pane (that lives in the GTK/KDE
+                    // clients), so the change notification is a no-op here.
+                    SignalEvent::ScratchpadChanged { .. } => {}
                 }
             }
             _ = async {
@@ -526,17 +539,18 @@ async fn run(
                     ReconnectState::Connected => None,
                 };
                 app.status_message = "Reconnecting...".to_string();
-                match connect_transport(config).await {
-                    Ok((transport_client, rx)) => {
-                        match transport_client.list_conversations().await {
+                match Connector::connect(config).await {
+                    Ok(conn) => {
+                        // Subscribe before any prompt so no early chunk is lost.
+                        signal_rx = conn.subscribe();
+                        match conn.client().list_conversations().await {
                             Ok(convs) => app.set_conversations(convs),
                             Err(e) => app.status_message = format!("Error loading conversations: {e}"),
                         }
-                        init_background_tasks(&mut app, &transport_client).await;
-                        client = Some(transport_client);
-                        signal_rx = rx;
+                        init_background_tasks(&mut app, conn.client()).await;
                         reconnect = ReconnectState::Connected;
-                        app.status_message = transport_label(config);
+                        app.status_message = conn.label().to_string();
+                        connector = Some(conn);
                     }
                     Err(e) => {
                         reconnect = schedule_reconnect(prev_delay);
@@ -580,7 +594,7 @@ async fn run(
                 match outcome {
                     DictationOutcome::Transcribed(text) => {
                         insert_dictated_text(&mut app, &text);
-                        send_prompt_from_input(&mut app, &client).await;
+                        send_prompt_from_input(&mut app, &connector).await;
                     }
                     DictationOutcome::NoSpeech => {
                         app.status_message = "No speech detected".into();
@@ -594,17 +608,16 @@ async fn run(
     }
 }
 
-async fn handle_action(
-    app: &mut App,
-    client: &Option<desktop_assistant_client_common::TransportClient>,
-    action: Action,
-) {
+async fn handle_action(app: &mut App, connector: &Option<Connector>, action: Action) {
+    // The action handlers all want the transport client; pull it out once as an
+    // `Option<&TransportClient>` so each arm reads the same as before.
+    let client: Option<&TransportClient> = connector.as_ref().map(Connector::client);
     match action {
         Action::Quit => app.quit(),
         Action::NextConversation => app.next_conversation(),
         Action::PreviousConversation => app.previous_conversation(),
         Action::OpenConversation => {
-            if let (Some(client), Some(id)) = (client.as_ref(), app.selected_conversation_id()) {
+            if let (Some(client), Some(id)) = (client, app.selected_conversation_id()) {
                 let id = id.to_string();
                 match client.get_conversation(&id).await {
                     Ok(detail) => {
@@ -617,14 +630,14 @@ async fn handle_action(
         }
         Action::DeleteConversation => {
             if let Some(id) = app.delete_selected_conversation()
-                && let Some(client) = client.as_ref()
+                && let Some(client) = client
                 && let Err(e) = client.delete_conversation(&id).await
             {
                 app.status_message = format!("Delete error: {e}");
             }
         }
         Action::NewConversation => {
-            if let Some(client) = client.as_ref() {
+            if let Some(client) = client {
                 match client.create_conversation("New Conversation").await {
                     Ok(id) => {
                         match fetch_conversations(client, app.show_archived).await {
@@ -657,7 +670,7 @@ async fn handle_action(
             }
         }
         Action::ExitEditMode => app.enter_normal_mode(),
-        Action::SubmitPrompt => send_prompt_from_input(app, client).await,
+        Action::SubmitPrompt => send_prompt_from_input(app, connector).await,
         // Dictation is handled in the event loop (it needs the embedded voice
         // session + a result channel + a spawned capture task — loop-local
         // resources that don't belong in `handle_action`'s signature).
@@ -667,7 +680,7 @@ async fn handle_action(
         }
         Action::ToggleShowArchived => {
             app.show_archived = !app.show_archived;
-            if let Some(client) = client.as_ref() {
+            if let Some(client) = client {
                 match fetch_conversations(client, app.show_archived).await {
                     Ok(convs) => app.set_conversations(convs),
                     Err(e) => app.status_message = format!("Error refreshing: {e}"),
@@ -680,7 +693,7 @@ async fn handle_action(
             };
         }
         Action::ArchiveConversation => {
-            if let (Some(client), Some(id)) = (client.as_ref(), app.selected_conversation_id()) {
+            if let (Some(client), Some(id)) = (client, app.selected_conversation_id()) {
                 let id = id.to_string();
                 // Determine if conversation is currently archived
                 let is_archived = app
@@ -720,7 +733,7 @@ async fn handle_action(
         }
         Action::SubmitRename => {
             if let Some((id, title)) = app.submit_rename()
-                && let Some(client) = client.as_ref()
+                && let Some(client) = client
             {
                 match client.rename_conversation(&id, &title).await {
                     Ok(()) => {
@@ -799,12 +812,12 @@ async fn handle_action(
         Action::PreviousTask => app.tasks.move_selection(-1),
         Action::CancelSelectedTask => {
             if let Some(id) = app.request_cancel_selected_task()
-                && let Some(client) = client.as_ref()
-                && let Some(ws) = client.as_ws()
+                && let Some(client) = client
+                && let Some(commands) = client.as_commands()
             {
                 let cmd =
                     desktop_assistant_api_model::Command::CancelBackgroundTask { id: id.0.clone() };
-                match ws.send_command(cmd).await {
+                match commands.send_command(cmd).await {
                     Ok(_) => {
                         // Status will move to "Cancelling..." then resolve
                         // when `TaskCompleted { status: Cancelled }` arrives.
@@ -818,7 +831,7 @@ async fn handle_action(
         }
         Action::OpenSelectedTaskConversation => {
             if let Some(conv_id) = app.jump_to_selected_task_conversation()
-                && let Some(client) = client.as_ref()
+                && let Some(client) = client
             {
                 match client.get_conversation(&conv_id).await {
                     Ok(detail) => {
@@ -905,25 +918,26 @@ fn insert_dictated_text(app: &mut App, text: &str) {
 /// transport. Shared by the keyboard submit (`Enter`) and the dictation path
 /// (which appends a transcript to the input, then submits via the same route),
 /// so both honor the staged model override and the same ack handling.
-async fn send_prompt_from_input(
-    app: &mut App,
-    client: &Option<desktop_assistant_client_common::TransportClient>,
-) {
+async fn send_prompt_from_input(app: &mut App, connector: &Option<Connector>) {
     if let Some((conv_id, prompt)) = app.submit_prompt()
-        && let Some(client) = client.as_ref()
+        && let Some(connector) = connector.as_ref()
     {
+        let client = connector.client();
         let override_selection = app.take_pending_override();
-        // Use the WS override path when one was staged via the model picker;
-        // the trait-level `send_prompt` only takes the bare prompt. D-Bus +
-        // override isn't supported yet — we fall back to plain send and warn.
-        let result = match (override_selection, client.as_ws()) {
-            (Some(ovr), Some(ws)) => {
-                ws.send_prompt_with_override(&conv_id, &prompt, Some(ovr))
+        // Use the command-channel override path when one was staged via the
+        // model picker; the high-level `send_prompt` only takes the bare prompt.
+        // `as_commands()` is `Some` on both socket transports (UDS + WS) but
+        // `None` on D-Bus, which has no override field — there we fall back to a
+        // plain send and warn.
+        let result = match (override_selection, client.as_commands()) {
+            (Some(ovr), Some(commands)) => {
+                commands
+                    .send_prompt_with_override(&conv_id, &prompt, Some(ovr))
                     .await
             }
             (Some(_), None) => {
                 app.status_message =
-                    "Model override only works over WebSocket — sent without override".into();
+                    "Model override isn't supported over D-Bus — sent without override".into();
                 client.send_prompt(&conv_id, &prompt).await
             }
             (None, _) => client.send_prompt(&conv_id, &prompt).await,
@@ -939,20 +953,21 @@ async fn send_prompt_from_input(
 /// events. Failure is non-fatal — the chat still works without the
 /// process-manager pane, so we surface a status hint and move on.
 ///
-/// Both commands only exist over WS today. Over D-Bus the call quietly
+/// These commands ride the shared command channel (`as_commands`), so they
+/// work over both socket transports (UDS + WS). Over D-Bus the call quietly
 /// no-ops; the pane will simply stay empty.
 async fn init_background_tasks(
     app: &mut App,
     client: &desktop_assistant_client_common::TransportClient,
 ) {
-    let Some(ws) = client.as_ws() else {
+    let Some(commands) = client.as_commands() else {
         return;
     };
     let list = desktop_assistant_api_model::Command::ListBackgroundTasks {
         include_finished: false,
         limit: None,
     };
-    match ws.send_command(list).await {
+    match commands.send_command(list).await {
         Ok(desktop_assistant_api_model::CommandResult::BackgroundTasks(tasks)) => {
             app.tasks.set_initial(tasks);
         }
@@ -963,7 +978,7 @@ async fn init_background_tasks(
             app.status_message = format!("Tasks snapshot failed: {e}");
         }
     }
-    if let Err(e) = ws
+    if let Err(e) = commands
         .send_command(desktop_assistant_api_model::Command::SubscribeBackgroundTasks)
         .await
     {

--- a/src/model_selector.rs
+++ b/src/model_selector.rs
@@ -143,9 +143,9 @@ fn advance(state: &mut State, delta: i32) {
 }
 
 async fn refresh(state: &mut State, client: &TransportClient, refresh_cache: bool) {
-    let Some(ws) = client.as_ws() else {
+    let Some(commands) = client.as_commands() else {
         state.error = Some(
-            "Model selection is only available over WebSocket — switch transport with --transport ws"
+            "Model selection isn't available over D-Bus — switch transport with --transport ws or the local socket"
                 .into(),
         );
         state.busy = None;
@@ -156,7 +156,7 @@ async fn refresh(state: &mut State, client: &TransportClient, refresh_cache: boo
     } else {
         "Loading models...".into()
     });
-    match ws.list_available_models(None, refresh_cache).await {
+    match commands.list_available_models(None, refresh_cache).await {
         Ok(models) => {
             state.models = models;
             state.busy = None;

--- a/src/purposes.rs
+++ b/src/purposes.rs
@@ -32,7 +32,7 @@ use desktop_assistant_api_model::{
     Command, CommandResult, ConnectionView, EffortLevel, ModelListing, PurposeConfigView,
     PurposeKindApi, PurposesView,
 };
-use desktop_assistant_client_common::{AssistantCommands, TransportClient};
+use desktop_assistant_client_common::TransportClient;
 use futures::StreamExt;
 use ratatui::{
     Frame, Terminal,
@@ -266,14 +266,14 @@ async fn refresh_all(state: &mut State, client: &TransportClient) {
 }
 
 async fn refresh_models(state: &mut State, client: &TransportClient, refresh_cache: bool) {
-    let Some(ws) = client.as_ws() else {
+    let Some(commands) = client.as_commands() else {
         state.error = Some(
-            "Purposes management is only available over WebSocket — switch transport with --transport ws"
+            "Purposes management isn't available over D-Bus — switch transport with --transport ws or the local socket"
                 .into(),
         );
         return;
     };
-    match ws.list_available_models(None, refresh_cache).await {
+    match commands.list_available_models(None, refresh_cache).await {
         Ok(models) => state.models = models,
         Err(e) => state.error = Some(format!("Failed to list models: {e}")),
     }
@@ -481,11 +481,11 @@ fn effort_label(effort: Option<EffortLevel>) -> &'static str {
 }
 
 async fn send(client: &TransportClient, command: Command) -> anyhow::Result<CommandResult> {
-    if let Some(ws) = client.as_ws() {
-        ws.send_command(command).await
+    if let Some(commands) = client.as_commands() {
+        commands.send_command(command).await
     } else {
         anyhow::bail!(
-            "Purposes management is only available over WebSocket — switch transport with --transport ws"
+            "Purposes management isn't available over D-Bus — switch transport with --transport ws or the local socket"
         )
     }
 }


### PR DESCRIPTION
Closes #69

## Summary
Migrates the TUI off the low-level `connect_transport` + hand-rolled `(client, signal_rx)` + `select!` plumbing onto the shared `Connector` (desktop-assistant#203), and makes every management feature work over the **default UDS transport** by switching `as_ws()` → `as_commands()`. Lands all three parts of the issue together since they touch the same files.

## Part A — adopt the `Connector`
- `run()` now holds `Option<Connector>` plus one `subscribe()`d `signal_rx` instead of an owned `(TransportClient, UnboundedReceiver)` pair. The connector owns the transport and pumps the signal stream to subscribers from its own task; the `select!` loop just drains its `subscribe()` receiver.
- `connector.client()` is passed wherever a `&TransportClient` is needed (kb / connections / purposes / model_selector, the action handlers, `init_background_tasks`).
- Status label comes from `connector.label()`.
- Initial connect, reconnect-backoff, and disconnect all rebuild/drop the connector; we `subscribe()` **before** any prompt so no early chunk is lost. Behavior is otherwise identical.

## Part B — transport-generic management (the real bug)
The TUI defaults to UDS (#59), but `as_ws()` is `Some` only on WebSocket — so model selection, connection management, purposes, background-task snapshot/subscribe/cancel, and the per-message model override were all **silently unavailable** on the default transport. Switched **every** call site to `as_commands()` (`Some` on both UDS + WS, `None` only on D-Bus). Every method used (`send_command`, `send_prompt_with_override`, `list_available_models`) is on the `AssistantCommands` trait, so no functionality is dropped. User-facing "only over WebSocket" messages corrected to "not over D-Bus". **No `as_ws()` references remain.** Mirrors adele-gtk#49.

Call sites updated: `model_selector.rs`, `connections.rs`, `purposes.rs`, and three in `main.rs` (cancel-task, model override, background-task init).

## Part C — root cause of "stuck over UDS, fine over D-Bus"
The defect was in the TUI's bespoke signal consumption, **not** `UdsClient`/client-common — so no desktop-assistant change is needed:
- The daemon routes `SendMessage` streaming events back through the **originating connection's own outbound sink** (`ChannelEventSink` in `transport-dispatch`), with no separate subscription required. UDS and WS are symmetric here.
- The `UdsClient` reader pumps `Chunk`/`Complete` to `signal_rx` correctly (confirmed at both the pinned and current client-common revisions).
- Voice already streams end-to-end over UDS via the same `Connector`.

Migrating to the `Connector` decouples signal-pumping from the TUI loop and guarantees the subscription precedes any prompt, which resolves it.

**Verified live over the default UDS transport** (`adele --transport local`, real daemon):
- Two sequential prompts each streamed token-by-token and finalized; conversation title updated via `TitleChanged`.
- Connections manager (F3) loaded the live connection list over UDS.
- Purposes manager (F4) loaded all four purpose→model mappings over UDS.

## Incidental (surfaced by bumping client-common to the Connector revision)
The pinned revision predated the Connector, so `Cargo.lock` is bumped. That bump also surfaced two pre-existing gaps, fixed here:
- Handle the `SignalEvent::ScratchpadChanged` variant (no-op — the TUI has no scratchpad pane).
- Add the new `ConnectionView.config` field to a test helper (`config: None`; the TUI's edit form pre-fills from id/connector_type only — `config`-based pre-fill is a separate feature).

## Checks
`just check` (fmt + clippy `-D warnings` + build + tests) green: **281 passed, 0 failed, 1 ignored** (the `#[ignore]`d keyring integration test).

## Do not merge
This flips default-transport behavior — leaving it for QA / the user to decide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)