### PR TITLE
Per-conversation speech toggle + session-scoped say_this (#73)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,6 +49,8 @@ dependencies = [
 name = "adele-voice-core"
 version = "0.1.0"
 dependencies = [
+ "pulldown-cmark",
+ "serde_json",
  "thiserror 2.0.18",
  "tokio",
 ]

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use desktop_assistant_api_model::TaskId;
 pub use desktop_assistant_client_common::{ChatMessage, ConversationDetail, ConversationSummary};
 use ratatui::style::Style;
@@ -128,6 +130,17 @@ pub struct App {
     /// actually closes the loop; this is purely so the status bar can
     /// say "cancelling t-1..." while we wait.
     pub pending_task_cancel: Option<TaskId>,
+    /// Per-conversation "speech enabled" hard toggle (adele-tui#73). Keyed by
+    /// conversation id; a conversation absent from the map uses
+    /// `speech_default`. This is the master cut-off: when a conversation's
+    /// flag is `false` nothing is ever spoken — not reply narration, not the
+    /// daemon's `say_this` client tool. Toggled in-app with `Ctrl+S`.
+    speech_enabled: HashMap<String, bool>,
+    /// Default speech state for a conversation not yet in `speech_enabled`.
+    /// Seeded from `voice.toml`'s `play_replies` so existing
+    /// `play_replies = true` users keep audio, but it is now per-conversation
+    /// and toggleable. Defaults `false` (off) when voice is unconfigured.
+    speech_default: bool,
 }
 
 impl App {
@@ -160,7 +173,50 @@ impl App {
             pending_model_override: None,
             tasks: TaskPane::new(),
             pending_task_cancel: None,
+            speech_enabled: HashMap::new(),
+            speech_default: false,
         }
+    }
+
+    // --- Per-conversation speech toggle (adele-tui#73) ---
+
+    /// Seed the default speech state new conversations inherit (from
+    /// `voice.toml`'s `play_replies`). Conversations already toggled keep
+    /// their explicit state; only the implicit default changes.
+    pub fn set_speech_default(&mut self, _default: bool) {
+        // TODO(adele-tui#73): seed the per-conversation default.
+    }
+
+    /// Whether speech is enabled for `conversation_id`. Falls back to
+    /// `speech_default` for a conversation the user hasn't toggled.
+    pub fn speech_enabled_for(&self, _conversation_id: &str) -> bool {
+        // TODO(adele-tui#73): per-conversation lookup with default fallback.
+        false
+    }
+
+    /// Whether speech is enabled for the currently-open conversation. `false`
+    /// when no conversation is open (nothing to speak into).
+    pub fn current_speech_enabled(&self) -> bool {
+        // TODO(adele-tui#73).
+        false
+    }
+
+    /// Flip the speech toggle for the currently-open conversation and return
+    /// the new state. `None` when no conversation is open. Per-conversation:
+    /// toggling one conversation never affects another.
+    pub fn toggle_current_speech(&mut self) -> Option<bool> {
+        // TODO(adele-tui#73): flip and persist the per-conversation toggle.
+        None
+    }
+
+    /// Render a `say_this` call that arrived while speech was OFF as an inline
+    /// note in the transcript instead of speaking it (adele-tui#73). Appended
+    /// to `conversation_id` only when that is the open conversation, so a call
+    /// from a stale/other conversation never bleeds into the visible chat.
+    /// Returns whether the note was shown.
+    pub fn push_speech_disabled_note(&mut self, _conversation_id: &str, _text: &str) -> bool {
+        // TODO(adele-tui#73): append the inline disabled note.
+        false
     }
 
     // --- Tasks-pane glue ---
@@ -1378,6 +1434,107 @@ mod tests {
         let mut app = App::new();
         let id = app.request_cancel_selected_task();
         assert!(id.is_none());
+    }
+
+    // --- Per-conversation speech toggle (adele-tui#73) ---
+
+    fn app_with_open_conversation(id: &str) -> App {
+        let mut app = App::new();
+        app.current_conversation = Some(ConversationDetail {
+            id: id.into(),
+            title: "Chat".into(),
+            messages: vec![],
+            model_selection: None,
+            conversation_personality: None,
+        });
+        app
+    }
+
+    #[test]
+    fn speech_defaults_off_when_play_replies_unset() {
+        // With no voice config (`speech_default = false`), a fresh
+        // conversation must have speech OFF — the hard cut-off default.
+        let app = app_with_open_conversation("c1");
+        assert!(!app.current_speech_enabled());
+        assert!(!app.speech_enabled_for("c1"));
+    }
+
+    #[test]
+    fn speech_default_seeds_untoggled_conversations() {
+        // `play_replies = true` seeds the per-conversation default ON so
+        // existing users keep audio — but it is now per-conversation.
+        let mut app = app_with_open_conversation("c1");
+        app.set_speech_default(true);
+        assert!(app.current_speech_enabled());
+        assert!(app.speech_enabled_for("c1"));
+        assert!(app.speech_enabled_for("never-opened"));
+    }
+
+    #[test]
+    fn toggle_current_speech_flips_and_returns_new_state() {
+        let mut app = app_with_open_conversation("c1");
+        assert_eq!(app.toggle_current_speech(), Some(true));
+        assert!(app.current_speech_enabled());
+        assert_eq!(app.toggle_current_speech(), Some(false));
+        assert!(!app.current_speech_enabled());
+    }
+
+    #[test]
+    fn toggle_current_speech_without_conversation_is_none() {
+        let mut app = App::new();
+        assert_eq!(app.toggle_current_speech(), None);
+        assert!(!app.current_speech_enabled());
+    }
+
+    #[test]
+    fn speech_toggle_is_per_conversation_isolated() {
+        // Enabling speech in one conversation must NOT bleed into another.
+        let mut app = app_with_open_conversation("c1");
+        assert_eq!(app.toggle_current_speech(), Some(true)); // c1 ON
+        assert!(app.speech_enabled_for("c1"));
+        assert!(!app.speech_enabled_for("c2")); // c2 untouched → default OFF
+    }
+
+    #[test]
+    fn speech_toggle_overrides_the_default_per_conversation() {
+        // With default ON, an explicit toggle to OFF for one conversation
+        // sticks for that conversation only.
+        let mut app = app_with_open_conversation("c1");
+        app.set_speech_default(true);
+        assert_eq!(app.toggle_current_speech(), Some(false)); // c1 explicitly OFF
+        assert!(!app.speech_enabled_for("c1"));
+        assert!(app.speech_enabled_for("c2")); // others still follow default ON
+    }
+
+    #[test]
+    fn push_speech_disabled_note_appends_inline_to_open_conversation() {
+        let mut app = app_with_open_conversation("c1");
+        assert!(app.push_speech_disabled_note("c1", "the kettle is on"));
+        let msgs = &app.current_conversation.as_ref().unwrap().messages;
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].role, "assistant");
+        assert_eq!(msgs[0].content, "(speech mode disabled) the kettle is on");
+    }
+
+    #[test]
+    fn push_speech_disabled_note_ignores_other_conversation() {
+        // A say_this call referencing a conversation that isn't the open one
+        // must NOT bleed text into the visible transcript.
+        let mut app = app_with_open_conversation("c1");
+        assert!(!app.push_speech_disabled_note("c2", "wrong conversation"));
+        assert!(
+            app.current_conversation
+                .as_ref()
+                .unwrap()
+                .messages
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn push_speech_disabled_note_with_no_conversation_is_noop() {
+        let mut app = App::new();
+        assert!(!app.push_speech_disabled_note("c1", "anything"));
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -183,30 +183,35 @@ impl App {
     /// Seed the default speech state new conversations inherit (from
     /// `voice.toml`'s `play_replies`). Conversations already toggled keep
     /// their explicit state; only the implicit default changes.
-    pub fn set_speech_default(&mut self, _default: bool) {
-        // TODO(adele-tui#73): seed the per-conversation default.
+    pub fn set_speech_default(&mut self, default: bool) {
+        self.speech_default = default;
     }
 
     /// Whether speech is enabled for `conversation_id`. Falls back to
     /// `speech_default` for a conversation the user hasn't toggled.
-    pub fn speech_enabled_for(&self, _conversation_id: &str) -> bool {
-        // TODO(adele-tui#73): per-conversation lookup with default fallback.
-        false
+    pub fn speech_enabled_for(&self, conversation_id: &str) -> bool {
+        self.speech_enabled
+            .get(conversation_id)
+            .copied()
+            .unwrap_or(self.speech_default)
     }
 
     /// Whether speech is enabled for the currently-open conversation. `false`
     /// when no conversation is open (nothing to speak into).
     pub fn current_speech_enabled(&self) -> bool {
-        // TODO(adele-tui#73).
-        false
+        self.current_conversation
+            .as_ref()
+            .is_some_and(|c| self.speech_enabled_for(&c.id))
     }
 
     /// Flip the speech toggle for the currently-open conversation and return
     /// the new state. `None` when no conversation is open. Per-conversation:
     /// toggling one conversation never affects another.
     pub fn toggle_current_speech(&mut self) -> Option<bool> {
-        // TODO(adele-tui#73): flip and persist the per-conversation toggle.
-        None
+        let conv_id = self.current_conversation.as_ref()?.id.clone();
+        let next = !self.speech_enabled_for(&conv_id);
+        self.speech_enabled.insert(conv_id, next);
+        Some(next)
     }
 
     /// Render a `say_this` call that arrived while speech was OFF as an inline
@@ -214,9 +219,19 @@ impl App {
     /// to `conversation_id` only when that is the open conversation, so a call
     /// from a stale/other conversation never bleeds into the visible chat.
     /// Returns whether the note was shown.
-    pub fn push_speech_disabled_note(&mut self, _conversation_id: &str, _text: &str) -> bool {
-        // TODO(adele-tui#73): append the inline disabled note.
-        false
+    pub fn push_speech_disabled_note(&mut self, conversation_id: &str, text: &str) -> bool {
+        let Some(conv) = self.current_conversation.as_mut() else {
+            return false;
+        };
+        if conv.id != conversation_id {
+            return false;
+        }
+        conv.messages.push(ChatMessage {
+            role: "assistant".to_string(),
+            content: format!("(speech mode disabled) {text}"),
+        });
+        self.scroll_offset = 0;
+        true
     }
 
     // --- Tasks-pane glue ---

--- a/src/client_tools.rs
+++ b/src/client_tools.rs
@@ -1,0 +1,181 @@
+//! Client-local tool handling for the TUI (adele-tui#73).
+//!
+//! The daemon can suspend a turn on a *client* tool (`SignalEvent::ClientToolCall`)
+//! and park until the client posts a result back. Before #261 the per-user tool
+//! registry meant another client's tools (e.g. a voice session's `say_this`)
+//! could fire on a TUI turn that the TUI then ignored, wedging the turn forever.
+//!
+//! This module turns an incoming call into a pure [`ToolOutcome`]: the result
+//! string to submit back to the daemon (so the turn ALWAYS resumes) plus an
+//! optional side effect (speak the text, or show it inline). The async event
+//! loop performs the side effect and submits the result; the decision itself is
+//! pure so it is unit-testable without a transport or an audio device.
+//!
+//! The one tool the TUI understands is `say_this` — "speak this text aloud".
+//! Whether it actually speaks is gated by the per-conversation speech toggle
+//! (the hard cut-off): ON ⇒ speak; OFF ⇒ render `(speech mode disabled) <text>`
+//! inline instead. Either way the turn completes. Any other tool name resolves
+//! to an error result rather than a wedge.
+
+/// The TUI's one client tool: speak a short piece of text aloud. The daemon
+/// forwards this name verbatim to the LLM's tool list.
+pub const SAY_THIS: &str = "say_this";
+
+/// A `SignalEvent::ClientToolCall` flattened into one value so the async
+/// handler takes a single argument instead of five positional ones. Built in
+/// the event-loop match arm from the event's destructured fields.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClientToolCall {
+    pub task_id: String,
+    pub conversation_id: String,
+    pub tool_call_id: String,
+    pub tool_name: String,
+    pub arguments: serde_json::Value,
+}
+
+/// What the event loop should do with a client tool call, plus the result
+/// string to submit back to the daemon. `result` is `Ok` on success and `Err`
+/// with a human-readable message on failure (malformed args, unknown tool);
+/// either way it is submitted so the suspended turn resumes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToolOutcome {
+    /// Side effect the loop performs after deciding (speak / show / nothing).
+    pub effect: ToolEffect,
+    /// The result to hand to `submit_client_tool_result`.
+    pub result: Result<String, String>,
+}
+
+/// The side effect a tool call requires, decoupled from the async machinery so
+/// the decision stays pure.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ToolEffect {
+    /// Speak `text` aloud via the embedded `Speaker`.
+    Speak(String),
+    /// Speech is off for this conversation: show `text` inline in the
+    /// transcript prefixed with `(speech mode disabled)` instead of speaking.
+    ShowDisabled(String),
+    /// Nothing to do beyond submitting the result (unknown tool / bad args).
+    None,
+}
+
+/// Decide how to handle a `say_this` client tool call.
+///
+/// `arguments` is the raw JSON the daemon forwarded; `speech_enabled` is the
+/// per-conversation hard toggle for the call's conversation. Never panics:
+/// a non-object payload or a missing/non-string `text` field becomes an error
+/// result (the turn still resumes) rather than an unwrap.
+pub fn handle_say_this(_arguments: &serde_json::Value, _speech_enabled: bool) -> ToolOutcome {
+    // TODO(adele-tui#73): implement say_this dispatch.
+    ToolOutcome {
+        effect: ToolEffect::None,
+        result: Ok(String::new()),
+    }
+}
+
+/// Dispatch an arbitrary client tool call by name. `say_this` is handled;
+/// anything else resolves to an error result so an unexpected tool (e.g. one
+/// leaked from another session pre-#261, or a future tool the TUI doesn't yet
+/// implement) still resumes the turn instead of wedging it.
+pub fn dispatch(
+    _tool_name: &str,
+    _arguments: &serde_json::Value,
+    _speech_enabled: bool,
+) -> ToolOutcome {
+    // TODO(adele-tui#73): route tools and always produce a result.
+    ToolOutcome {
+        effect: ToolEffect::None,
+        result: Ok(String::new()),
+    }
+}
+
+/// The `say_this` tool registration to advertise to the daemon. Re-sent on
+/// every connect because the daemon replaces the whole set each time (#231).
+pub fn say_this_registration() -> desktop_assistant_api_model::ClientToolRegistration {
+    // TODO(adele-tui#73): build the say_this registration.
+    desktop_assistant_api_model::ClientToolRegistration {
+        name: String::new(),
+        description: String::new(),
+        input_schema: serde_json::Value::Null,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(text: &str) -> serde_json::Value {
+        serde_json::json!({ "text": text })
+    }
+
+    #[test]
+    fn say_this_while_enabled_speaks_and_reports_spoken() {
+        let outcome = handle_say_this(&args("hello there"), true);
+        assert_eq!(outcome.effect, ToolEffect::Speak("hello there".to_string()));
+        assert_eq!(outcome.result, Ok("spoken".to_string()));
+    }
+
+    #[test]
+    fn say_this_while_disabled_shows_inline_and_does_not_speak() {
+        let outcome = handle_say_this(&args("hello there"), false);
+        assert_eq!(
+            outcome.effect,
+            ToolEffect::ShowDisabled("hello there".to_string())
+        );
+        // Result is Ok so the turn completes, but it tells the model the text
+        // was shown, not spoken.
+        let msg = outcome.result.expect("disabled say_this still succeeds");
+        assert!(msg.contains("disabled"));
+        assert!(msg.contains("not spoken"));
+        // Crucially, NOT a Speak effect.
+        assert!(!matches!(outcome.effect, ToolEffect::Speak(_)));
+    }
+
+    #[test]
+    fn say_this_missing_text_is_an_error_not_a_panic() {
+        let outcome = handle_say_this(&serde_json::json!({ "other": 1 }), true);
+        assert_eq!(outcome.effect, ToolEffect::None);
+        assert!(outcome.result.is_err());
+    }
+
+    #[test]
+    fn say_this_non_string_text_is_an_error() {
+        let outcome = handle_say_this(&serde_json::json!({ "text": 42 }), true);
+        assert_eq!(outcome.effect, ToolEffect::None);
+        assert!(outcome.result.is_err());
+    }
+
+    #[test]
+    fn say_this_non_object_payload_is_an_error_not_a_panic() {
+        // A malformed (non-object) arguments value must not panic.
+        let outcome = handle_say_this(&serde_json::json!("just a string"), true);
+        assert_eq!(outcome.effect, ToolEffect::None);
+        assert!(outcome.result.is_err());
+        let outcome = handle_say_this(&serde_json::Value::Null, false);
+        assert!(outcome.result.is_err());
+    }
+
+    #[test]
+    fn dispatch_routes_say_this() {
+        let outcome = dispatch(SAY_THIS, &args("hi"), true);
+        assert_eq!(outcome.effect, ToolEffect::Speak("hi".to_string()));
+    }
+
+    #[test]
+    fn dispatch_unknown_tool_returns_error_result_so_turn_resumes() {
+        // The wedge-killer: any unexpected tool name still yields a result to
+        // submit (an error), never a silent drop.
+        let outcome = dispatch("delete_everything", &args("ignored"), true);
+        assert_eq!(outcome.effect, ToolEffect::None);
+        assert!(outcome.result.is_err());
+        assert!(outcome.result.unwrap_err().contains("delete_everything"));
+    }
+
+    #[test]
+    fn registration_has_say_this_name_and_required_text() {
+        let reg = say_this_registration();
+        assert_eq!(reg.name, SAY_THIS);
+        assert!(!reg.description.is_empty());
+        let required = reg.input_schema.get("required").unwrap();
+        assert_eq!(required, &serde_json::json!(["text"]));
+    }
+}

--- a/src/client_tools.rs
+++ b/src/client_tools.rs
@@ -64,11 +64,27 @@ pub enum ToolEffect {
 /// per-conversation hard toggle for the call's conversation. Never panics:
 /// a non-object payload or a missing/non-string `text` field becomes an error
 /// result (the turn still resumes) rather than an unwrap.
-pub fn handle_say_this(_arguments: &serde_json::Value, _speech_enabled: bool) -> ToolOutcome {
-    // TODO(adele-tui#73): implement say_this dispatch.
-    ToolOutcome {
-        effect: ToolEffect::None,
-        result: Ok(String::new()),
+pub fn handle_say_this(arguments: &serde_json::Value, speech_enabled: bool) -> ToolOutcome {
+    let Some(text) = arguments.get("text").and_then(|t| t.as_str()) else {
+        return ToolOutcome {
+            effect: ToolEffect::None,
+            result: Err("say_this requires a string `text` argument".to_string()),
+        };
+    };
+    if speech_enabled {
+        ToolOutcome {
+            effect: ToolEffect::Speak(text.to_string()),
+            result: Ok("spoken".to_string()),
+        }
+    } else {
+        ToolOutcome {
+            effect: ToolEffect::ShowDisabled(text.to_string()),
+            result: Ok(
+                "speech mode is disabled in this conversation; the text was shown to the user, \
+                 not spoken"
+                    .to_string(),
+            ),
+        }
     }
 }
 
@@ -77,25 +93,37 @@ pub fn handle_say_this(_arguments: &serde_json::Value, _speech_enabled: bool) ->
 /// leaked from another session pre-#261, or a future tool the TUI doesn't yet
 /// implement) still resumes the turn instead of wedging it.
 pub fn dispatch(
-    _tool_name: &str,
-    _arguments: &serde_json::Value,
-    _speech_enabled: bool,
+    tool_name: &str,
+    arguments: &serde_json::Value,
+    speech_enabled: bool,
 ) -> ToolOutcome {
-    // TODO(adele-tui#73): route tools and always produce a result.
-    ToolOutcome {
-        effect: ToolEffect::None,
-        result: Ok(String::new()),
+    match tool_name {
+        SAY_THIS => handle_say_this(arguments, speech_enabled),
+        other => ToolOutcome {
+            effect: ToolEffect::None,
+            result: Err(format!("unknown client tool `{other}`")),
+        },
     }
 }
 
 /// The `say_this` tool registration to advertise to the daemon. Re-sent on
 /// every connect because the daemon replaces the whole set each time (#231).
 pub fn say_this_registration() -> desktop_assistant_api_model::ClientToolRegistration {
-    // TODO(adele-tui#73): build the say_this registration.
     desktop_assistant_api_model::ClientToolRegistration {
-        name: String::new(),
-        description: String::new(),
-        input_schema: serde_json::Value::Null,
+        name: SAY_THIS.to_string(),
+        description: "Speak a short piece of text aloud to the user through their speakers. \
+            Use for brief spoken asides; the user's reply still arrives as text."
+            .to_string(),
+        input_schema: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "text": {
+                    "type": "string",
+                    "description": "The text to speak aloud."
+                }
+            },
+            "required": ["text"]
+        }),
     }
 }
 

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -51,6 +51,13 @@ pub enum Action {
     /// ("Go, voice") — free across modes and not intercepted by terminals or
     /// the textarea. No-op unless voice is in `embedded` mode (adele-tui#67).
     Dictate,
+    /// Toggle the per-conversation "speech enabled" hard switch (adele-tui#73).
+    /// Bound to `Ctrl+S` ("Speech"). The keyboard-enhancement flags pushed at
+    /// startup deliver Ctrl+S as a real key event (not terminal XOFF flow
+    /// control). When ON the assistant's replies are spoken aloud and the
+    /// daemon's `say_this` client tool speaks; when OFF nothing is ever
+    /// played. Defaults OFF per conversation (seeded from `play_replies`).
+    ToggleSpeech,
 }
 
 /// Handle key events that we intercept before passing to textarea.
@@ -108,6 +115,7 @@ pub fn handle_key_event(
             // Ctrl+G starts embedded dictation (mic → prompt). A no-op when
             // voice isn't in embedded mode; main.rs gates on the session.
             KeyCode::Char('g') => Some(Action::Dictate),
+            // TODO(adele-tui#73): bind Ctrl+S to Action::ToggleSpeech.
             _ => None,
         };
     }
@@ -797,6 +805,48 @@ mod tests {
                 false
             ),
             Some(Action::Dictate)
+        );
+    }
+
+    // --- Ctrl+S toggles per-conversation speech (adele-tui#73) ---
+
+    #[test]
+    fn ctrl_s_toggles_speech_in_normal() {
+        assert_eq!(
+            handle_key_event(
+                key_with_mod(KeyCode::Char('s'), KeyModifiers::CONTROL),
+                &InputMode::Normal,
+                false
+            ),
+            Some(Action::ToggleSpeech)
+        );
+    }
+
+    #[test]
+    fn ctrl_s_toggles_speech_in_editing() {
+        // Speech is a per-conversation control the user will flip while
+        // composing, so it must be reachable from editing mode too.
+        assert_eq!(
+            handle_key_event(
+                key_with_mod(KeyCode::Char('s'), KeyModifiers::CONTROL),
+                &InputMode::Editing,
+                false
+            ),
+            Some(Action::ToggleSpeech)
+        );
+    }
+
+    #[test]
+    fn ctrl_s_is_not_intercepted_in_renaming() {
+        // Renaming forwards all Ctrl combos to the rename textarea; the speech
+        // toggle must not hijack them mid-rename.
+        assert_eq!(
+            handle_key_event(
+                key_with_mod(KeyCode::Char('s'), KeyModifiers::CONTROL),
+                &InputMode::Renaming,
+                false
+            ),
+            None
         );
     }
 

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -115,7 +115,9 @@ pub fn handle_key_event(
             // Ctrl+G starts embedded dictation (mic → prompt). A no-op when
             // voice isn't in embedded mode; main.rs gates on the session.
             KeyCode::Char('g') => Some(Action::Dictate),
-            // TODO(adele-tui#73): bind Ctrl+S to Action::ToggleSpeech.
+            // Ctrl+S toggles per-conversation speech (adele-tui#73). A no-op
+            // status hint when no conversation is open; main.rs gates on it.
+            KeyCode::Char('s') => Some(Action::ToggleSpeech),
             _ => None,
         };
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 //! independently of the binary entry point.
 
 pub mod app;
+pub mod client_tools;
 pub mod connections;
 pub mod credentials;
 pub mod kb;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@
 //! base, connections, and purposes management screens).
 
 mod app;
+mod client_tools;
 mod connections;
 mod credentials;
 mod kb;
@@ -316,6 +317,10 @@ async fn run(
                 Err(e) => app.status_message = format!("Error loading conversations: {e}"),
             }
             init_background_tasks(&mut app, conn.client()).await;
+            // Advertise the TUI's `say_this` client tool (adele-tui#73). Scoped
+            // to this session via desktop-assistant#261, so a concurrent voice
+            // session's tools never fire on a TUI turn.
+            register_client_tools(&conn).await;
             app.status_message = conn.label().to_string();
             connector = Some(conn);
         }
@@ -336,6 +341,13 @@ async fn run(
     // result and the ready session are merged into the select! loop like every
     // other async source (per AGENTS.md). Off/daemon mode wires nothing.
     let voice_cfg = VoiceConfig::load();
+    // Seed the per-conversation speech toggle's default (adele-tui#73). Existing
+    // `play_replies = true` users keep audio (now per-conversation + toggleable
+    // via Ctrl+S); everyone else defaults to speech OFF. Only meaningful in
+    // embedded mode — there is no `Speaker` to narrate with otherwise.
+    if voice_cfg.embedded_enabled() {
+        app.set_speech_default(voice_cfg.play_replies);
+    }
     let mut voice_session: Option<VoiceSession> = None;
     let mut dictating = false;
     let (dictation_tx, mut dictation_rx) = unbounded_channel::<DictationOutcome>();
@@ -485,11 +497,15 @@ async fn run(
                     }
                     SignalEvent::Complete { request_id, full_response } => {
                         app.complete_streaming(&request_id, &full_response);
-                        // Speak the reply aloud (embedded TTS, no daemon) when
-                        // enabled. Fire-and-forget on a task so synth+playback
-                        // never blocks the UI; `Speaker` is cheap to clone.
+                        // Speak the reply aloud (embedded TTS, no daemon) only
+                        // when the OPEN conversation's per-conversation speech
+                        // toggle is ON (adele-tui#73) — the hard cut-off. The
+                        // completing reply streams into the open conversation,
+                        // so that toggle is the right gate. Fire-and-forget on a
+                        // task so synth+playback never blocks the UI; `Speaker`
+                        // is cheap to clone.
                         if let Some(session) = voice_session.as_ref()
-                            && session.play_replies()
+                            && app.current_speech_enabled()
                             && !full_response.trim().is_empty()
                         {
                             let speaker = session.speaker();
@@ -554,11 +570,28 @@ async fn run(
                     // The TUI has no scratchpad pane (that lives in the GTK/KDE
                     // clients), so the change notification is a no-op here.
                     SignalEvent::ScratchpadChanged { .. } => {}
-                    // The TUI registers no client-local MCP tools
-                    // (`register_client_tools`), so the daemon never parks a turn
-                    // on it — this variant can't actually arrive here. Match it
-                    // explicitly to keep the arm list exhaustive (#231).
-                    SignalEvent::ClientToolCall { .. } => {}
+                    // The daemon suspended a turn on a client-local tool (#107)
+                    // — the TUI registers `say_this` (adele-tui#73). Dispatch
+                    // it, perform the side effect (speak / show inline), and
+                    // ALWAYS submit a result so the parked turn resumes. With
+                    // the per-session registry (desktop-assistant#261) a
+                    // concurrent voice session's tools no longer fire here.
+                    SignalEvent::ClientToolCall {
+                        task_id,
+                        conversation_id,
+                        tool_call_id,
+                        tool_name,
+                        arguments,
+                    } => {
+                        let call = client_tools::ClientToolCall {
+                            task_id,
+                            conversation_id,
+                            tool_call_id,
+                            tool_name,
+                            arguments,
+                        };
+                        handle_client_tool_call(&mut app, &connector, &voice_session, call).await;
+                    }
                 }
             }
             _ = async {
@@ -581,6 +614,9 @@ async fn run(
                             Err(e) => app.status_message = format!("Error loading conversations: {e}"),
                         }
                         init_background_tasks(&mut app, conn.client()).await;
+                        // Re-advertise client tools — the daemon replaces the
+                        // per-session set on each connect (adele-tui#73 / #231).
+                        register_client_tools(&conn).await;
                         reconnect = ReconnectState::Connected;
                         app.status_message = conn.label().to_string();
                         connector = Some(conn);
@@ -708,6 +744,19 @@ async fn handle_action(app: &mut App, connector: &Option<Connector>, action: Act
         // session + a result channel + a spawned capture task — loop-local
         // resources that don't belong in `handle_action`'s signature).
         Action::Dictate => {}
+        Action::ToggleSpeech => match app.toggle_current_speech() {
+            Some(true) => {
+                app.status_message =
+                    "Speech ON for this conversation (replies + say_this spoken aloud)".into();
+            }
+            Some(false) => {
+                app.status_message = "Speech OFF for this conversation".into();
+            }
+            None => {
+                app.status_message =
+                    "Open a conversation first — speech is per-conversation".into();
+            }
+        },
         Action::InsertNewline => {
             app.textarea.insert_newline();
         }
@@ -884,6 +933,73 @@ async fn handle_action(app: &mut App, connector: &Option<Connector>, action: Act
                 }
             }
         }
+    }
+}
+
+/// Handle a daemon `ClientToolCall` for the TUI's `say_this` tool, then submit
+/// a result so the suspended turn resumes (adele-tui#73). The decision is pure
+/// (see [`client_tools::dispatch`]); this just performs the side effect — speak
+/// via the embedded `Speaker`, or render the text inline when speech is off —
+/// and posts the outcome back over the connector. A result is ALWAYS submitted
+/// (even on a transport/submit error we log rather than wedge silently).
+async fn handle_client_tool_call(
+    app: &mut App,
+    connector: &Option<Connector>,
+    voice_session: &Option<VoiceSession>,
+    call: client_tools::ClientToolCall,
+) {
+    // Gate on the call's OWN conversation, not the open one, so the hard toggle
+    // is honored per conversation even if the user has since switched tabs.
+    let speech_enabled = app.speech_enabled_for(&call.conversation_id);
+    let outcome = client_tools::dispatch(&call.tool_name, &call.arguments, speech_enabled);
+
+    match outcome.effect {
+        client_tools::ToolEffect::Speak(text) => {
+            // Fire-and-forget playback so we don't block submitting the result.
+            if let Some(session) = voice_session.as_ref() {
+                let speaker = session.speaker();
+                tokio::spawn(async move {
+                    if let Err(e) = speaker.say(&text).await {
+                        tracing::warn!("say_this playback failed: {e}");
+                    }
+                });
+            } else {
+                // Speech enabled but no audio pipeline (voice off / failed to
+                // load): degrade to showing the text rather than dropping it.
+                app.push_speech_disabled_note(&call.conversation_id, &text);
+            }
+        }
+        client_tools::ToolEffect::ShowDisabled(text) => {
+            app.push_speech_disabled_note(&call.conversation_id, &text);
+        }
+        client_tools::ToolEffect::None => {}
+    }
+
+    if let Some(conn) = connector.as_ref() {
+        if let Err(e) = conn
+            .submit_client_tool_result(&call.task_id, &call.tool_call_id, outcome.result)
+            .await
+        {
+            app.status_message = format!("Client tool result submit failed: {e}");
+        }
+    } else {
+        // No live connection to submit through — the turn is already lost to a
+        // disconnect; surface it rather than failing silently.
+        app.status_message = "Client tool call arrived while disconnected".into();
+    }
+}
+
+/// Advertise the TUI's `say_this` client tool to the daemon. The daemon
+/// replaces the whole set each call, so this runs on every (re)connect (#231).
+/// Best-effort: voice playback is a convenience, so a failure to register is
+/// only logged and never blocks the chat. Over D-Bus (no command channel for
+/// client tools) this is expected to fail and is silently skipped.
+async fn register_client_tools(conn: &Connector) {
+    if let Err(e) = conn
+        .register_client_tools(vec![client_tools::say_this_registration()])
+        .await
+    {
+        tracing::debug!("client tool registration skipped: {e}");
     }
 }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -368,10 +368,12 @@ fn draw_messages(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
         .and_then(|conv| conv.model_selection.as_ref())
         .map(|sel| format!("  ·  {} · {}", sel.connection_id, sel.model_id))
         .unwrap_or_default();
+    // TODO(adele-tui#73): show a persistent speech cue when the toggle is ON.
+    let speech_suffix = "";
     let title = if app.scroll_offset > 0 {
-        format!("{chat_title}{model_suffix} (Ctrl+u/d scroll, Ctrl+e bottom)")
+        format!("{chat_title}{model_suffix}{speech_suffix} (Ctrl+u/d scroll, Ctrl+e bottom)")
     } else {
-        format!("{chat_title}{model_suffix}")
+        format!("{chat_title}{model_suffix}{speech_suffix}")
     };
 
     let block = Block::default()
@@ -512,6 +514,45 @@ mod tests {
             conversation_personality: None,
         });
         terminal.draw(|f| draw(f, &mut app)).unwrap();
+    }
+
+    #[test]
+    fn draw_shows_speech_cue_only_when_enabled() {
+        // The persistent speech indicator (adele-tui#73) appears in the chat
+        // title only while the open conversation's toggle is ON.
+        let backend = TestBackend::new(100, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut app = App::new();
+        app.current_conversation = Some(ConversationDetail {
+            id: "c1".into(),
+            title: "ChatProbe".into(),
+            messages: vec![],
+            model_selection: None,
+            conversation_personality: None,
+        });
+
+        // OFF (default): no "speech" cue in the title.
+        terminal.draw(|f| draw(f, &mut app)).unwrap();
+        let dump: String = terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .map(|c| c.symbol())
+            .collect();
+        assert!(!dump.contains("speech"));
+
+        // ON: the cue appears.
+        assert_eq!(app.toggle_current_speech(), Some(true));
+        terminal.draw(|f| draw(f, &mut app)).unwrap();
+        let dump: String = terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .map(|c| c.symbol())
+            .collect();
+        assert!(dump.contains("speech"));
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -368,8 +368,14 @@ fn draw_messages(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
         .and_then(|conv| conv.model_selection.as_ref())
         .map(|sel| format!("  ·  {} · {}", sel.connection_id, sel.model_id))
         .unwrap_or_default();
-    // TODO(adele-tui#73): show a persistent speech cue when the toggle is ON.
-    let speech_suffix = "";
+    // Persistent cue for the per-conversation speech toggle (adele-tui#73), so
+    // the user can always tell whether replies/say_this will be spoken. Only
+    // shown when ON; OFF (the common default) stays uncluttered.
+    let speech_suffix = if app.current_speech_enabled() {
+        "  ·  🔊 speech (Ctrl+S)"
+    } else {
+        ""
+    };
     let title = if app.scroll_offset > 0 {
         format!("{chat_title}{model_suffix}{speech_suffix} (Ctrl+u/d scroll, Ctrl+e bottom)")
     } else {

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -55,8 +55,11 @@ pub enum VoiceMode {
 pub struct VoiceConfig {
     /// The capability toggle (`off` | `embedded` | `daemon`).
     pub mode: VoiceMode,
-    /// Speak assistant replies aloud after they finish streaming. Only has an
-    /// effect in `embedded` mode.
+    /// Seeds the per-conversation speech toggle's default (adele-tui#73). When
+    /// `true`, new conversations start with speech ON (so existing
+    /// `play_replies = true` users keep audio), but speech is now an in-app
+    /// per-conversation control (`Ctrl+S`), no longer a global always-on gate.
+    /// Only meaningful in `embedded` mode. Defaults `false` (speech off).
     pub play_replies: bool,
     pub audio: AudioConfig,
     pub vad: VadConfig,
@@ -111,20 +114,23 @@ fn config_path() -> Option<std::path::PathBuf> {
 pub struct VoiceSession {
     dictation: Arc<Mutex<Dictation<SileroVad, WhisperStt>>>,
     speaker: Speaker<TtsBackend>,
-    play_replies: bool,
 }
 
 impl VoiceSession {
     /// Wire the embedded pipeline from config. Loads the VAD/STT models and the
     /// TTS backend (local-first Kokoro→Piper fallback), so this is the expensive
     /// step; call it once, lazily, on the first dictate.
+    ///
+    /// Whether replies are *spoken* is no longer a property of the session: the
+    /// per-conversation `Ctrl+S` speech toggle (adele-tui#73) governs that, with
+    /// its default seeded from `cfg.play_replies`. The session just supplies the
+    /// `Speaker`; the caller decides per conversation whether to use it.
     pub async fn build(cfg: &VoiceConfig) -> anyhow::Result<Self> {
         let dictation = build_dictation(&cfg.audio, &cfg.vad, &cfg.stt)?;
         let speaker = build_speaker(&cfg.tts, &cfg.audio).await;
         Ok(Self {
             dictation: Arc::new(Mutex::new(dictation)),
             speaker,
-            play_replies: cfg.play_replies,
         })
     }
 
@@ -136,11 +142,6 @@ impl VoiceSession {
     /// A speaker clone for spawning a playback task.
     pub fn speaker(&self) -> Speaker<TtsBackend> {
         self.speaker.clone()
-    }
-
-    /// Whether replies should be spoken aloud.
-    pub fn play_replies(&self) -> bool {
-        self.play_replies
     }
 }
 


### PR DESCRIPTION
Closes #73

Phase 1 of the per-conversation voice-mode work for the TUI (mirrors the gtk #76 scope). Replaces the always-on `play_replies` config gate with a per-conversation, in-app **hard speech toggle** (default OFF) and makes the daemon's `say_this` client tool safe to handle. Depends on the already-merged desktop-assistant #261 (per-session client tools) + #262 (suspension timeout), which the git-dep on `desktop-assistant` `main` already provides.

## What's in this PR (the four agreed items)

1. **Per-conversation hard "speech enabled" toggle** — bound to **Ctrl+S** ("Speech"). Default **OFF**. This replaces the always-on `play_replies` gate with a per-conversation in-app control. A persistent cue (`🔊 speech (Ctrl+S)`) shows in the chat title while ON; the status bar confirms each toggle. Ctrl+S is delivered as a real key event (not terminal XOFF) because the TUI already pushes `REPORT_ALL_KEYS_AS_ESCAPE_CODES`; it's forwarded to the rename textarea in Renaming mode like the other Ctrl combos.

2. **Reply narration** via the embedded `Speaker` only when the **open** conversation's toggle is ON — the master cut-off. (The completing reply streams into the open conversation, so that toggle is the correct gate.)

3. **ClientToolCall ALWAYS returns a result** — the `SignalEvent::ClientToolCall { .. } => {}` no-op is replaced with dispatch + `submit_client_tool_result(...)`. This kills the suspended-turn wedge the per-user tool registry exposed. Unknown tool names and malformed arguments still produce a result (an error), never a silent drop and never a panic.

4. **`say_this` handled with downgrade** — toggle ON → speak via `Speaker`, result `"spoken"`; toggle OFF → append `(speech mode disabled) <text>` inline to the transcript, result noting the text was shown not spoken. The turn always completes.

### say_this option chosen: **registered** (session-scoped)
`say_this` is registered as the TUI's **own** client tool (`register_client_tools`) on every (re)connect (the daemon replaces the whole per-session set each connect, #231). With desktop-assistant #261 the registry is per-session, so a concurrent voice session's tools never fire on a TUI turn. Registration is best-effort: over D-Bus (no command channel for client tools) it's silently skipped, never blocking the chat.

### Design note
The dispatch decision lives in a new **pure `client_tools` module** (no transport, no audio device) so it's unit-tested directly. The async handler just performs the side effect (spawn `Speaker::say`, or push the inline note) and submits the result. Gating is keyed to each call's **own** `conversation_id`, not the open one, so a stale/other conversation never bleeds audio or text. If speech is ON but no audio pipeline exists (voice off / failed to load), `say_this` degrades to showing the text rather than dropping it.

## `play_replies` migration decision
`play_replies` is **kept in `voice.toml`** but repurposed as the **seed for the per-conversation toggle's default** (only in `embedded` mode). Existing `play_replies = true` users keep audio, but it is now per-conversation and toggleable via Ctrl+S; everyone else defaults to speech OFF. `VoiceSession` no longer carries `play_replies` (narration is governed by the App-side per-conversation toggle). Documented in the `VoiceConfig::play_replies` doc comment.

## Deferred to a follow-up (not in this PR, per the agreed scope)
- Model-driven `request_voice` / `stop_voice` tools.
- Passing the voice `system_refinement` on send.

## Tests (TDD: failing tests committed first, then implementation)
New named tests, all passing (288 in the bin crate / 310 in the lib crate; full suite green):
- `client_tools`: `say_this_while_enabled_speaks_and_reports_spoken`, `say_this_while_disabled_shows_inline_and_does_not_speak`, `say_this_missing_text_is_an_error_not_a_panic`, `say_this_non_string_text_is_an_error`, `say_this_non_object_payload_is_an_error_not_a_panic`, `dispatch_routes_say_this`, `dispatch_unknown_tool_returns_error_result_so_turn_resumes`, `registration_has_say_this_name_and_required_text`.
- `app`: `speech_defaults_off_when_play_replies_unset`, `speech_default_seeds_untoggled_conversations`, `toggle_current_speech_flips_and_returns_new_state`, `toggle_current_speech_without_conversation_is_none`, `speech_toggle_is_per_conversation_isolated`, `speech_toggle_overrides_the_default_per_conversation`, `push_speech_disabled_note_appends_inline_to_open_conversation`, `push_speech_disabled_note_ignores_other_conversation`, `push_speech_disabled_note_with_no_conversation_is_noop`.
- `keys`: `ctrl_s_toggles_speech_in_normal`, `ctrl_s_toggles_speech_in_editing`, `ctrl_s_is_not_intercepted_in_renaming`.
- `ui`: `draw_shows_speech_cue_only_when_enabled`.

## Quality gates
- `cargo build`, `cargo test`, `cargo clippy --all-targets -- -D warnings`: all clean for this diff. No broad `#[allow]` (the only would-be `too_many_arguments` was removed by grouping the call fields into a `ClientToolCall` struct).
- `cargo fmt --check` clean (package-wide); `just check` passes — pushed **without** `--no-verify`.

## Security self-review
Adversarial read of the diff: no `unwrap`/`expect`/`panic!` on the `arguments` JSON path — a non-object payload or missing/non-string `text` yields an error result (the turn resumes). No audio plays on any path while a conversation's toggle is OFF (narration and `say_this` both gate on it). No cross-conversation bleed: narration gates on the open conversation; `say_this` gates on the call's own `conversation_id` and the inline note only appends when that matches the open conversation. A result is always submitted so a turn can never wedge.

## Note
`Cargo.lock` has a 2-line transitive bump (`adele-voice-core` now pulls `pulldown-cmark` + `serde_json`) that the current `voice` path-dep requires to build; it re-applies on any build and is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)