### PR TITLE
Phase 2: model-driven soft-sticky voice mode (read-aloud + request_voice/stop_voice) (#75)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -141,6 +141,14 @@ pub struct App {
     /// `play_replies = true` users keep audio, but it is now per-conversation
     /// and toggleable. Defaults `false` (off) when voice is unconfigured.
     speech_default: bool,
+    /// Per-conversation soft-sticky **voice mode** (adele-tui#75), keyed by
+    /// conversation id. Independent of `speech_enabled` (read-aloud): either one
+    /// being ON narrates replies. Entered/left by the user (`Ctrl+V`) or by the
+    /// model (`request_voice` / `stop_voice`). When ON, sends also carry a
+    /// concise read-aloud `system_refinement` so replies are shaped for speech.
+    /// A conversation absent from the map is OFF (the default). No `*_default`
+    /// seed: voice mode is always entered explicitly, never config-seeded.
+    voice_mode: HashMap<String, bool>,
 }
 
 impl App {
@@ -175,6 +183,7 @@ impl App {
             pending_task_cancel: None,
             speech_enabled: HashMap::new(),
             speech_default: false,
+            voice_mode: HashMap::new(),
         }
     }
 
@@ -232,6 +241,58 @@ impl App {
         });
         self.scroll_offset = 0;
         true
+    }
+
+    // --- Per-conversation voice mode (adele-tui#75) ---
+
+    /// Whether soft-sticky voice mode is on for `conversation_id`. A
+    /// conversation never entered is OFF (the default). Independent of
+    /// `speech_enabled_for` (read-aloud).
+    pub fn voice_mode_for(&self, conversation_id: &str) -> bool {
+        self.voice_mode
+            .get(conversation_id)
+            .copied()
+            .unwrap_or(false)
+    }
+
+    /// Whether voice mode is on for the currently-open conversation. `false`
+    /// when no conversation is open.
+    pub fn current_voice_mode(&self) -> bool {
+        self.current_conversation
+            .as_ref()
+            .is_some_and(|c| self.voice_mode_for(&c.id))
+    }
+
+    /// Set voice mode for an explicit `conversation_id` (used by the model's
+    /// `request_voice` / `stop_voice` tools, which carry their own
+    /// conversation). Per-conversation: only the named conversation is affected.
+    pub fn set_voice_mode(&mut self, _conversation_id: &str, _on: bool) {
+        // STUB (tests-first): no-op.
+    }
+
+    /// Flip voice mode for the currently-open conversation and return the new
+    /// state (used by the `Ctrl+V` keybind). `None` when no conversation is
+    /// open. Per-conversation: toggling one never affects another.
+    pub fn toggle_current_voice_mode(&mut self) -> Option<bool> {
+        // STUB (tests-first): never flips.
+        None
+    }
+
+    /// Whether a reply for `conversation_id` should be spoken: read-aloud OR
+    /// voice-mode (adele-tui#75). This is the single narration / `say_this`
+    /// audio gate.
+    pub fn audio_enabled_for(&self, conversation_id: &str) -> bool {
+        // STUB (tests-first): read-aloud only, ignores voice mode.
+        self.speech_enabled_for(conversation_id)
+    }
+
+    /// Whether audio is on for the currently-open conversation (read-aloud OR
+    /// voice-mode). `false` when no conversation is open. This is the reply
+    /// narration gate for the streaming completion path.
+    pub fn current_audio_enabled(&self) -> bool {
+        self.current_conversation
+            .as_ref()
+            .is_some_and(|c| self.audio_enabled_for(&c.id))
     }
 
     // --- Tasks-pane glue ---
@@ -1550,6 +1611,78 @@ mod tests {
     fn push_speech_disabled_note_with_no_conversation_is_noop() {
         let mut app = App::new();
         assert!(!app.push_speech_disabled_note("c1", "anything"));
+    }
+
+    // --- Per-conversation voice mode (adele-tui#75) ---
+
+    #[test]
+    fn voice_mode_defaults_off() {
+        let app = app_with_open_conversation("c1");
+        assert!(!app.current_voice_mode());
+        assert!(!app.voice_mode_for("c1"));
+        assert!(!app.voice_mode_for("never-seen"));
+    }
+
+    #[test]
+    fn toggle_current_voice_mode_flips_and_returns_new_state() {
+        let mut app = app_with_open_conversation("c1");
+        assert_eq!(app.toggle_current_voice_mode(), Some(true));
+        assert!(app.current_voice_mode());
+        assert_eq!(app.toggle_current_voice_mode(), Some(false));
+        assert!(!app.current_voice_mode());
+    }
+
+    #[test]
+    fn toggle_current_voice_mode_without_conversation_is_none() {
+        let mut app = App::new();
+        assert_eq!(app.toggle_current_voice_mode(), None);
+        assert!(!app.current_voice_mode());
+    }
+
+    #[test]
+    fn set_voice_mode_targets_an_explicit_conversation() {
+        // The model's request_voice/stop_voice carry their own conversation id,
+        // which may not be the open one.
+        let mut app = app_with_open_conversation("c1");
+        app.set_voice_mode("c2", true);
+        assert!(app.voice_mode_for("c2"));
+        assert!(!app.voice_mode_for("c1")); // open conversation untouched
+        app.set_voice_mode("c2", false);
+        assert!(!app.voice_mode_for("c2"));
+    }
+
+    #[test]
+    fn voice_mode_is_per_conversation_isolated() {
+        let mut app = app_with_open_conversation("c1");
+        assert_eq!(app.toggle_current_voice_mode(), Some(true)); // c1 ON
+        assert!(app.voice_mode_for("c1"));
+        assert!(!app.voice_mode_for("c2")); // c2 untouched → OFF
+    }
+
+    #[test]
+    fn audio_enabled_is_read_aloud_or_voice_mode() {
+        // Both off → no audio (exactly phase-1 toggle-off).
+        let mut app = app_with_open_conversation("c1");
+        assert!(!app.audio_enabled_for("c1"));
+        assert!(!app.current_audio_enabled());
+
+        // Read-aloud on (phase-1 toggle) → audio on.
+        assert_eq!(app.toggle_current_speech(), Some(true));
+        assert!(app.audio_enabled_for("c1"));
+        assert!(app.current_audio_enabled());
+
+        // Read-aloud back off, voice-mode on → still audio on.
+        assert_eq!(app.toggle_current_speech(), Some(false));
+        assert!(!app.audio_enabled_for("c1"));
+        assert_eq!(app.toggle_current_voice_mode(), Some(true));
+        assert!(app.audio_enabled_for("c1"));
+        assert!(app.current_audio_enabled());
+    }
+
+    #[test]
+    fn current_audio_enabled_is_false_without_a_conversation() {
+        let app = App::new();
+        assert!(!app.current_audio_enabled());
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -266,24 +266,25 @@ impl App {
     /// Set voice mode for an explicit `conversation_id` (used by the model's
     /// `request_voice` / `stop_voice` tools, which carry their own
     /// conversation). Per-conversation: only the named conversation is affected.
-    pub fn set_voice_mode(&mut self, _conversation_id: &str, _on: bool) {
-        // STUB (tests-first): no-op.
+    pub fn set_voice_mode(&mut self, conversation_id: &str, on: bool) {
+        self.voice_mode.insert(conversation_id.to_string(), on);
     }
 
     /// Flip voice mode for the currently-open conversation and return the new
     /// state (used by the `Ctrl+V` keybind). `None` when no conversation is
     /// open. Per-conversation: toggling one never affects another.
     pub fn toggle_current_voice_mode(&mut self) -> Option<bool> {
-        // STUB (tests-first): never flips.
-        None
+        let conv_id = self.current_conversation.as_ref()?.id.clone();
+        let next = !self.voice_mode_for(&conv_id);
+        self.voice_mode.insert(conv_id, next);
+        Some(next)
     }
 
     /// Whether a reply for `conversation_id` should be spoken: read-aloud OR
     /// voice-mode (adele-tui#75). This is the single narration / `say_this`
     /// audio gate.
     pub fn audio_enabled_for(&self, conversation_id: &str) -> bool {
-        // STUB (tests-first): read-aloud only, ignores voice mode.
-        self.speech_enabled_for(conversation_id)
+        self.speech_enabled_for(conversation_id) || self.voice_mode_for(conversation_id)
     }
 
     /// Whether audio is on for the currently-open conversation (read-aloud OR

--- a/src/client_tools.rs
+++ b/src/client_tools.rs
@@ -11,15 +11,33 @@
 //! loop performs the side effect and submits the result; the decision itself is
 //! pure so it is unit-testable without a transport or an audio device.
 //!
-//! The one tool the TUI understands is `say_this` — "speak this text aloud".
-//! Whether it actually speaks is gated by the per-conversation speech toggle
-//! (the hard cut-off): ON ⇒ speak; OFF ⇒ render `(speech mode disabled) <text>`
-//! inline instead. Either way the turn completes. Any other tool name resolves
-//! to an error result rather than a wedge.
+//! The TUI understands three tools:
+//!
+//! * `say_this` — "speak this text aloud". Whether it actually speaks is gated
+//!   by whether ANY audio control is on for the call's conversation:
+//!   read-aloud (the phase-1 accessibility toggle) OR voice-mode (phase-2). ON
+//!   ⇒ speak; OFF ⇒ render `(speech mode disabled) <text>` inline instead.
+//! * `request_voice` (adele-tui#75) — the model switching this conversation into
+//!   spoken voice mode ("ok, let's talk by voice"). Turns the per-conversation
+//!   soft-sticky voice mode ON.
+//! * `stop_voice` (adele-tui#75) — the model leaving voice mode; turns it OFF.
+//!
+//! Either way the turn always completes, and any other tool name resolves to an
+//! error result rather than a wedge. The decision is pure; the async handler
+//! performs the side effect (speak / show inline / flip `App::voice_mode`).
 
-/// The TUI's one client tool: speak a short piece of text aloud. The daemon
-/// forwards this name verbatim to the LLM's tool list.
+/// The TUI's `say_this` client tool: speak a short piece of text aloud. The
+/// daemon forwards this name verbatim to the LLM's tool list.
 pub const SAY_THIS: &str = "say_this";
+
+/// The model-driven "enter voice mode" tool (adele-tui#75). The model calls it
+/// when the user asks to talk by voice; it flips the conversation's soft-sticky
+/// voice mode ON (replies narrated + shaped for speech).
+pub const REQUEST_VOICE: &str = "request_voice";
+
+/// The model-driven "leave voice mode" tool (adele-tui#75). Flips the
+/// conversation's voice mode OFF, back to text-only.
+pub const STOP_VOICE: &str = "stop_voice";
 
 /// A `SignalEvent::ClientToolCall` flattened into one value so the async
 /// handler takes a single argument instead of five positional ones. Built in
@@ -51,27 +69,32 @@ pub struct ToolOutcome {
 pub enum ToolEffect {
     /// Speak `text` aloud via the embedded `Speaker`.
     Speak(String),
-    /// Speech is off for this conversation: show `text` inline in the
+    /// No audio control is on for this conversation: show `text` inline in the
     /// transcript prefixed with `(speech mode disabled)` instead of speaking.
     ShowDisabled(String),
+    /// Set the call's conversation's soft-sticky voice mode (adele-tui#75) —
+    /// `true` for `request_voice`, `false` for `stop_voice`. The async handler
+    /// applies it to `App::voice_mode` so this decision stays pure.
+    SetVoiceMode(bool),
     /// Nothing to do beyond submitting the result (unknown tool / bad args).
     None,
 }
 
 /// Decide how to handle a `say_this` client tool call.
 ///
-/// `arguments` is the raw JSON the daemon forwarded; `speech_enabled` is the
-/// per-conversation hard toggle for the call's conversation. Never panics:
-/// a non-object payload or a missing/non-string `text` field becomes an error
-/// result (the turn still resumes) rather than an unwrap.
-pub fn handle_say_this(arguments: &serde_json::Value, speech_enabled: bool) -> ToolOutcome {
+/// `arguments` is the raw JSON the daemon forwarded; `audio_enabled` is whether
+/// ANY audio control is on for the call's conversation — read-aloud OR
+/// voice-mode (adele-tui#75 broadened this from phase-1's read-aloud-only
+/// gate). Never panics: a non-object payload or a missing/non-string `text`
+/// field becomes an error result (the turn still resumes) rather than an unwrap.
+pub fn handle_say_this(arguments: &serde_json::Value, audio_enabled: bool) -> ToolOutcome {
     let Some(text) = arguments.get("text").and_then(|t| t.as_str()) else {
         return ToolOutcome {
             effect: ToolEffect::None,
             result: Err("say_this requires a string `text` argument".to_string()),
         };
     };
-    if speech_enabled {
+    if audio_enabled {
         ToolOutcome {
             effect: ToolEffect::Speak(text.to_string()),
             result: Ok("spoken".to_string()),
@@ -88,17 +111,41 @@ pub fn handle_say_this(arguments: &serde_json::Value, speech_enabled: bool) -> T
     }
 }
 
-/// Dispatch an arbitrary client tool call by name. `say_this` is handled;
-/// anything else resolves to an error result so an unexpected tool (e.g. one
-/// leaked from another session pre-#261, or a future tool the TUI doesn't yet
-/// implement) still resumes the turn instead of wedging it.
+/// Decide how to handle a `request_voice` call (adele-tui#75): the model is
+/// entering voice mode for the conversation. Pure — emits a `SetVoiceMode(true)`
+/// effect the handler applies to `App::voice_mode`, and always a result.
+pub fn handle_request_voice() -> ToolOutcome {
+    // STUB (tests-first): wrong effect + no result message, so the test fails.
+    ToolOutcome {
+        effect: ToolEffect::None,
+        result: Err("unimplemented".to_string()),
+    }
+}
+
+/// Decide how to handle a `stop_voice` call (adele-tui#75): the model is leaving
+/// voice mode. Pure — emits a `SetVoiceMode(false)` effect and always a result.
+pub fn handle_stop_voice() -> ToolOutcome {
+    // STUB (tests-first).
+    ToolOutcome {
+        effect: ToolEffect::None,
+        result: Err("unimplemented".to_string()),
+    }
+}
+
+/// Dispatch an arbitrary client tool call by name. `say_this`, `request_voice`,
+/// and `stop_voice` are handled; anything else resolves to an error result so an
+/// unexpected tool (e.g. one leaked from another session pre-#261, or a future
+/// tool the TUI doesn't yet implement) still resumes the turn instead of wedging
+/// it. `audio_enabled` is whether any audio control is on for the call's
+/// conversation (read-aloud OR voice-mode); it only affects `say_this`.
 pub fn dispatch(
     tool_name: &str,
     arguments: &serde_json::Value,
-    speech_enabled: bool,
+    audio_enabled: bool,
 ) -> ToolOutcome {
     match tool_name {
-        SAY_THIS => handle_say_this(arguments, speech_enabled),
+        SAY_THIS => handle_say_this(arguments, audio_enabled),
+        // STUB (tests-first): request_voice/stop_voice not yet routed.
         other => ToolOutcome {
             effect: ToolEffect::None,
             result: Err(format!("unknown client tool `{other}`")),
@@ -123,6 +170,40 @@ pub fn say_this_registration() -> desktop_assistant_api_model::ClientToolRegistr
                 }
             },
             "required": ["text"]
+        }),
+    }
+}
+
+/// The `request_voice` tool registration (adele-tui#75). Advertised on every
+/// (re)connect alongside `say_this`. Calling it switches the conversation into
+/// spoken voice mode.
+pub fn request_voice_registration() -> desktop_assistant_api_model::ClientToolRegistration {
+    desktop_assistant_api_model::ClientToolRegistration {
+        name: REQUEST_VOICE.to_string(),
+        description: "Switch this conversation into spoken voice mode (the user asked to talk by \
+            voice); replies are read aloud and kept short and conversational. Call when the user \
+            says something like \"let's talk by voice\" or \"read your replies to me\". No \
+            arguments."
+            .to_string(),
+        input_schema: serde_json::json!({
+            "type": "object",
+            "properties": {}
+        }),
+    }
+}
+
+/// The `stop_voice` tool registration (adele-tui#75). Leaves voice mode, back to
+/// text-only.
+pub fn stop_voice_registration() -> desktop_assistant_api_model::ClientToolRegistration {
+    desktop_assistant_api_model::ClientToolRegistration {
+        name: STOP_VOICE.to_string(),
+        description: "Leave voice mode; this conversation goes back to text-only (replies are no \
+            longer read aloud). Call when the user says something like \"stop talking\" or \"let's \
+            go back to text\". No arguments."
+            .to_string(),
+        input_schema: serde_json::json!({
+            "type": "object",
+            "properties": {}
         }),
     }
 }
@@ -205,5 +286,78 @@ mod tests {
         assert!(!reg.description.is_empty());
         let required = reg.input_schema.get("required").unwrap();
         assert_eq!(required, &serde_json::json!(["text"]));
+    }
+
+    // --- Voice mode (adele-tui#75) ---
+
+    #[test]
+    fn request_voice_turns_voice_mode_on_with_a_result() {
+        let outcome = handle_request_voice();
+        assert_eq!(outcome.effect, ToolEffect::SetVoiceMode(true));
+        let msg = outcome
+            .result
+            .expect("request_voice always returns a result");
+        assert!(msg.contains("voice mode on"));
+    }
+
+    #[test]
+    fn stop_voice_turns_voice_mode_off_with_a_result() {
+        let outcome = handle_stop_voice();
+        assert_eq!(outcome.effect, ToolEffect::SetVoiceMode(false));
+        let msg = outcome.result.expect("stop_voice always returns a result");
+        assert!(msg.contains("voice mode off"));
+    }
+
+    #[test]
+    fn dispatch_routes_request_voice() {
+        // request_voice ignores its arguments and the audio gate; it just flips
+        // voice mode on. Pass an empty object and audio OFF to prove that.
+        let outcome = dispatch(REQUEST_VOICE, &serde_json::json!({}), false);
+        assert_eq!(outcome.effect, ToolEffect::SetVoiceMode(true));
+        assert!(outcome.result.is_ok());
+    }
+
+    #[test]
+    fn dispatch_routes_stop_voice() {
+        let outcome = dispatch(STOP_VOICE, &serde_json::json!({}), true);
+        assert_eq!(outcome.effect, ToolEffect::SetVoiceMode(false));
+        assert!(outcome.result.is_ok());
+    }
+
+    #[test]
+    fn request_voice_with_malformed_args_still_returns_a_result_no_panic() {
+        // The model shouldn't send args, but a non-object payload must not
+        // panic — request_voice ignores arguments entirely.
+        let outcome = dispatch(REQUEST_VOICE, &serde_json::Value::Null, false);
+        assert_eq!(outcome.effect, ToolEffect::SetVoiceMode(true));
+        assert!(outcome.result.is_ok());
+    }
+
+    #[test]
+    fn say_this_speaks_when_audio_enabled_via_voice_mode() {
+        // Phase-2: the say_this audio gate is (read-aloud OR voice-mode). The
+        // caller passes the OR'd value; here it is on (e.g. via voice-mode).
+        let outcome = handle_say_this(&args("aside"), true);
+        assert_eq!(outcome.effect, ToolEffect::Speak("aside".to_string()));
+    }
+
+    #[test]
+    fn say_this_shows_inline_when_no_audio_control_is_on() {
+        let outcome = handle_say_this(&args("aside"), false);
+        assert_eq!(
+            outcome.effect,
+            ToolEffect::ShowDisabled("aside".to_string())
+        );
+        assert!(outcome.result.is_ok());
+    }
+
+    #[test]
+    fn voice_registrations_have_names_and_descriptions() {
+        let req = request_voice_registration();
+        assert_eq!(req.name, REQUEST_VOICE);
+        assert!(!req.description.is_empty());
+        let stop = stop_voice_registration();
+        assert_eq!(stop.name, STOP_VOICE);
+        assert!(!stop.description.is_empty());
     }
 }

--- a/src/client_tools.rs
+++ b/src/client_tools.rs
@@ -115,20 +115,22 @@ pub fn handle_say_this(arguments: &serde_json::Value, audio_enabled: bool) -> To
 /// entering voice mode for the conversation. Pure — emits a `SetVoiceMode(true)`
 /// effect the handler applies to `App::voice_mode`, and always a result.
 pub fn handle_request_voice() -> ToolOutcome {
-    // STUB (tests-first): wrong effect + no result message, so the test fails.
     ToolOutcome {
-        effect: ToolEffect::None,
-        result: Err("unimplemented".to_string()),
+        effect: ToolEffect::SetVoiceMode(true),
+        result: Ok(
+            "voice mode on: this conversation is now spoken — replies will be read aloud and \
+             kept brief and conversational"
+                .to_string(),
+        ),
     }
 }
 
 /// Decide how to handle a `stop_voice` call (adele-tui#75): the model is leaving
 /// voice mode. Pure — emits a `SetVoiceMode(false)` effect and always a result.
 pub fn handle_stop_voice() -> ToolOutcome {
-    // STUB (tests-first).
     ToolOutcome {
-        effect: ToolEffect::None,
-        result: Err("unimplemented".to_string()),
+        effect: ToolEffect::SetVoiceMode(false),
+        result: Ok("voice mode off: this conversation is back to text-only".to_string()),
     }
 }
 
@@ -145,7 +147,8 @@ pub fn dispatch(
 ) -> ToolOutcome {
     match tool_name {
         SAY_THIS => handle_say_this(arguments, audio_enabled),
-        // STUB (tests-first): request_voice/stop_voice not yet routed.
+        REQUEST_VOICE => handle_request_voice(),
+        STOP_VOICE => handle_stop_voice(),
         other => ToolOutcome {
             effect: ToolEffect::None,
             result: Err(format!("unknown client tool `{other}`")),

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -127,7 +127,9 @@ pub fn handle_key_event(
             // Ctrl+S toggles per-conversation read-aloud (adele-tui#73). A
             // no-op status hint when no conversation is open; main.rs gates.
             KeyCode::Char('s') => Some(Action::ToggleSpeech),
-            // STUB (tests-first): Ctrl+V not yet mapped to ToggleVoiceMode.
+            // Ctrl+V toggles per-conversation voice mode (adele-tui#75). Like
+            // Ctrl+S it is delivered as a real key by the enhancement flags.
+            KeyCode::Char('v') => Some(Action::ToggleVoiceMode),
             _ => None,
         };
     }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -51,13 +51,22 @@ pub enum Action {
     /// ("Go, voice") — free across modes and not intercepted by terminals or
     /// the textarea. No-op unless voice is in `embedded` mode (adele-tui#67).
     Dictate,
-    /// Toggle the per-conversation "speech enabled" hard switch (adele-tui#73).
-    /// Bound to `Ctrl+S` ("Speech"). The keyboard-enhancement flags pushed at
-    /// startup deliver Ctrl+S as a real key event (not terminal XOFF flow
-    /// control). When ON the assistant's replies are spoken aloud and the
-    /// daemon's `say_this` client tool speaks; when OFF nothing is ever
-    /// played. Defaults OFF per conversation (seeded from `play_replies`).
+    /// Toggle the per-conversation "read aloud" accessibility switch
+    /// (adele-tui#73, reframed in #75). Bound to `Ctrl+S` ("Speech"). The
+    /// keyboard-enhancement flags pushed at startup deliver Ctrl+S as a real
+    /// key event (not terminal XOFF flow control). When ON every assistant
+    /// reply is read aloud and the daemon's `say_this` client tool speaks; it is
+    /// LLM-unaware (the model isn't told). Independent of voice mode — either
+    /// one being ON narrates replies. Defaults OFF per conversation (seeded from
+    /// `play_replies`).
     ToggleSpeech,
+    /// Toggle the per-conversation soft-sticky **voice mode** (adele-tui#75).
+    /// Bound to `Ctrl+V` ("Voice"), delivered as a real key event by the same
+    /// keyboard-enhancement flags. When ON, replies are read aloud (like
+    /// read-aloud) AND a concise spoken-style `system_refinement` shapes each
+    /// send so replies are brief and conversational. Also entered/left by the
+    /// model via the `request_voice` / `stop_voice` client tools. Defaults OFF.
+    ToggleVoiceMode,
 }
 
 /// Handle key events that we intercept before passing to textarea.
@@ -115,9 +124,10 @@ pub fn handle_key_event(
             // Ctrl+G starts embedded dictation (mic → prompt). A no-op when
             // voice isn't in embedded mode; main.rs gates on the session.
             KeyCode::Char('g') => Some(Action::Dictate),
-            // Ctrl+S toggles per-conversation speech (adele-tui#73). A no-op
-            // status hint when no conversation is open; main.rs gates on it.
+            // Ctrl+S toggles per-conversation read-aloud (adele-tui#73). A
+            // no-op status hint when no conversation is open; main.rs gates.
             KeyCode::Char('s') => Some(Action::ToggleSpeech),
+            // STUB (tests-first): Ctrl+V not yet mapped to ToggleVoiceMode.
             _ => None,
         };
     }
@@ -859,6 +869,48 @@ mod tests {
         assert_eq!(
             handle_key_event(
                 key_with_mod(KeyCode::Char('g'), KeyModifiers::CONTROL),
+                &InputMode::Renaming,
+                false
+            ),
+            None
+        );
+    }
+
+    // --- Ctrl+V toggles per-conversation voice mode (adele-tui#75) ---
+
+    #[test]
+    fn ctrl_v_toggles_voice_mode_in_normal() {
+        assert_eq!(
+            handle_key_event(
+                key_with_mod(KeyCode::Char('v'), KeyModifiers::CONTROL),
+                &InputMode::Normal,
+                false
+            ),
+            Some(Action::ToggleVoiceMode)
+        );
+    }
+
+    #[test]
+    fn ctrl_v_toggles_voice_mode_in_editing() {
+        // Voice mode is a per-conversation control the user will flip while
+        // composing, so it must be reachable from editing mode too.
+        assert_eq!(
+            handle_key_event(
+                key_with_mod(KeyCode::Char('v'), KeyModifiers::CONTROL),
+                &InputMode::Editing,
+                false
+            ),
+            Some(Action::ToggleVoiceMode)
+        );
+    }
+
+    #[test]
+    fn ctrl_v_is_not_intercepted_in_renaming() {
+        // Renaming forwards all Ctrl combos to the rename textarea; the voice
+        // toggle must not hijack them mid-rename.
+        assert_eq!(
+            handle_key_event(
+                key_with_mod(KeyCode::Char('v'), KeyModifiers::CONTROL),
                 &InputMode::Renaming,
                 false
             ),

--- a/src/main.rs
+++ b/src/main.rs
@@ -209,6 +209,17 @@ enum ReconnectState {
 const RECONNECT_INITIAL_SECS: u64 = 2;
 const RECONNECT_MAX_SECS: u64 = 30;
 
+/// Per-turn system-prompt refinement sent while a conversation is in voice mode
+/// (adele-tui#75). It shapes the reply for the ear without touching the visible
+/// transcript or later turns. A deliberately concise echo of the voice daemon's
+/// `spoken_response_hint` essence — NOT a copy of its full paragraph.
+const VOICE_SYSTEM_REFINEMENT: &str = "This reply will be read aloud, so write it to be heard, \
+    not read. Keep it brief and conversational — a few short sentences — and lead with the answer. \
+    Use no markdown or formatting of any kind (no asterisks, backticks, bullets, or emoji); write \
+    plain spoken prose. Spell out symbols, abbreviations, and acronyms as words (say \"and\" not \
+    \"&\", \"percent\" not \"%\", \"for example\" not \"e.g.\"), and don't read out URLs, file \
+    paths, or email addresses — describe them instead.";
+
 fn next_backoff(prev_secs: u64) -> u64 {
     prev_secs.saturating_mul(2).min(RECONNECT_MAX_SECS)
 }
@@ -498,14 +509,13 @@ async fn run(
                     SignalEvent::Complete { request_id, full_response } => {
                         app.complete_streaming(&request_id, &full_response);
                         // Speak the reply aloud (embedded TTS, no daemon) only
-                        // when the OPEN conversation's per-conversation speech
-                        // toggle is ON (adele-tui#73) — the hard cut-off. The
-                        // completing reply streams into the open conversation,
-                        // so that toggle is the right gate. Fire-and-forget on a
-                        // task so synth+playback never blocks the UI; `Speaker`
-                        // is cheap to clone.
+                        // when the OPEN conversation has audio on — read-aloud OR
+                        // voice mode (adele-tui#73/#75). The completing reply
+                        // streams into the open conversation, so that gate is
+                        // right. Fire-and-forget on a task so synth+playback
+                        // never blocks the UI; `Speaker` is cheap to clone.
                         if let Some(session) = voice_session.as_ref()
-                            && app.current_speech_enabled()
+                            && app.current_audio_enabled()
                             && !full_response.trim().is_empty()
                         {
                             let speaker = session.speaker();
@@ -747,14 +757,30 @@ async fn handle_action(app: &mut App, connector: &Option<Connector>, action: Act
         Action::ToggleSpeech => match app.toggle_current_speech() {
             Some(true) => {
                 app.status_message =
-                    "Speech ON for this conversation (replies + say_this spoken aloud)".into();
+                    "Read aloud ON for this conversation (replies read aloud) — Ctrl+S to stop"
+                        .into();
             }
             Some(false) => {
-                app.status_message = "Speech OFF for this conversation".into();
+                app.status_message = "Read aloud OFF for this conversation".into();
             }
             None => {
                 app.status_message =
-                    "Open a conversation first — speech is per-conversation".into();
+                    "Open a conversation first — read aloud is per-conversation".into();
+            }
+        },
+        Action::ToggleVoiceMode => match app.toggle_current_voice_mode() {
+            Some(true) => {
+                app.status_message =
+                    "Voice mode ON for this conversation (replies read aloud + kept conversational) \
+                     — Ctrl+V to stop"
+                        .into();
+            }
+            Some(false) => {
+                app.status_message = "Voice mode OFF for this conversation".into();
+            }
+            None => {
+                app.status_message =
+                    "Open a conversation first — voice mode is per-conversation".into();
             }
         },
         Action::InsertNewline => {
@@ -948,10 +974,11 @@ async fn handle_client_tool_call(
     voice_session: &Option<VoiceSession>,
     call: client_tools::ClientToolCall,
 ) {
-    // Gate on the call's OWN conversation, not the open one, so the hard toggle
-    // is honored per conversation even if the user has since switched tabs.
-    let speech_enabled = app.speech_enabled_for(&call.conversation_id);
-    let outcome = client_tools::dispatch(&call.tool_name, &call.arguments, speech_enabled);
+    // Gate on the call's OWN conversation, not the open one, so the per-
+    // conversation controls are honored even if the user has since switched
+    // tabs. The say_this audio gate is read-aloud OR voice-mode (adele-tui#75).
+    let audio_enabled = app.audio_enabled_for(&call.conversation_id);
+    let outcome = client_tools::dispatch(&call.tool_name, &call.arguments, audio_enabled);
 
     match outcome.effect {
         client_tools::ToolEffect::Speak(text) => {
@@ -964,13 +991,19 @@ async fn handle_client_tool_call(
                     }
                 });
             } else {
-                // Speech enabled but no audio pipeline (voice off / failed to
-                // load): degrade to showing the text rather than dropping it.
+                // Audio enabled but no pipeline (voice off / failed to load):
+                // degrade to showing the text rather than dropping it.
                 app.push_speech_disabled_note(&call.conversation_id, &text);
             }
         }
         client_tools::ToolEffect::ShowDisabled(text) => {
             app.push_speech_disabled_note(&call.conversation_id, &text);
+        }
+        // request_voice / stop_voice (adele-tui#75): the model entered/left
+        // voice mode for its OWN conversation. Apply it to App state here so the
+        // pure dispatch stays free of App.
+        client_tools::ToolEffect::SetVoiceMode(on) => {
+            app.set_voice_mode(&call.conversation_id, on);
         }
         client_tools::ToolEffect::None => {}
     }
@@ -989,14 +1022,19 @@ async fn handle_client_tool_call(
     }
 }
 
-/// Advertise the TUI's `say_this` client tool to the daemon. The daemon
-/// replaces the whole set each call, so this runs on every (re)connect (#231).
-/// Best-effort: voice playback is a convenience, so a failure to register is
-/// only logged and never blocks the chat. Over D-Bus (no command channel for
-/// client tools) this is expected to fail and is silently skipped.
+/// Advertise the TUI's client tools to the daemon: `say_this` (adele-tui#73)
+/// plus `request_voice` / `stop_voice` (adele-tui#75). The daemon replaces the
+/// whole set each call, so this runs on every (re)connect (#231). Best-effort:
+/// voice playback is a convenience, so a failure to register is only logged and
+/// never blocks the chat. Over D-Bus (no command channel for client tools) this
+/// is expected to fail and is silently skipped.
 async fn register_client_tools(conn: &Connector) {
     if let Err(e) = conn
-        .register_client_tools(vec![client_tools::say_this_registration()])
+        .register_client_tools(vec![
+            client_tools::say_this_registration(),
+            client_tools::request_voice_registration(),
+            client_tools::stop_voice_registration(),
+        ])
         .await
     {
         tracing::debug!("client tool registration skipped: {e}");
@@ -1083,23 +1121,38 @@ async fn send_prompt_from_input(app: &mut App, connector: &Option<Connector>) {
     {
         let client = connector.client();
         let override_selection = app.take_pending_override();
-        // Use the command-channel override path when one was staged via the
-        // model picker; the high-level `send_prompt` only takes the bare prompt.
-        // `as_commands()` is `Some` on both socket transports (UDS + WS) but
-        // `None` on D-Bus, which has no override field — there we fall back to a
-        // plain send and warn.
+        // In voice mode (adele-tui#75) carry a concise read-aloud system
+        // refinement so the reply is shaped for speech. It only refines the
+        // system prompt for THIS turn — never stored, never in the transcript.
+        let refinement = if app.voice_mode_for(&conv_id) {
+            VOICE_SYSTEM_REFINEMENT
+        } else {
+            ""
+        };
+        // Use the command-channel `send_prompt_full` when a model override is
+        // staged (model picker) and/or a refinement applies; the high-level
+        // `send_prompt` carries neither. `as_commands()` is `Some` on both
+        // socket transports (UDS + WS) but `None` on D-Bus. The Connector's
+        // refinement helper already folds the refinement into the prompt over
+        // D-Bus, so the no-override voice-mode path works everywhere.
         let result = match (override_selection, client.as_commands()) {
             (Some(ovr), Some(commands)) => {
                 commands
-                    .send_prompt_with_override(&conv_id, &prompt, Some(ovr))
+                    .send_prompt_full(&conv_id, &prompt, Some(ovr), refinement.to_string())
                     .await
             }
             (Some(_), None) => {
                 app.status_message =
                     "Model override isn't supported over D-Bus — sent without override".into();
-                client.send_prompt(&conv_id, &prompt).await
+                connector
+                    .send_prompt_with_system_refinement(&conv_id, &prompt, refinement)
+                    .await
             }
-            (None, _) => client.send_prompt(&conv_id, &prompt).await,
+            (None, _) => {
+                connector
+                    .send_prompt_with_system_refinement(&conv_id, &prompt, refinement)
+                    .await
+            }
         };
         match result {
             Ok(task_id) => app.apply_prompt_ack(task_id),

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -380,8 +380,11 @@ fn draw_messages(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
     // glyph so it reads differently from read-aloud's speaker glyph; shown only
     // when ON. Voice mode also narrates, but it adds spoken-style shaping, so it
     // is surfaced separately even when read-aloud is also on.
-    // STUB (tests-first): voice-mode cue not yet rendered.
-    let voice_suffix = "";
+    let voice_suffix = if app.current_voice_mode() {
+        "  ·  🎙 voice mode (Ctrl+V)"
+    } else {
+        ""
+    };
     let title = if app.scroll_offset > 0 {
         format!(
             "{chat_title}{model_suffix}{speech_suffix}{voice_suffix} \

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -368,18 +368,27 @@ fn draw_messages(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
         .and_then(|conv| conv.model_selection.as_ref())
         .map(|sel| format!("  ·  {} · {}", sel.connection_id, sel.model_id))
         .unwrap_or_default();
-    // Persistent cue for the per-conversation speech toggle (adele-tui#73), so
-    // the user can always tell whether replies/say_this will be spoken. Only
+    // Persistent cue for the per-conversation read-aloud toggle (adele-tui#73),
+    // so the user can always tell whether replies/say_this will be spoken. Only
     // shown when ON; OFF (the common default) stays uncluttered.
     let speech_suffix = if app.current_speech_enabled() {
-        "  ·  🔊 speech (Ctrl+S)"
+        "  ·  🔊 read aloud (Ctrl+S)"
     } else {
         ""
     };
+    // Persistent cue for soft-sticky voice mode (adele-tui#75). A distinct mic
+    // glyph so it reads differently from read-aloud's speaker glyph; shown only
+    // when ON. Voice mode also narrates, but it adds spoken-style shaping, so it
+    // is surfaced separately even when read-aloud is also on.
+    // STUB (tests-first): voice-mode cue not yet rendered.
+    let voice_suffix = "";
     let title = if app.scroll_offset > 0 {
-        format!("{chat_title}{model_suffix}{speech_suffix} (Ctrl+u/d scroll, Ctrl+e bottom)")
+        format!(
+            "{chat_title}{model_suffix}{speech_suffix}{voice_suffix} \
+             (Ctrl+u/d scroll, Ctrl+e bottom)"
+        )
     } else {
-        format!("{chat_title}{model_suffix}{speech_suffix}")
+        format!("{chat_title}{model_suffix}{speech_suffix}{voice_suffix}")
     };
 
     let block = Block::default()
@@ -548,7 +557,7 @@ mod tests {
             .collect();
         assert!(!dump.contains("speech"));
 
-        // ON: the cue appears.
+        // ON: the cue appears (reframed to "read aloud" in #75).
         assert_eq!(app.toggle_current_speech(), Some(true));
         terminal.draw(|f| draw(f, &mut app)).unwrap();
         let dump: String = terminal
@@ -558,7 +567,47 @@ mod tests {
             .iter()
             .map(|c| c.symbol())
             .collect();
-        assert!(dump.contains("speech"));
+        assert!(dump.contains("read aloud"));
+    }
+
+    #[test]
+    fn draw_shows_voice_mode_cue_only_when_enabled() {
+        // The persistent voice-mode indicator (adele-tui#75) appears in the
+        // chat title only while the open conversation's voice mode is ON, and
+        // is distinct from the read-aloud cue.
+        let backend = TestBackend::new(100, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut app = App::new();
+        app.current_conversation = Some(ConversationDetail {
+            id: "c1".into(),
+            title: "ChatProbe".into(),
+            messages: vec![],
+            model_selection: None,
+            conversation_personality: None,
+        });
+
+        // OFF (default): no "voice mode" cue in the title.
+        terminal.draw(|f| draw(f, &mut app)).unwrap();
+        let dump: String = terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .map(|c| c.symbol())
+            .collect();
+        assert!(!dump.contains("voice mode"));
+
+        // ON: the cue appears.
+        assert_eq!(app.toggle_current_voice_mode(), Some(true));
+        terminal.draw(|f| draw(f, &mut app)).unwrap();
+        let dump: String = terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .map(|c| c.symbol())
+            .collect();
+        assert!(dump.contains("voice mode"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #75

Phase-2 of the per-conversation voice-interaction work for the TUI, **strictly additive** to the merged phase-1 (#74). Text is always rendered in the transcript — narration is purely additive and never suppresses text. Two independent per-conversation audio controls, each its own opt-in; both off = no audio (exactly phase-1's toggle-off).

## What's in this PR

1. **Read aloud (Ctrl+S)** — the existing phase-1 per-conversation toggle, *reframed* to accessibility framing. LLM-unaware; when ON every reply is read aloud and `say_this` speaks. Behavior unchanged — only the on-screen label/status copy changed (`🔊 read aloud (Ctrl+S)`, "Read aloud ON/OFF…").

2. **Voice mode (Ctrl+V, NEW — soft-sticky, default OFF)** — entered/left by the user (Ctrl+V) **or** the model (`request_voice` / `stop_voice` client tools). Sticky per conversation. When ON: (a) every reply is narrated (same routing as read-aloud), AND (b) a concise read-aloud `system_refinement` is passed on send so replies are shaped for speech. A distinct `🎙 voice mode (Ctrl+V)` chat-title cue shows when ON.

**Narration rule:** spoken iff (read-aloud ON) OR (voice-mode ON) — `App::current_audio_enabled`.
**say_this rule:** the phase-1 gate is broadened to (read-aloud OR voice-mode); otherwise the text is shown inline `(speech mode disabled) <text>` exactly as before.

### request_voice / stop_voice flow (pure dispatch → App state)
The decision stays in the pure `client_tools` module: `dispatch` routes `request_voice` → `ToolOutcome { effect: SetVoiceMode(true), result: Ok("voice mode on…") }` and `stop_voice` → `SetVoiceMode(false)`. The async `handle_client_tool_call` applies the effect to `app.set_voice_mode(&call.conversation_id, on)` — keyed to the call's **own** conversation, never the open one — and **always** submits the `ClientToolResult` (no wedge). Both are registered alongside `say_this` on every (re)connect (#231 replaces the whole set each connect; per-session via #261).

### Voice-mode send
`send_prompt_from_input` passes `VOICE_SYSTEM_REFINEMENT` when the target conversation's voice mode is on, via `send_prompt_full` (when a model override is also staged) or `Connector::send_prompt_with_system_refinement` (which folds the refinement into the prompt over D-Bus, so it works on every transport). The refinement affects only the system prompt for that turn — never stored, never in the visible transcript.

`VOICE_SYSTEM_REFINEMENT` (a concise echo of the voice daemon's `spoken_response_hint` essence, not a copy of its paragraph):

> This reply will be read aloud, so write it to be heard, not read. Keep it brief and conversational — a few short sentences — and lead with the answer. Use no markdown or formatting of any kind (no asterisks, backticks, bullets, or emoji); write plain spoken prose. Spell out symbols, abbreviations, and acronyms as words (say "and" not "&", "percent" not "%", "for example" not "e.g."), and don't read out URLs, file paths, or email addresses — describe them instead.

## Tests (TDD: failing tests committed first, then implementation)
First commit adds the specs through the pure seams with the new behavior stubbed (12 fail, phase-1 green); the second implements them. Final suite green (329 in the bin crate / 307 in the lib crate).

New named tests:
- `client_tools`: `request_voice_turns_voice_mode_on_with_a_result`, `stop_voice_turns_voice_mode_off_with_a_result`, `dispatch_routes_request_voice`, `dispatch_routes_stop_voice`, `request_voice_with_malformed_args_still_returns_a_result_no_panic`, `say_this_speaks_when_audio_enabled_via_voice_mode`, `say_this_shows_inline_when_no_audio_control_is_on`, `voice_registrations_have_names_and_descriptions`.
- `app`: `voice_mode_defaults_off`, `toggle_current_voice_mode_flips_and_returns_new_state`, `toggle_current_voice_mode_without_conversation_is_none`, `set_voice_mode_targets_an_explicit_conversation`, `voice_mode_is_per_conversation_isolated`, `audio_enabled_is_read_aloud_or_voice_mode`, `current_audio_enabled_is_false_without_a_conversation`.
- `keys`: `ctrl_v_toggles_voice_mode_in_normal`, `ctrl_v_toggles_voice_mode_in_editing`, `ctrl_v_is_not_intercepted_in_renaming`.
- `ui`: `draw_shows_voice_mode_cue_only_when_enabled` (+ `draw_shows_speech_cue_only_when_enabled` updated to the reframed copy).

## Quality gates
- `cargo build`, `cargo test`, `cargo clippy --all-targets -- -D warnings`: clean. No broad `#[allow]`.
- `rustfmt --edition 2024 --check` clean on all changed files; `just check` passes. Pushed **without** `--no-verify`.

## Security self-review
Adversarial read of the diff: `request_voice`/`stop_voice` ignore their arguments and never touch the JSON, so a non-object/`null` payload cannot panic; `say_this` keeps its non-panicking arg parsing. No audio plays while both controls are OFF for the call's/open conversation (narration gates on `current_audio_enabled`; `say_this` gates on `audio_enabled_for(call.conversation_id)`). No cross-conversation bleed: voice mode is keyed per conversation, the model tools mutate the call's **own** conversation, and the inline note still only appends to the open conversation. A `ClientToolResult` is always submitted so a turn can never wedge. The refinement only refines the per-turn system prompt — it never enters the visible transcript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)