### PR TITLE
Mirror gtk#80: You/Adele voice controls (Disabled/On Demand/Always) in the TUI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,6 +6,7 @@ version = 4
 name = "adele"
 version = "0.1.0"
 dependencies = [
+ "adele-voice-core",
  "adele-voice-module",
  "adele-voice-stt-whisper",
  "adele-voice-vad-silero",
@@ -30,6 +31,7 @@ dependencies = [
  "toml",
  "tracing",
  "url",
+ "zbus",
  "zbus-secret-service-keyring-store",
 ]
 
@@ -41,6 +43,7 @@ dependencies = [
  "anyhow",
  "cpal",
  "ringbuf",
+ "rubato",
  "tokio",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,11 @@ rustls = { version = "0.23", default-features = false, features = ["ring"] }
 url = "2"
 toml = "0.9"
 tracing = "0.1"
+# Direct zbus client for the standalone voice daemon (`org.desktopAssistant.Voice`),
+# a separate D-Bus service from the orchestrator transport. Used by
+# `voice_client::VoiceController` to route narration through the daemon's warm
+# `SayText`, mirroring adele-gtk#80's `voice_client.rs`. Matches gtk's pin.
+zbus = { version = "5", default-features = false, features = ["tokio"] }
 # Shared protocol + transport crates live in the desktop-assistant repo.
 # Cargo resolves the package by name from that workspace; Cargo.lock pins
 # the exact revision for reproducibility.
@@ -44,6 +49,13 @@ desktop-assistant-api-model = { git = "https://github.com/adelie-ai/desktop-assi
 # transitive deps from the voice workspace automatically.
 [dependencies.adele-voice-module]
 path = "../voice/crates/module"
+
+# Shared voice domain crate: its `SentenceBuffer` carries the sentence-chunking
+# algorithm so a long reply is spoken one short sentence at a time (each synth is
+# one-shot with a ~20s timeout). Used by `voice::into_speakable_sentences`,
+# mirroring adele-gtk#80's `voice_embedded::into_speakable_sentences`.
+[dependencies.adele-voice-core]
+path = "../voice/crates/core"
 
 [dependencies.adele-voice-vad-silero]
 path = "../voice/crates/vad-silero"

--- a/src/app.rs
+++ b/src/app.rs
@@ -70,6 +70,46 @@ pub enum InputMode {
     Renaming,
 }
 
+/// The `Adele:` voice-output level for a conversation (adele-tui#77, mirroring
+/// adele-gtk#80's `AdeleOutput`). Decides reply narration (with `You`), the
+/// `say_this` aside gate, and the send-time `system_refinement`. Defaults to
+/// [`AdeleOutput::Disabled`].
+///
+/// * `Disabled` — never speaks; a `say_this` aside downgrades to inline text.
+/// * `OnDemand` — speaks replies only while `You == Enabled` (shaped for the ear,
+///   brief and conversational) and always speaks `say_this` asides. Selected by
+///   the model's `request_voice`.
+/// * `Always` — reads every reply aloud, in full but made speakable (not
+///   shortened).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AdeleOutput {
+    /// Never speaks (the default). `say_this` → inline note.
+    #[default]
+    Disabled,
+    /// Speaks replies when `You == Enabled`; always speaks `say_this` asides.
+    OnDemand,
+    /// Reads every reply aloud, in full, made speakable.
+    Always,
+}
+
+impl AdeleOutput {
+    /// The next level when the user cycles the control
+    /// (`Disabled → OnDemand → Always → Disabled`).
+    pub fn next(self) -> Self {
+        // STUB (failing-tests commit): cycle not yet implemented.
+        Self::Disabled
+    }
+
+    /// Short label for the status line / chat title cue.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Disabled => "Disabled",
+            Self::OnDemand => "On Demand",
+            Self::Always => "Always",
+        }
+    }
+}
+
 pub struct App {
     pub conversations: Vec<ConversationSummary>,
     pub selected_conversation: Option<usize>,
@@ -130,25 +170,21 @@ pub struct App {
     /// actually closes the loop; this is purely so the status bar can
     /// say "cancelling t-1..." while we wait.
     pub pending_task_cancel: Option<TaskId>,
-    /// Per-conversation "speech enabled" hard toggle (adele-tui#73). Keyed by
-    /// conversation id; a conversation absent from the map uses
-    /// `speech_default`. This is the master cut-off: when a conversation's
-    /// flag is `false` nothing is ever spoken — not reply narration, not the
-    /// daemon's `say_this` client tool. Toggled in-app with `Ctrl+S`.
-    speech_enabled: HashMap<String, bool>,
-    /// Default speech state for a conversation not yet in `speech_enabled`.
-    /// Seeded from `voice.toml`'s `play_replies` so existing
-    /// `play_replies = true` users keep audio, but it is now per-conversation
-    /// and toggleable. Defaults `false` (off) when voice is unconfigured.
-    speech_default: bool,
-    /// Per-conversation soft-sticky **voice mode** (adele-tui#75), keyed by
-    /// conversation id. Independent of `speech_enabled` (read-aloud): either one
-    /// being ON narrates replies. Entered/left by the user (`Ctrl+V`) or by the
-    /// model (`request_voice` / `stop_voice`). When ON, sends also carry a
-    /// concise read-aloud `system_refinement` so replies are shaped for speech.
-    /// A conversation absent from the map is OFF (the default). No `*_default`
-    /// seed: voice mode is always entered explicitly, never config-seeded.
-    voice_mode: HashMap<String, bool>,
+    /// Per-conversation `You:` (voice input) state (adele-tui#77, mirroring
+    /// adele-gtk#80). Keyed by conversation id; a conversation absent from the
+    /// map is **Disabled** (type only). When `true` (Enabled), a push-to-talk
+    /// control is available and — combined with `Adele == OnDemand` — gates
+    /// reply narration. Toggled in-app with `Ctrl+V`. Per-conversation, so
+    /// enabling it in one conversation never affects another.
+    voice_in: HashMap<String, bool>,
+    /// Per-conversation `Adele:` (voice output) level (adele-tui#77, mirroring
+    /// adele-gtk#80). Keyed by conversation id; a conversation absent from the
+    /// map is `Disabled` (never speaks). Set by the user (`Ctrl+S` cycles it) or
+    /// the model (`request_voice` → OnDemand, `stop_voice` → Disabled). Decides
+    /// reply narration (with `You`), the `say_this` aside gate, and the send-time
+    /// `system_refinement`. Replaces phase-1/2's `speech_enabled` (read-aloud ==
+    /// Always) and `voice_mode` (== OnDemand) toggles.
+    adele_output: HashMap<String, AdeleOutput>,
 }
 
 impl App {
@@ -181,53 +217,110 @@ impl App {
             pending_model_override: None,
             tasks: TaskPane::new(),
             pending_task_cancel: None,
-            speech_enabled: HashMap::new(),
-            speech_default: false,
-            voice_mode: HashMap::new(),
+            voice_in: HashMap::new(),
+            adele_output: HashMap::new(),
         }
     }
 
-    // --- Per-conversation speech toggle (adele-tui#73) ---
+    // --- Per-conversation You/Adele voice controls (adele-tui#77) ---
+    //
+    // Two independent per-conversation controls mirroring adele-gtk#80:
+    //   * `You` (voice input)  — `voice_in`: Disabled (type only) | Enabled (PTT).
+    //   * `Adele` (voice output) — `adele_output`: Disabled | OnDemand | Always.
+    // Text input is always available regardless. The narration gate, the
+    // `say_this` aside gate, and the send-time refinement all derive from these
+    // two as pure functions so they are unit-testable without a transport or
+    // audio device.
 
-    /// Seed the default speech state new conversations inherit (from
-    /// `voice.toml`'s `play_replies`). Conversations already toggled keep
-    /// their explicit state; only the implicit default changes.
-    pub fn set_speech_default(&mut self, default: bool) {
-        self.speech_default = default;
+    /// Whether `You:` (voice input) is Enabled for `conversation_id`. A
+    /// conversation absent from the map is Disabled (the default).
+    pub fn voice_in_for(&self, conversation_id: &str) -> bool {
+        self.voice_in.get(conversation_id).copied().unwrap_or(false)
     }
 
-    /// Whether speech is enabled for `conversation_id`. Falls back to
-    /// `speech_default` for a conversation the user hasn't toggled.
-    pub fn speech_enabled_for(&self, conversation_id: &str) -> bool {
-        self.speech_enabled
-            .get(conversation_id)
-            .copied()
-            .unwrap_or(self.speech_default)
-    }
-
-    /// Whether speech is enabled for the currently-open conversation. `false`
-    /// when no conversation is open (nothing to speak into).
-    pub fn current_speech_enabled(&self) -> bool {
+    /// Whether `You:` is Enabled for the currently-open conversation. `false`
+    /// when no conversation is open.
+    pub fn current_voice_in(&self) -> bool {
         self.current_conversation
             .as_ref()
-            .is_some_and(|c| self.speech_enabled_for(&c.id))
+            .is_some_and(|c| self.voice_in_for(&c.id))
     }
 
-    /// Flip the speech toggle for the currently-open conversation and return
-    /// the new state. `None` when no conversation is open. Per-conversation:
-    /// toggling one conversation never affects another.
-    pub fn toggle_current_speech(&mut self) -> Option<bool> {
+    /// Flip `You:` for the currently-open conversation and return the new state
+    /// (used by the `Ctrl+V` keybind). `None` when no conversation is open.
+    pub fn toggle_current_voice_in(&mut self) -> Option<bool> {
         let conv_id = self.current_conversation.as_ref()?.id.clone();
-        let next = !self.speech_enabled_for(&conv_id);
-        self.speech_enabled.insert(conv_id, next);
+        let next = !self.voice_in_for(&conv_id);
+        self.voice_in.insert(conv_id, next);
         Some(next)
     }
 
-    /// Render a `say_this` call that arrived while speech was OFF as an inline
-    /// note in the transcript instead of speaking it (adele-tui#73). Appended
-    /// to `conversation_id` only when that is the open conversation, so a call
-    /// from a stale/other conversation never bleeds into the visible chat.
-    /// Returns whether the note was shown.
+    /// The `Adele:` (voice output) level for `conversation_id`. `Disabled` when
+    /// the conversation was never set (the default).
+    pub fn adele_output_for(&self, conversation_id: &str) -> AdeleOutput {
+        self.adele_output
+            .get(conversation_id)
+            .copied()
+            .unwrap_or_default()
+    }
+
+    /// The `Adele:` level for the currently-open conversation. `Disabled` when
+    /// no conversation is open.
+    pub fn current_adele_output(&self) -> AdeleOutput {
+        self.current_conversation
+            .as_ref()
+            .map(|c| self.adele_output_for(&c.id))
+            .unwrap_or_default()
+    }
+
+    /// Set `Adele:` for an explicit `conversation_id` (used by the model's
+    /// `request_voice` → OnDemand / `stop_voice` → Disabled tools, which carry
+    /// their own conversation). Per-conversation: only the named conversation is
+    /// affected.
+    pub fn set_adele_output(&mut self, conversation_id: &str, level: AdeleOutput) {
+        self.adele_output.insert(conversation_id.to_string(), level);
+    }
+
+    /// Cycle `Adele:` for the currently-open conversation
+    /// (`Disabled → OnDemand → Always → Disabled`) and return the new level
+    /// (used by the `Ctrl+S` keybind). `None` when no conversation is open.
+    pub fn cycle_current_adele_output(&mut self) -> Option<AdeleOutput> {
+        let conv_id = self.current_conversation.as_ref()?.id.clone();
+        let next = self.adele_output_for(&conv_id).next();
+        self.adele_output.insert(conv_id, next);
+        Some(next)
+    }
+
+    /// Whether a *reply* is spoken for `conversation_id` (adele-tui#77, the
+    /// narration gate): `Adele == Always` OR (`Adele == OnDemand` AND
+    /// `You == Enabled`). `Disabled` never narrates.
+    pub fn narrate_for(&self, _conversation_id: &str) -> bool {
+        // STUB (failing-tests commit): narration gate not yet implemented.
+        false
+    }
+
+    /// Whether a reply is spoken for the currently-open conversation. `false`
+    /// when no conversation is open. The reply-narration gate the streaming
+    /// completion path consults.
+    pub fn current_narrate(&self) -> bool {
+        self.current_conversation
+            .as_ref()
+            .is_some_and(|c| self.narrate_for(&c.id))
+    }
+
+    /// Whether a `say_this` aside is spoken for `conversation_id` (adele-tui#77):
+    /// spoken iff `Adele ∈ {OnDemand, Always}` (independent of `You`). `Disabled`
+    /// downgrades the aside to inline text.
+    pub fn say_this_spoken_for(&self, _conversation_id: &str) -> bool {
+        // STUB (failing-tests commit): aside gate not yet implemented.
+        false
+    }
+
+    /// Render a `say_this` call whose aside is NOT spoken (Adele == Disabled) as
+    /// an inline note in the transcript instead (adele-tui#77). Appended to
+    /// `conversation_id` only when that is the open conversation, so a call from
+    /// a stale/other conversation never bleeds into the visible chat. Returns
+    /// whether the note was shown.
     pub fn push_speech_disabled_note(&mut self, conversation_id: &str, text: &str) -> bool {
         let Some(conv) = self.current_conversation.as_mut() else {
             return false;
@@ -241,59 +334,6 @@ impl App {
         });
         self.scroll_offset = 0;
         true
-    }
-
-    // --- Per-conversation voice mode (adele-tui#75) ---
-
-    /// Whether soft-sticky voice mode is on for `conversation_id`. A
-    /// conversation never entered is OFF (the default). Independent of
-    /// `speech_enabled_for` (read-aloud).
-    pub fn voice_mode_for(&self, conversation_id: &str) -> bool {
-        self.voice_mode
-            .get(conversation_id)
-            .copied()
-            .unwrap_or(false)
-    }
-
-    /// Whether voice mode is on for the currently-open conversation. `false`
-    /// when no conversation is open.
-    pub fn current_voice_mode(&self) -> bool {
-        self.current_conversation
-            .as_ref()
-            .is_some_and(|c| self.voice_mode_for(&c.id))
-    }
-
-    /// Set voice mode for an explicit `conversation_id` (used by the model's
-    /// `request_voice` / `stop_voice` tools, which carry their own
-    /// conversation). Per-conversation: only the named conversation is affected.
-    pub fn set_voice_mode(&mut self, conversation_id: &str, on: bool) {
-        self.voice_mode.insert(conversation_id.to_string(), on);
-    }
-
-    /// Flip voice mode for the currently-open conversation and return the new
-    /// state (used by the `Ctrl+V` keybind). `None` when no conversation is
-    /// open. Per-conversation: toggling one never affects another.
-    pub fn toggle_current_voice_mode(&mut self) -> Option<bool> {
-        let conv_id = self.current_conversation.as_ref()?.id.clone();
-        let next = !self.voice_mode_for(&conv_id);
-        self.voice_mode.insert(conv_id, next);
-        Some(next)
-    }
-
-    /// Whether a reply for `conversation_id` should be spoken: read-aloud OR
-    /// voice-mode (adele-tui#75). This is the single narration / `say_this`
-    /// audio gate.
-    pub fn audio_enabled_for(&self, conversation_id: &str) -> bool {
-        self.speech_enabled_for(conversation_id) || self.voice_mode_for(conversation_id)
-    }
-
-    /// Whether audio is on for the currently-open conversation (read-aloud OR
-    /// voice-mode). `false` when no conversation is open. This is the reply
-    /// narration gate for the streaming completion path.
-    pub fn current_audio_enabled(&self) -> bool {
-        self.current_conversation
-            .as_ref()
-            .is_some_and(|c| self.audio_enabled_for(&c.id))
     }
 
     // --- Tasks-pane glue ---
@@ -1513,7 +1553,7 @@ mod tests {
         assert!(id.is_none());
     }
 
-    // --- Per-conversation speech toggle (adele-tui#73) ---
+    // --- Per-conversation You/Adele voice controls (adele-tui#77) ---
 
     fn app_with_open_conversation(id: &str) -> App {
         let mut app = App::new();
@@ -1528,59 +1568,163 @@ mod tests {
     }
 
     #[test]
-    fn speech_defaults_off_when_play_replies_unset() {
-        // With no voice config (`speech_default = false`), a fresh
-        // conversation must have speech OFF — the hard cut-off default.
+    fn adele_output_next_cycles_disabled_on_demand_always() {
+        assert_eq!(AdeleOutput::Disabled.next(), AdeleOutput::OnDemand);
+        assert_eq!(AdeleOutput::OnDemand.next(), AdeleOutput::Always);
+        assert_eq!(AdeleOutput::Always.next(), AdeleOutput::Disabled);
+    }
+
+    #[test]
+    fn defaults_are_you_disabled_and_adele_disabled_silent() {
+        // The default gate must be closed: nothing is spoken, asides go inline.
         let app = app_with_open_conversation("c1");
-        assert!(!app.current_speech_enabled());
-        assert!(!app.speech_enabled_for("c1"));
+        assert!(!app.current_voice_in(), "You defaults Disabled");
+        assert_eq!(
+            app.current_adele_output(),
+            AdeleOutput::Disabled,
+            "Adele defaults Disabled"
+        );
+        assert!(
+            !app.current_narrate(),
+            "default gate is closed (no narration)"
+        );
+        assert!(
+            !app.say_this_spoken_for("c1"),
+            "default say_this is not spoken (Disabled)"
+        );
+        assert!(!app.narrate_for("never-seen"));
     }
 
     #[test]
-    fn speech_default_seeds_untoggled_conversations() {
-        // `play_replies = true` seeds the per-conversation default ON so
-        // existing users keep audio — but it is now per-conversation.
+    fn toggle_current_voice_in_flips_and_returns_new_state() {
         let mut app = app_with_open_conversation("c1");
-        app.set_speech_default(true);
-        assert!(app.current_speech_enabled());
-        assert!(app.speech_enabled_for("c1"));
-        assert!(app.speech_enabled_for("never-opened"));
+        assert_eq!(app.toggle_current_voice_in(), Some(true));
+        assert!(app.current_voice_in());
+        assert_eq!(app.toggle_current_voice_in(), Some(false));
+        assert!(!app.current_voice_in());
     }
 
     #[test]
-    fn toggle_current_speech_flips_and_returns_new_state() {
-        let mut app = app_with_open_conversation("c1");
-        assert_eq!(app.toggle_current_speech(), Some(true));
-        assert!(app.current_speech_enabled());
-        assert_eq!(app.toggle_current_speech(), Some(false));
-        assert!(!app.current_speech_enabled());
-    }
-
-    #[test]
-    fn toggle_current_speech_without_conversation_is_none() {
+    fn toggle_current_voice_in_without_conversation_is_none() {
         let mut app = App::new();
-        assert_eq!(app.toggle_current_speech(), None);
-        assert!(!app.current_speech_enabled());
+        assert_eq!(app.toggle_current_voice_in(), None);
+        assert!(!app.current_voice_in());
     }
 
     #[test]
-    fn speech_toggle_is_per_conversation_isolated() {
-        // Enabling speech in one conversation must NOT bleed into another.
+    fn cycle_current_adele_output_advances_and_returns_new_level() {
         let mut app = app_with_open_conversation("c1");
-        assert_eq!(app.toggle_current_speech(), Some(true)); // c1 ON
-        assert!(app.speech_enabled_for("c1"));
-        assert!(!app.speech_enabled_for("c2")); // c2 untouched → default OFF
+        assert_eq!(
+            app.cycle_current_adele_output(),
+            Some(AdeleOutput::OnDemand)
+        );
+        assert_eq!(app.current_adele_output(), AdeleOutput::OnDemand);
+        assert_eq!(app.cycle_current_adele_output(), Some(AdeleOutput::Always));
+        assert_eq!(
+            app.cycle_current_adele_output(),
+            Some(AdeleOutput::Disabled)
+        );
     }
 
     #[test]
-    fn speech_toggle_overrides_the_default_per_conversation() {
-        // With default ON, an explicit toggle to OFF for one conversation
-        // sticks for that conversation only.
+    fn cycle_current_adele_output_without_conversation_is_none() {
+        let mut app = App::new();
+        assert_eq!(app.cycle_current_adele_output(), None);
+        assert_eq!(app.current_adele_output(), AdeleOutput::Disabled);
+    }
+
+    #[test]
+    fn adele_always_narrates_regardless_of_you() {
+        // Always reads every reply aloud whether or not You is Enabled.
+        for you in [false, true] {
+            let mut app = app_with_open_conversation("c1");
+            app.voice_in.insert("c1".to_string(), you);
+            app.set_adele_output("c1", AdeleOutput::Always);
+            assert!(app.current_narrate(), "Always must narrate (You={you})");
+            assert!(
+                app.say_this_spoken_for("c1"),
+                "Always always speaks say_this (You={you})"
+            );
+        }
+    }
+
+    #[test]
+    fn adele_on_demand_narrates_only_when_you_enabled() {
+        // The gate's OnDemand arm: spoken iff You == Enabled.
         let mut app = app_with_open_conversation("c1");
-        app.set_speech_default(true);
-        assert_eq!(app.toggle_current_speech(), Some(false)); // c1 explicitly OFF
-        assert!(!app.speech_enabled_for("c1"));
-        assert!(app.speech_enabled_for("c2")); // others still follow default ON
+        app.set_adele_output("c1", AdeleOutput::OnDemand);
+
+        // You Disabled → reply text-only, but say_this aside still spoken.
+        app.voice_in.insert("c1".to_string(), false);
+        assert!(
+            !app.current_narrate(),
+            "OnDemand + You=Disabled: no narration"
+        );
+        assert!(
+            app.say_this_spoken_for("c1"),
+            "OnDemand say_this aside spoken even when You=Disabled"
+        );
+
+        // You Enabled → reply narrated.
+        app.voice_in.insert("c1".to_string(), true);
+        assert!(app.current_narrate(), "OnDemand + You=Enabled narrates");
+        assert!(app.say_this_spoken_for("c1"));
+    }
+
+    #[test]
+    fn adele_disabled_never_narrates_and_say_this_goes_inline() {
+        let mut app = app_with_open_conversation("c1");
+        app.set_adele_output("c1", AdeleOutput::Disabled);
+        for you in [false, true] {
+            app.voice_in.insert("c1".to_string(), you);
+            assert!(
+                !app.current_narrate(),
+                "Disabled never narrates (You={you})"
+            );
+            assert!(
+                !app.say_this_spoken_for("c1"),
+                "Disabled never speaks say_this (You={you})"
+            );
+        }
+    }
+
+    #[test]
+    fn set_voice_in_targets_an_explicit_conversation() {
+        // The model's tools / the streaming path carry their own conversation id.
+        let mut app = app_with_open_conversation("c1");
+        app.voice_in.insert("c2".to_string(), true);
+        assert!(app.voice_in_for("c2"));
+        assert!(!app.voice_in_for("c1")); // open conversation untouched
+    }
+
+    #[test]
+    fn set_adele_output_targets_an_explicit_conversation() {
+        let mut app = app_with_open_conversation("c1");
+        app.set_adele_output("c2", AdeleOutput::OnDemand);
+        assert_eq!(app.adele_output_for("c2"), AdeleOutput::OnDemand);
+        assert_eq!(app.adele_output_for("c1"), AdeleOutput::Disabled);
+    }
+
+    #[test]
+    fn voice_controls_are_per_conversation_isolated() {
+        // Enabling You / raising Adele in one conversation must NOT bleed.
+        let mut app = app_with_open_conversation("c1");
+        assert_eq!(app.toggle_current_voice_in(), Some(true)); // c1 You ON
+        app.set_adele_output("c1", AdeleOutput::Always);
+        assert!(app.voice_in_for("c1"));
+        assert_eq!(app.adele_output_for("c1"), AdeleOutput::Always);
+        // c2 untouched → both defaults.
+        assert!(!app.voice_in_for("c2"));
+        assert_eq!(app.adele_output_for("c2"), AdeleOutput::Disabled);
+        assert!(!app.narrate_for("c2"));
+    }
+
+    #[test]
+    fn current_narrate_is_false_without_a_conversation() {
+        let mut app = App::new();
+        // Even with stale per-conversation state, no open conversation → silent.
+        app.set_adele_output("c1", AdeleOutput::Always);
+        assert!(!app.current_narrate());
     }
 
     #[test]
@@ -1612,78 +1756,6 @@ mod tests {
     fn push_speech_disabled_note_with_no_conversation_is_noop() {
         let mut app = App::new();
         assert!(!app.push_speech_disabled_note("c1", "anything"));
-    }
-
-    // --- Per-conversation voice mode (adele-tui#75) ---
-
-    #[test]
-    fn voice_mode_defaults_off() {
-        let app = app_with_open_conversation("c1");
-        assert!(!app.current_voice_mode());
-        assert!(!app.voice_mode_for("c1"));
-        assert!(!app.voice_mode_for("never-seen"));
-    }
-
-    #[test]
-    fn toggle_current_voice_mode_flips_and_returns_new_state() {
-        let mut app = app_with_open_conversation("c1");
-        assert_eq!(app.toggle_current_voice_mode(), Some(true));
-        assert!(app.current_voice_mode());
-        assert_eq!(app.toggle_current_voice_mode(), Some(false));
-        assert!(!app.current_voice_mode());
-    }
-
-    #[test]
-    fn toggle_current_voice_mode_without_conversation_is_none() {
-        let mut app = App::new();
-        assert_eq!(app.toggle_current_voice_mode(), None);
-        assert!(!app.current_voice_mode());
-    }
-
-    #[test]
-    fn set_voice_mode_targets_an_explicit_conversation() {
-        // The model's request_voice/stop_voice carry their own conversation id,
-        // which may not be the open one.
-        let mut app = app_with_open_conversation("c1");
-        app.set_voice_mode("c2", true);
-        assert!(app.voice_mode_for("c2"));
-        assert!(!app.voice_mode_for("c1")); // open conversation untouched
-        app.set_voice_mode("c2", false);
-        assert!(!app.voice_mode_for("c2"));
-    }
-
-    #[test]
-    fn voice_mode_is_per_conversation_isolated() {
-        let mut app = app_with_open_conversation("c1");
-        assert_eq!(app.toggle_current_voice_mode(), Some(true)); // c1 ON
-        assert!(app.voice_mode_for("c1"));
-        assert!(!app.voice_mode_for("c2")); // c2 untouched → OFF
-    }
-
-    #[test]
-    fn audio_enabled_is_read_aloud_or_voice_mode() {
-        // Both off → no audio (exactly phase-1 toggle-off).
-        let mut app = app_with_open_conversation("c1");
-        assert!(!app.audio_enabled_for("c1"));
-        assert!(!app.current_audio_enabled());
-
-        // Read-aloud on (phase-1 toggle) → audio on.
-        assert_eq!(app.toggle_current_speech(), Some(true));
-        assert!(app.audio_enabled_for("c1"));
-        assert!(app.current_audio_enabled());
-
-        // Read-aloud back off, voice-mode on → still audio on.
-        assert_eq!(app.toggle_current_speech(), Some(false));
-        assert!(!app.audio_enabled_for("c1"));
-        assert_eq!(app.toggle_current_voice_mode(), Some(true));
-        assert!(app.audio_enabled_for("c1"));
-        assert!(app.current_audio_enabled());
-    }
-
-    #[test]
-    fn current_audio_enabled_is_false_without_a_conversation() {
-        let app = App::new();
-        assert!(!app.current_audio_enabled());
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -96,8 +96,11 @@ impl AdeleOutput {
     /// The next level when the user cycles the control
     /// (`Disabled → OnDemand → Always → Disabled`).
     pub fn next(self) -> Self {
-        // STUB (failing-tests commit): cycle not yet implemented.
-        Self::Disabled
+        match self {
+            Self::Disabled => Self::OnDemand,
+            Self::OnDemand => Self::Always,
+            Self::Always => Self::Disabled,
+        }
     }
 
     /// Short label for the status line / chat title cue.
@@ -294,9 +297,12 @@ impl App {
     /// Whether a *reply* is spoken for `conversation_id` (adele-tui#77, the
     /// narration gate): `Adele == Always` OR (`Adele == OnDemand` AND
     /// `You == Enabled`). `Disabled` never narrates.
-    pub fn narrate_for(&self, _conversation_id: &str) -> bool {
-        // STUB (failing-tests commit): narration gate not yet implemented.
-        false
+    pub fn narrate_for(&self, conversation_id: &str) -> bool {
+        match self.adele_output_for(conversation_id) {
+            AdeleOutput::Always => true,
+            AdeleOutput::OnDemand => self.voice_in_for(conversation_id),
+            AdeleOutput::Disabled => false,
+        }
     }
 
     /// Whether a reply is spoken for the currently-open conversation. `false`
@@ -311,9 +317,11 @@ impl App {
     /// Whether a `say_this` aside is spoken for `conversation_id` (adele-tui#77):
     /// spoken iff `Adele ∈ {OnDemand, Always}` (independent of `You`). `Disabled`
     /// downgrades the aside to inline text.
-    pub fn say_this_spoken_for(&self, _conversation_id: &str) -> bool {
-        // STUB (failing-tests commit): aside gate not yet implemented.
-        false
+    pub fn say_this_spoken_for(&self, conversation_id: &str) -> bool {
+        !matches!(
+            self.adele_output_for(conversation_id),
+            AdeleOutput::Disabled
+        )
     }
 
     /// Render a `say_this` call whose aside is NOT spoken (Adele == Disabled) as

--- a/src/client_tools.rs
+++ b/src/client_tools.rs
@@ -123,7 +123,7 @@ pub fn handle_say_this(arguments: &serde_json::Value, say_this_spoken: bool) -> 
 /// and always a result.
 pub fn handle_request_voice() -> ToolOutcome {
     ToolOutcome {
-        effect: ToolEffect::None, // STUB (failing-tests commit)
+        effect: ToolEffect::SetAdeleOutput(AdeleOutput::OnDemand),
         result: Ok(
             "voice mode on: this conversation is now spoken — replies will be read aloud and \
              kept brief and conversational"
@@ -137,7 +137,7 @@ pub fn handle_request_voice() -> ToolOutcome {
 /// result.
 pub fn handle_stop_voice() -> ToolOutcome {
     ToolOutcome {
-        effect: ToolEffect::None, // STUB (failing-tests commit)
+        effect: ToolEffect::SetAdeleOutput(AdeleOutput::Disabled),
         result: Ok("voice mode off: this conversation is back to text-only".to_string()),
     }
 }

--- a/src/client_tools.rs
+++ b/src/client_tools.rs
@@ -1,4 +1,5 @@
-//! Client-local tool handling for the TUI (adele-tui#73).
+//! Client-local tool handling for the TUI (adele-tui#73, reworked for the
+//! You/Adele model in adele-tui#77).
 //!
 //! The daemon can suspend a turn on a *client* tool (`SignalEvent::ClientToolCall`)
 //! and park until the client posts a result back. Before #261 the per-user tool
@@ -7,36 +8,41 @@
 //!
 //! This module turns an incoming call into a pure [`ToolOutcome`]: the result
 //! string to submit back to the daemon (so the turn ALWAYS resumes) plus an
-//! optional side effect (speak the text, or show it inline). The async event
-//! loop performs the side effect and submits the result; the decision itself is
-//! pure so it is unit-testable without a transport or an audio device.
+//! optional side effect (speak the text, show it inline, or set the `Adele`
+//! output level). The async event loop performs the side effect and submits the
+//! result; the decision itself is pure so it is unit-testable without a
+//! transport or an audio device.
 //!
 //! The TUI understands three tools:
 //!
 //! * `say_this` — "speak this text aloud". Whether it actually speaks is gated
-//!   by whether ANY audio control is on for the call's conversation:
-//!   read-aloud (the phase-1 accessibility toggle) OR voice-mode (phase-2). ON
-//!   ⇒ speak; OFF ⇒ render `(speech mode disabled) <text>` inline instead.
-//! * `request_voice` (adele-tui#75) — the model switching this conversation into
-//!   spoken voice mode ("ok, let's talk by voice"). Turns the per-conversation
-//!   soft-sticky voice mode ON.
-//! * `stop_voice` (adele-tui#75) — the model leaving voice mode; turns it OFF.
+//!   by whether the call's conversation's `Adele` level is `OnDemand` or
+//!   `Always` (i.e. not `Disabled`); the caller passes that boolean as
+//!   `say_this_spoken`. Spoken ⇒ speak (daemon-first, chunked); not spoken ⇒
+//!   render `(speech mode disabled) <text>` inline instead.
+//! * `request_voice` (adele-tui#77) — the model switching this conversation into
+//!   spoken voice mode ("ok, let's talk by voice"). Sets `Adele = OnDemand`.
+//! * `stop_voice` (adele-tui#77) — the model leaving voice mode; sets
+//!   `Adele = Disabled`.
 //!
 //! Either way the turn always completes, and any other tool name resolves to an
 //! error result rather than a wedge. The decision is pure; the async handler
-//! performs the side effect (speak / show inline / flip `App::voice_mode`).
+//! performs the side effect (speak / show inline / set `App::adele_output`).
+
+use crate::app::AdeleOutput;
 
 /// The TUI's `say_this` client tool: speak a short piece of text aloud. The
 /// daemon forwards this name verbatim to the LLM's tool list.
 pub const SAY_THIS: &str = "say_this";
 
-/// The model-driven "enter voice mode" tool (adele-tui#75). The model calls it
-/// when the user asks to talk by voice; it flips the conversation's soft-sticky
-/// voice mode ON (replies narrated + shaped for speech).
+/// The model-driven "enter voice mode" tool (adele-tui#77). The model calls it
+/// when the user asks to talk by voice; it sets the conversation's `Adele`
+/// output level to `OnDemand` (replies narrated when `You == Enabled` + shaped
+/// for speech, `say_this` asides always spoken).
 pub const REQUEST_VOICE: &str = "request_voice";
 
-/// The model-driven "leave voice mode" tool (adele-tui#75). Flips the
-/// conversation's voice mode OFF, back to text-only.
+/// The model-driven "leave voice mode" tool (adele-tui#77). Sets the
+/// conversation's `Adele` level to `Disabled`, back to text-only.
 pub const STOP_VOICE: &str = "stop_voice";
 
 /// A `SignalEvent::ClientToolCall` flattened into one value so the async
@@ -67,34 +73,34 @@ pub struct ToolOutcome {
 /// the decision stays pure.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ToolEffect {
-    /// Speak `text` aloud via the embedded `Speaker`.
+    /// Speak `text` aloud (daemon-first, chunked; embedded fallback).
     Speak(String),
-    /// No audio control is on for this conversation: show `text` inline in the
-    /// transcript prefixed with `(speech mode disabled)` instead of speaking.
+    /// The call's conversation has `Adele == Disabled`: show `text` inline in
+    /// the transcript prefixed with `(speech mode disabled)` instead of speaking.
     ShowDisabled(String),
-    /// Set the call's conversation's soft-sticky voice mode (adele-tui#75) —
-    /// `true` for `request_voice`, `false` for `stop_voice`. The async handler
-    /// applies it to `App::voice_mode` so this decision stays pure.
-    SetVoiceMode(bool),
+    /// Set the call's conversation's `Adele` output level (adele-tui#77) —
+    /// `OnDemand` for `request_voice`, `Disabled` for `stop_voice`. The async
+    /// handler applies it to `App::adele_output` so this decision stays pure.
+    SetAdeleOutput(AdeleOutput),
     /// Nothing to do beyond submitting the result (unknown tool / bad args).
     None,
 }
 
 /// Decide how to handle a `say_this` client tool call.
 ///
-/// `arguments` is the raw JSON the daemon forwarded; `audio_enabled` is whether
-/// ANY audio control is on for the call's conversation — read-aloud OR
-/// voice-mode (adele-tui#75 broadened this from phase-1's read-aloud-only
-/// gate). Never panics: a non-object payload or a missing/non-string `text`
-/// field becomes an error result (the turn still resumes) rather than an unwrap.
-pub fn handle_say_this(arguments: &serde_json::Value, audio_enabled: bool) -> ToolOutcome {
+/// `arguments` is the raw JSON the daemon forwarded; `say_this_spoken` is whether
+/// the call's conversation's `Adele` level is `OnDemand` or `Always` (i.e. not
+/// `Disabled`) — the aside gate (adele-tui#77). Never panics: a non-object
+/// payload or a missing/non-string `text` field becomes an error result (the
+/// turn still resumes) rather than an unwrap.
+pub fn handle_say_this(arguments: &serde_json::Value, say_this_spoken: bool) -> ToolOutcome {
     let Some(text) = arguments.get("text").and_then(|t| t.as_str()) else {
         return ToolOutcome {
             effect: ToolEffect::None,
             result: Err("say_this requires a string `text` argument".to_string()),
         };
     };
-    if audio_enabled {
+    if say_this_spoken {
         ToolOutcome {
             effect: ToolEffect::Speak(text.to_string()),
             result: Ok("spoken".to_string()),
@@ -111,12 +117,13 @@ pub fn handle_say_this(arguments: &serde_json::Value, audio_enabled: bool) -> To
     }
 }
 
-/// Decide how to handle a `request_voice` call (adele-tui#75): the model is
-/// entering voice mode for the conversation. Pure — emits a `SetVoiceMode(true)`
-/// effect the handler applies to `App::voice_mode`, and always a result.
+/// Decide how to handle a `request_voice` call (adele-tui#77): the model is
+/// entering voice mode for the conversation. Pure — emits a
+/// `SetAdeleOutput(OnDemand)` effect the handler applies to `App::adele_output`,
+/// and always a result.
 pub fn handle_request_voice() -> ToolOutcome {
     ToolOutcome {
-        effect: ToolEffect::SetVoiceMode(true),
+        effect: ToolEffect::None, // STUB (failing-tests commit)
         result: Ok(
             "voice mode on: this conversation is now spoken — replies will be read aloud and \
              kept brief and conversational"
@@ -125,11 +132,12 @@ pub fn handle_request_voice() -> ToolOutcome {
     }
 }
 
-/// Decide how to handle a `stop_voice` call (adele-tui#75): the model is leaving
-/// voice mode. Pure — emits a `SetVoiceMode(false)` effect and always a result.
+/// Decide how to handle a `stop_voice` call (adele-tui#77): the model is leaving
+/// voice mode. Pure — emits a `SetAdeleOutput(Disabled)` effect and always a
+/// result.
 pub fn handle_stop_voice() -> ToolOutcome {
     ToolOutcome {
-        effect: ToolEffect::SetVoiceMode(false),
+        effect: ToolEffect::None, // STUB (failing-tests commit)
         result: Ok("voice mode off: this conversation is back to text-only".to_string()),
     }
 }
@@ -138,15 +146,15 @@ pub fn handle_stop_voice() -> ToolOutcome {
 /// and `stop_voice` are handled; anything else resolves to an error result so an
 /// unexpected tool (e.g. one leaked from another session pre-#261, or a future
 /// tool the TUI doesn't yet implement) still resumes the turn instead of wedging
-/// it. `audio_enabled` is whether any audio control is on for the call's
-/// conversation (read-aloud OR voice-mode); it only affects `say_this`.
+/// it. `say_this_spoken` is whether the call's conversation's `Adele` level
+/// speaks asides (OnDemand/Always); it only affects `say_this`.
 pub fn dispatch(
     tool_name: &str,
     arguments: &serde_json::Value,
-    audio_enabled: bool,
+    say_this_spoken: bool,
 ) -> ToolOutcome {
     match tool_name {
-        SAY_THIS => handle_say_this(arguments, audio_enabled),
+        SAY_THIS => handle_say_this(arguments, say_this_spoken),
         REQUEST_VOICE => handle_request_voice(),
         STOP_VOICE => handle_stop_voice(),
         other => ToolOutcome {
@@ -177,9 +185,9 @@ pub fn say_this_registration() -> desktop_assistant_api_model::ClientToolRegistr
     }
 }
 
-/// The `request_voice` tool registration (adele-tui#75). Advertised on every
+/// The `request_voice` tool registration (adele-tui#77). Advertised on every
 /// (re)connect alongside `say_this`. Calling it switches the conversation into
-/// spoken voice mode.
+/// spoken voice mode (`Adele = OnDemand`).
 pub fn request_voice_registration() -> desktop_assistant_api_model::ClientToolRegistration {
     desktop_assistant_api_model::ClientToolRegistration {
         name: REQUEST_VOICE.to_string(),
@@ -195,8 +203,8 @@ pub fn request_voice_registration() -> desktop_assistant_api_model::ClientToolRe
     }
 }
 
-/// The `stop_voice` tool registration (adele-tui#75). Leaves voice mode, back to
-/// text-only.
+/// The `stop_voice` tool registration (adele-tui#77). Leaves voice mode
+/// (`Adele = Disabled`), back to text-only.
 pub fn stop_voice_registration() -> desktop_assistant_api_model::ClientToolRegistration {
     desktop_assistant_api_model::ClientToolRegistration {
         name: STOP_VOICE.to_string(),
@@ -291,12 +299,15 @@ mod tests {
         assert_eq!(required, &serde_json::json!(["text"]));
     }
 
-    // --- Voice mode (adele-tui#75) ---
+    // --- Voice mode (adele-tui#77) ---
 
     #[test]
-    fn request_voice_turns_voice_mode_on_with_a_result() {
+    fn request_voice_sets_adele_on_demand_with_a_result() {
         let outcome = handle_request_voice();
-        assert_eq!(outcome.effect, ToolEffect::SetVoiceMode(true));
+        assert_eq!(
+            outcome.effect,
+            ToolEffect::SetAdeleOutput(AdeleOutput::OnDemand)
+        );
         let msg = outcome
             .result
             .expect("request_voice always returns a result");
@@ -304,26 +315,35 @@ mod tests {
     }
 
     #[test]
-    fn stop_voice_turns_voice_mode_off_with_a_result() {
+    fn stop_voice_sets_adele_disabled_with_a_result() {
         let outcome = handle_stop_voice();
-        assert_eq!(outcome.effect, ToolEffect::SetVoiceMode(false));
+        assert_eq!(
+            outcome.effect,
+            ToolEffect::SetAdeleOutput(AdeleOutput::Disabled)
+        );
         let msg = outcome.result.expect("stop_voice always returns a result");
         assert!(msg.contains("voice mode off"));
     }
 
     #[test]
     fn dispatch_routes_request_voice() {
-        // request_voice ignores its arguments and the audio gate; it just flips
-        // voice mode on. Pass an empty object and audio OFF to prove that.
+        // request_voice ignores its arguments and the say_this gate; it just sets
+        // Adele = OnDemand. Pass an empty object and gate OFF to prove that.
         let outcome = dispatch(REQUEST_VOICE, &serde_json::json!({}), false);
-        assert_eq!(outcome.effect, ToolEffect::SetVoiceMode(true));
+        assert_eq!(
+            outcome.effect,
+            ToolEffect::SetAdeleOutput(AdeleOutput::OnDemand)
+        );
         assert!(outcome.result.is_ok());
     }
 
     #[test]
     fn dispatch_routes_stop_voice() {
         let outcome = dispatch(STOP_VOICE, &serde_json::json!({}), true);
-        assert_eq!(outcome.effect, ToolEffect::SetVoiceMode(false));
+        assert_eq!(
+            outcome.effect,
+            ToolEffect::SetAdeleOutput(AdeleOutput::Disabled)
+        );
         assert!(outcome.result.is_ok());
     }
 
@@ -332,20 +352,23 @@ mod tests {
         // The model shouldn't send args, but a non-object payload must not
         // panic — request_voice ignores arguments entirely.
         let outcome = dispatch(REQUEST_VOICE, &serde_json::Value::Null, false);
-        assert_eq!(outcome.effect, ToolEffect::SetVoiceMode(true));
+        assert_eq!(
+            outcome.effect,
+            ToolEffect::SetAdeleOutput(AdeleOutput::OnDemand)
+        );
         assert!(outcome.result.is_ok());
     }
 
     #[test]
-    fn say_this_speaks_when_audio_enabled_via_voice_mode() {
-        // Phase-2: the say_this audio gate is (read-aloud OR voice-mode). The
-        // caller passes the OR'd value; here it is on (e.g. via voice-mode).
+    fn say_this_speaks_when_aside_is_spoken() {
+        // The say_this gate is "Adele speaks asides" (OnDemand/Always). The
+        // caller passes that boolean; here it is on.
         let outcome = handle_say_this(&args("aside"), true);
         assert_eq!(outcome.effect, ToolEffect::Speak("aside".to_string()));
     }
 
     #[test]
-    fn say_this_shows_inline_when_no_audio_control_is_on() {
+    fn say_this_shows_inline_when_adele_disabled() {
         let outcome = handle_say_this(&args("aside"), false);
         assert_eq!(
             outcome.effect,

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -46,27 +46,30 @@ pub enum Action {
     CancelSelectedTask,
     /// Jump to the conversation linked to the highlighted task.
     OpenSelectedTaskConversation,
-    /// Start one-shot embedded dictation: capture a single utterance from the
-    /// mic and drop the transcript into the prompt input. Bound to `Ctrl+G`
-    /// ("Go, voice") — free across modes and not intercepted by terminals or
-    /// the textarea. No-op unless voice is in `embedded` mode (adele-tui#67).
+    /// Push-to-talk dictation (adele-tui#77). Bound to `Ctrl+G` ("Go, voice") —
+    /// free across modes and not intercepted by terminals or the textarea.
+    /// Prefers the voice daemon when it is running (it routes the whole spoken
+    /// turn into the active conversation); otherwise falls back to one-shot
+    /// embedded dictation (mic → transcript → prompt input), which is a no-op
+    /// unless voice is in `embedded` mode. Available when `You == Enabled`.
     Dictate,
-    /// Toggle the per-conversation "read aloud" accessibility switch
-    /// (adele-tui#73, reframed in #75). Bound to `Ctrl+S` ("Speech"). The
-    /// keyboard-enhancement flags pushed at startup deliver Ctrl+S as a real
-    /// key event (not terminal XOFF flow control). When ON every assistant
-    /// reply is read aloud and the daemon's `say_this` client tool speaks; it is
-    /// LLM-unaware (the model isn't told). Independent of voice mode — either
-    /// one being ON narrates replies. Defaults OFF per conversation (seeded from
-    /// `play_replies`).
-    ToggleSpeech,
-    /// Toggle the per-conversation soft-sticky **voice mode** (adele-tui#75).
-    /// Bound to `Ctrl+V` ("Voice"), delivered as a real key event by the same
-    /// keyboard-enhancement flags. When ON, replies are read aloud (like
-    /// read-aloud) AND a concise spoken-style `system_refinement` shapes each
-    /// send so replies are brief and conversational. Also entered/left by the
-    /// model via the `request_voice` / `stop_voice` client tools. Defaults OFF.
-    ToggleVoiceMode,
+    /// Cycle the per-conversation `Adele:` voice-output level (adele-tui#77),
+    /// `Disabled → On Demand → Always → Disabled`. Bound to `Ctrl+S` ("Speech";
+    /// Adele's speech). The keyboard-enhancement flags pushed at startup deliver
+    /// Ctrl+S as a real key event (not terminal XOFF flow control). `Always`
+    /// reads every reply aloud in full (made speakable); `On Demand` reads
+    /// replies only while `You == Enabled`, kept brief, and always speaks
+    /// `say_this` asides; `Disabled` never speaks. Also set by the model via
+    /// `request_voice` (→ On Demand) / `stop_voice` (→ Disabled). Defaults
+    /// `Disabled` per conversation.
+    CycleAdeleOutput,
+    /// Toggle the per-conversation `You:` voice-input control (adele-tui#77),
+    /// `Disabled ↔ Enabled`. Bound to `Ctrl+V` ("Voice"; your voice), delivered
+    /// as a real key event by the same keyboard-enhancement flags. When Enabled,
+    /// push-to-talk dictation is available (Ctrl+G) and — combined with
+    /// `Adele == On Demand` — reply narration is on. Defaults `Disabled` (type
+    /// only); text input is always available.
+    ToggleVoiceIn,
 }
 
 /// Handle key events that we intercept before passing to textarea.
@@ -124,12 +127,14 @@ pub fn handle_key_event(
             // Ctrl+G starts embedded dictation (mic → prompt). A no-op when
             // voice isn't in embedded mode; main.rs gates on the session.
             KeyCode::Char('g') => Some(Action::Dictate),
-            // Ctrl+S toggles per-conversation read-aloud (adele-tui#73). A
-            // no-op status hint when no conversation is open; main.rs gates.
-            KeyCode::Char('s') => Some(Action::ToggleSpeech),
-            // Ctrl+V toggles per-conversation voice mode (adele-tui#75). Like
-            // Ctrl+S it is delivered as a real key by the enhancement flags.
-            KeyCode::Char('v') => Some(Action::ToggleVoiceMode),
+            // Ctrl+S cycles the per-conversation Adele output level
+            // (adele-tui#77). A no-op status hint when no conversation is open;
+            // main.rs gates.
+            KeyCode::Char('s') => None, // STUB (failing-tests commit)
+            // Ctrl+V toggles the per-conversation You (voice-input) control
+            // (adele-tui#77). Like Ctrl+S it is delivered as a real key by the
+            // enhancement flags.
+            KeyCode::Char('v') => None, // STUB (failing-tests commit)
             _ => None,
         };
     }
@@ -822,23 +827,23 @@ mod tests {
         );
     }
 
-    // --- Ctrl+S toggles per-conversation speech (adele-tui#73) ---
+    // --- Ctrl+S cycles the Adele output level (adele-tui#77) ---
 
     #[test]
-    fn ctrl_s_toggles_speech_in_normal() {
+    fn ctrl_s_cycles_adele_output_in_normal() {
         assert_eq!(
             handle_key_event(
                 key_with_mod(KeyCode::Char('s'), KeyModifiers::CONTROL),
                 &InputMode::Normal,
                 false
             ),
-            Some(Action::ToggleSpeech)
+            Some(Action::CycleAdeleOutput)
         );
     }
 
     #[test]
-    fn ctrl_s_toggles_speech_in_editing() {
-        // Speech is a per-conversation control the user will flip while
+    fn ctrl_s_cycles_adele_output_in_editing() {
+        // Adele output is a per-conversation control the user will change while
         // composing, so it must be reachable from editing mode too.
         assert_eq!(
             handle_key_event(
@@ -846,14 +851,14 @@ mod tests {
                 &InputMode::Editing,
                 false
             ),
-            Some(Action::ToggleSpeech)
+            Some(Action::CycleAdeleOutput)
         );
     }
 
     #[test]
     fn ctrl_s_is_not_intercepted_in_renaming() {
-        // Renaming forwards all Ctrl combos to the rename textarea; the speech
-        // toggle must not hijack them mid-rename.
+        // Renaming forwards all Ctrl combos to the rename textarea; the Adele
+        // cycle must not hijack them mid-rename.
         assert_eq!(
             handle_key_event(
                 key_with_mod(KeyCode::Char('s'), KeyModifiers::CONTROL),
@@ -878,23 +883,23 @@ mod tests {
         );
     }
 
-    // --- Ctrl+V toggles per-conversation voice mode (adele-tui#75) ---
+    // --- Ctrl+V toggles the You (voice-input) control (adele-tui#77) ---
 
     #[test]
-    fn ctrl_v_toggles_voice_mode_in_normal() {
+    fn ctrl_v_toggles_voice_in_in_normal() {
         assert_eq!(
             handle_key_event(
                 key_with_mod(KeyCode::Char('v'), KeyModifiers::CONTROL),
                 &InputMode::Normal,
                 false
             ),
-            Some(Action::ToggleVoiceMode)
+            Some(Action::ToggleVoiceIn)
         );
     }
 
     #[test]
-    fn ctrl_v_toggles_voice_mode_in_editing() {
-        // Voice mode is a per-conversation control the user will flip while
+    fn ctrl_v_toggles_voice_in_in_editing() {
+        // The You control is a per-conversation control the user will flip while
         // composing, so it must be reachable from editing mode too.
         assert_eq!(
             handle_key_event(
@@ -902,13 +907,13 @@ mod tests {
                 &InputMode::Editing,
                 false
             ),
-            Some(Action::ToggleVoiceMode)
+            Some(Action::ToggleVoiceIn)
         );
     }
 
     #[test]
     fn ctrl_v_is_not_intercepted_in_renaming() {
-        // Renaming forwards all Ctrl combos to the rename textarea; the voice
+        // Renaming forwards all Ctrl combos to the rename textarea; the You
         // toggle must not hijack them mid-rename.
         assert_eq!(
             handle_key_event(

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -130,11 +130,11 @@ pub fn handle_key_event(
             // Ctrl+S cycles the per-conversation Adele output level
             // (adele-tui#77). A no-op status hint when no conversation is open;
             // main.rs gates.
-            KeyCode::Char('s') => None, // STUB (failing-tests commit)
+            KeyCode::Char('s') => Some(Action::CycleAdeleOutput),
             // Ctrl+V toggles the per-conversation You (voice-input) control
             // (adele-tui#77). Like Ctrl+S it is delivered as a real key by the
             // enhancement flags.
-            KeyCode::Char('v') => None, // STUB (failing-tests commit)
+            KeyCode::Char('v') => Some(Action::ToggleVoiceIn),
             _ => None,
         };
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ mod tasks;
 mod toolbar;
 mod ui;
 mod voice;
+mod voice_client;
 
 use std::io;
 use std::path::PathBuf;
@@ -46,12 +47,13 @@ use tokio::{
     time::{Instant, sleep_until},
 };
 
-use app::{App, InputMode};
+use app::{AdeleOutput, App, InputMode};
 use keys::{Action, handle_key_event};
 use picker::PickerOutcome;
 use profile::ProfileStore;
 use settings::Settings;
 use voice::{VoiceConfig, VoiceSession};
+use voice_client::VoiceController;
 
 const DEFAULT_WS_URL: &str = desktop_assistant_client_common::config::DEFAULT_WS_URL;
 const DEFAULT_WS_SUBJECT: &str = desktop_assistant_client_common::config::DEFAULT_WS_SUBJECT;
@@ -209,16 +211,45 @@ enum ReconnectState {
 const RECONNECT_INITIAL_SECS: u64 = 2;
 const RECONNECT_MAX_SECS: u64 = 30;
 
-/// Per-turn system-prompt refinement sent while a conversation is in voice mode
-/// (adele-tui#75). It shapes the reply for the ear without touching the visible
-/// transcript or later turns. A deliberately concise echo of the voice daemon's
-/// `spoken_response_hint` essence — NOT a copy of its full paragraph.
-const VOICE_SYSTEM_REFINEMENT: &str = "This reply will be read aloud, so write it to be heard, \
+/// System refinement attached on send while `Adele == OnDemand` (adele-tui#77,
+/// mirroring adele-gtk#80). Replies are spoken only while conversing by voice,
+/// so shape them **for the ear**: brief, conversational, no markdown,
+/// symbols/acronyms spelled out. Deliberately free of markdown markers so it
+/// can't itself leak formatting. Refines the system prompt for THIS turn only —
+/// never stored, never in the transcript.
+const ON_DEMAND_SYSTEM_REFINEMENT: &str = "This reply will be read aloud, so write it to be heard, \
     not read. Keep it brief and conversational — a few short sentences — and lead with the answer. \
     Use no markdown or formatting of any kind (no asterisks, backticks, bullets, or emoji); write \
     plain spoken prose. Spell out symbols, abbreviations, and acronyms as words (say \"and\" not \
     \"&\", \"percent\" not \"%\", \"for example\" not \"e.g.\"), and don't read out URLs, file \
     paths, or email addresses — describe them instead.";
+
+/// System refinement attached on send while `Adele == Always` (adele-tui#77,
+/// mirroring adele-gtk#80). Every reply is read aloud for accessibility, so make
+/// it **speakable but not shortened**: keep the full content, just strip
+/// formatting and spell out symbols. Crucially it does NOT ask for brevity
+/// (that's the OnDemand job) — Always reads the whole answer. Free of markdown
+/// markers itself.
+const ALWAYS_SYSTEM_REFINEMENT: &str = "This reply will be read aloud in full, so write it to be \
+    heard, not read, without leaving anything out. Do not shorten or summarize — cover everything \
+    you would normally say, just phrased for the ear. Use no markdown or formatting of any kind \
+    (no asterisks, backticks, bullets, or emoji); write plain spoken prose. Spell out symbols, \
+    abbreviations, and acronyms as words (say \"and\" not \"&\", \"percent\" not \"%\", \"for \
+    example\" not \"e.g.\"), and don't read out URLs, file paths, or email addresses — describe \
+    them instead.";
+
+/// The system refinement to attach on the next send for `conversation_id`
+/// (adele-tui#77), chosen by its `Adele:` level: `OnDemand` →
+/// brief/conversational/speakable; `Always` → speakable-but-full (don't
+/// shorten); `Disabled` → none. Pure decision the send path consults to choose
+/// the refinement string (empty = none).
+fn refinement_for_send(app: &App, conversation_id: &str) -> &'static str {
+    match app.adele_output_for(conversation_id) {
+        AdeleOutput::OnDemand => ON_DEMAND_SYSTEM_REFINEMENT,
+        AdeleOutput::Always => ALWAYS_SYSTEM_REFINEMENT,
+        AdeleOutput::Disabled => "",
+    }
+}
 
 fn next_backoff(prev_secs: u64) -> u64 {
     prev_secs.saturating_mul(2).min(RECONNECT_MAX_SECS)
@@ -352,13 +383,13 @@ async fn run(
     // result and the ready session are merged into the select! loop like every
     // other async source (per AGENTS.md). Off/daemon mode wires nothing.
     let voice_cfg = VoiceConfig::load();
-    // Seed the per-conversation speech toggle's default (adele-tui#73). Existing
-    // `play_replies = true` users keep audio (now per-conversation + toggleable
-    // via Ctrl+S); everyone else defaults to speech OFF. Only meaningful in
-    // embedded mode — there is no `Speaker` to narrate with otherwise.
-    if voice_cfg.embedded_enabled() {
-        app.set_speech_default(voice_cfg.play_replies);
-    }
+    // Connect to the standalone voice daemon (`org.desktopAssistant.Voice`) for
+    // narration (adele-tui#77). This is independent of the embedded pipeline and
+    // of `voice.toml`'s mode: when the daemon is running it is the preferred,
+    // warm speaker for reply narration + `say_this` asides; the embedded engine
+    // (if `embedded` mode built one) is the fallback. Connecting never fails hard
+    // — a missing daemon yields an inert controller probed per-utterance.
+    let voice_daemon = VoiceController::connect().await;
     let mut voice_session: Option<VoiceSession> = None;
     let mut dictating = false;
     let (dictation_tx, mut dictation_rx) = unbounded_channel::<DictationOutcome>();
@@ -478,13 +509,43 @@ async fn run(
                     }
                     if let Some(action) = handle_key_event(key, &app.mode, app.tasks.visible) {
                         if action == Action::Dictate {
-                            start_dictation(
-                                &mut app,
-                                &voice_cfg,
-                                &voice_session,
-                                &mut dictating,
-                                &dictation_tx,
-                            );
+                            // Push-to-talk (adele-tui#77). Prefer the voice
+                            // daemon's dictation when it is running: it captures,
+                            // transcribes, and routes the whole turn — spoken
+                            // prompt and reply — into the active conversation
+                            // (mirroring gtk's mic button). Fall back to the
+                            // embedded one-shot dictation (transcript → input)
+                            // when the daemon is absent.
+                            if voice_daemon.is_available().await {
+                                let conv = app
+                                    .current_conversation
+                                    .as_ref()
+                                    .map(|c| c.id.clone());
+                                // Barge-in: stop any in-progress narration before
+                                // we start listening, so the mic doesn't capture
+                                // Adele's own voice. Best-effort.
+                                let _ = voice_daemon.stop_speaking().await;
+                                match voice_daemon
+                                    .push_to_talk_routed(conv.as_deref())
+                                    .await
+                                {
+                                    Ok(()) => {
+                                        app.status_message = "Listening… (voice daemon)".into();
+                                    }
+                                    Err(e) => {
+                                        app.status_message =
+                                            format!("Push-to-talk failed: {e}");
+                                    }
+                                }
+                            } else {
+                                start_dictation(
+                                    &mut app,
+                                    &voice_cfg,
+                                    &voice_session,
+                                    &mut dictating,
+                                    &dictation_tx,
+                                );
+                            }
                         } else {
                             handle_action(&mut app, &connector, action).await;
                         }
@@ -508,22 +569,18 @@ async fn run(
                     }
                     SignalEvent::Complete { request_id, full_response } => {
                         app.complete_streaming(&request_id, &full_response);
-                        // Speak the reply aloud (embedded TTS, no daemon) only
-                        // when the OPEN conversation has audio on — read-aloud OR
-                        // voice mode (adele-tui#73/#75). The completing reply
-                        // streams into the open conversation, so that gate is
-                        // right. Fire-and-forget on a task so synth+playback
-                        // never blocks the UI; `Speaker` is cheap to clone.
-                        if let Some(session) = voice_session.as_ref()
-                            && app.current_audio_enabled()
-                            && !full_response.trim().is_empty()
-                        {
-                            let speaker = session.speaker();
-                            tokio::spawn(async move {
-                                if let Err(e) = speaker.say(&full_response).await {
-                                    tracing::warn!("voice playback failed: {e}");
-                                }
-                            });
+                        // Narrate the finalized reply only when the OPEN
+                        // conversation's gate holds (adele-tui#77): `Adele ==
+                        // Always` OR (`Adele == OnDemand` AND `You == Enabled`).
+                        // The completing reply streams into the open conversation,
+                        // so that gate is right. Route daemon-first + chunked via
+                        // `speak_text`; fire-and-forget so synth never blocks the
+                        // UI. Gated entirely here so the cut-off holds: when the
+                        // gate is false nothing is spoken on any path.
+                        if app.current_narrate() && !full_response.trim().is_empty() {
+                            let voice = Some(voice_daemon.clone());
+                            let embedded = voice_session.as_ref().map(VoiceSession::speaker);
+                            tokio::spawn(speak_text(voice, embedded, full_response));
                         }
                     }
                     SignalEvent::Error { request_id, error } => {
@@ -600,7 +657,14 @@ async fn run(
                             tool_name,
                             arguments,
                         };
-                        handle_client_tool_call(&mut app, &connector, &voice_session, call).await;
+                        handle_client_tool_call(
+                            &mut app,
+                            &connector,
+                            &voice_daemon,
+                            &voice_session,
+                            call,
+                        )
+                        .await;
                     }
                 }
             }
@@ -754,33 +818,39 @@ async fn handle_action(app: &mut App, connector: &Option<Connector>, action: Act
         // session + a result channel + a spawned capture task — loop-local
         // resources that don't belong in `handle_action`'s signature).
         Action::Dictate => {}
-        Action::ToggleSpeech => match app.toggle_current_speech() {
-            Some(true) => {
+        Action::CycleAdeleOutput => match app.cycle_current_adele_output() {
+            Some(AdeleOutput::Disabled) => {
                 app.status_message =
-                    "Read aloud ON for this conversation (replies read aloud) — Ctrl+S to stop"
-                        .into();
+                    "Adele: Disabled for this conversation (never speaks) — Ctrl+S to cycle".into();
             }
-            Some(false) => {
-                app.status_message = "Read aloud OFF for this conversation".into();
+            Some(AdeleOutput::OnDemand) => {
+                app.status_message = "Adele: On Demand for this conversation (speaks replies when \
+                     You is Enabled; always speaks asides) — Ctrl+S to cycle"
+                    .into();
+            }
+            Some(AdeleOutput::Always) => {
+                app.status_message =
+                    "Adele: Always for this conversation (reads every reply aloud) — Ctrl+S to cycle"
+                        .into();
             }
             None => {
                 app.status_message =
-                    "Open a conversation first — read aloud is per-conversation".into();
+                    "Open a conversation first — Adele output is per-conversation".into();
             }
         },
-        Action::ToggleVoiceMode => match app.toggle_current_voice_mode() {
+        Action::ToggleVoiceIn => match app.toggle_current_voice_in() {
             Some(true) => {
                 app.status_message =
-                    "Voice mode ON for this conversation (replies read aloud + kept conversational) \
-                     — Ctrl+V to stop"
+                    "You: Enabled for this conversation (push-to-talk with Ctrl+G; narrates \
+                     replies when Adele is On Demand) — Ctrl+V to disable"
                         .into();
             }
             Some(false) => {
-                app.status_message = "Voice mode OFF for this conversation".into();
+                app.status_message = "You: Disabled for this conversation (type only)".into();
             }
             None => {
                 app.status_message =
-                    "Open a conversation first — voice mode is per-conversation".into();
+                    "Open a conversation first — the You control is per-conversation".into();
             }
         },
         Action::InsertNewline => {
@@ -962,6 +1032,61 @@ async fn handle_action(app: &mut App, connector: &Option<Connector>, action: Act
     }
 }
 
+/// Speak `text` aloud, daemon-first and chunked (adele-tui#77, mirroring
+/// adele-gtk#80's `window::speak_text`).
+///
+/// Single entry point shared by reply narration and `say_this` asides so routing
+/// + chunking live in one place:
+///
+/// 1. **Chunk.** `text` is split into one-short-sentence-per-call pieces via
+///    [`voice::into_speakable_sentences`]. Both backends' synth is one-shot with
+///    a ~20s per-synth timeout, so feeding a long reply whole would blow it.
+/// 2. **Route, daemon-first.** When a connected voice daemon is available, each
+///    sentence goes to its warm `SayText`; otherwise, if the embedded engine is
+///    present, to its `Speaker`; otherwise nothing is spoken. The backend is
+///    chosen **once** for the whole utterance (not per sentence) so playback
+///    never splits across engines.
+/// 3. **Order.** Sentences are awaited **sequentially**, so the daemon/embedded
+///    sink receives — and plays — them in order; they are never fired unordered.
+///
+/// Spawned fire-and-forget by callers so synthesis + playback never blocks the
+/// UI. Errors are logged once (the first failing sentence) and the rest of the
+/// utterance is abandoned.
+async fn speak_text(
+    voice: Option<VoiceController>,
+    embedded: Option<adele_voice_module::Speaker<adele_voice_module::TtsBackend>>,
+    text: String,
+) {
+    let sentences = voice::into_speakable_sentences(&text);
+    if sentences.is_empty() {
+        return;
+    }
+
+    // Choose the backend once for the whole utterance: a daemon that has
+    // actually connected wins (warm models), else the in-process engine. Probing
+    // availability also avoids handing sentences to a daemon that vanished.
+    let daemon = match voice {
+        Some(controller) if controller.is_available().await => Some(controller),
+        _ => None,
+    };
+
+    for sentence in sentences {
+        let result = if let Some(controller) = &daemon {
+            controller.say(&sentence).await
+        } else if let Some(speaker) = &embedded {
+            speaker.say(&sentence).await.map_err(|e| e.to_string())
+        } else {
+            // Neither backend present: nothing to speak, and nothing more will
+            // become available mid-loop.
+            return;
+        };
+        if let Err(e) = result {
+            tracing::warn!("voice playback failed: {e}");
+            return;
+        }
+    }
+}
+
 /// Handle a daemon `ClientToolCall` for the TUI's `say_this` tool, then submit
 /// a result so the suspended turn resumes (adele-tui#73). The decision is pure
 /// (see [`client_tools::dispatch`]); this just performs the side effect — speak
@@ -971,39 +1096,39 @@ async fn handle_action(app: &mut App, connector: &Option<Connector>, action: Act
 async fn handle_client_tool_call(
     app: &mut App,
     connector: &Option<Connector>,
+    voice_daemon: &VoiceController,
     voice_session: &Option<VoiceSession>,
     call: client_tools::ClientToolCall,
 ) {
     // Gate on the call's OWN conversation, not the open one, so the per-
     // conversation controls are honored even if the user has since switched
-    // tabs. The say_this audio gate is read-aloud OR voice-mode (adele-tui#75).
-    let audio_enabled = app.audio_enabled_for(&call.conversation_id);
-    let outcome = client_tools::dispatch(&call.tool_name, &call.arguments, audio_enabled);
+    // tabs. The say_this aside gate is `Adele ∈ {OnDemand, Always}` (adele-tui#77).
+    let say_this_spoken = app.say_this_spoken_for(&call.conversation_id);
+    let outcome = client_tools::dispatch(&call.tool_name, &call.arguments, say_this_spoken);
 
     match outcome.effect {
         client_tools::ToolEffect::Speak(text) => {
-            // Fire-and-forget playback so we don't block submitting the result.
-            if let Some(session) = voice_session.as_ref() {
-                let speaker = session.speaker();
-                tokio::spawn(async move {
-                    if let Err(e) = speaker.say(&text).await {
-                        tracing::warn!("say_this playback failed: {e}");
-                    }
-                });
+            // Speak the aside daemon-first + chunked, fire-and-forget so we don't
+            // block submitting the result. When neither the daemon nor the
+            // embedded engine is present, `speak_text` is a no-op; degrade to
+            // showing the text inline instead of dropping it silently.
+            let has_backend = voice_daemon.is_available().await || voice_session.is_some();
+            if has_backend {
+                let voice = Some(voice_daemon.clone());
+                let embedded = voice_session.as_ref().map(VoiceSession::speaker);
+                tokio::spawn(speak_text(voice, embedded, text));
             } else {
-                // Audio enabled but no pipeline (voice off / failed to load):
-                // degrade to showing the text rather than dropping it.
                 app.push_speech_disabled_note(&call.conversation_id, &text);
             }
         }
         client_tools::ToolEffect::ShowDisabled(text) => {
             app.push_speech_disabled_note(&call.conversation_id, &text);
         }
-        // request_voice / stop_voice (adele-tui#75): the model entered/left
-        // voice mode for its OWN conversation. Apply it to App state here so the
-        // pure dispatch stays free of App.
-        client_tools::ToolEffect::SetVoiceMode(on) => {
-            app.set_voice_mode(&call.conversation_id, on);
+        // request_voice / stop_voice (adele-tui#77): the model set the `Adele`
+        // output level for its OWN conversation. Apply it to App state here so
+        // the pure dispatch stays free of App.
+        client_tools::ToolEffect::SetAdeleOutput(level) => {
+            app.set_adele_output(&call.conversation_id, level);
         }
         client_tools::ToolEffect::None => {}
     }
@@ -1121,14 +1246,12 @@ async fn send_prompt_from_input(app: &mut App, connector: &Option<Connector>) {
     {
         let client = connector.client();
         let override_selection = app.take_pending_override();
-        // In voice mode (adele-tui#75) carry a concise read-aloud system
-        // refinement so the reply is shaped for speech. It only refines the
-        // system prompt for THIS turn — never stored, never in the transcript.
-        let refinement = if app.voice_mode_for(&conv_id) {
-            VOICE_SYSTEM_REFINEMENT
-        } else {
-            ""
-        };
+        // Per the conversation's `Adele:` level (adele-tui#77) carry a system
+        // refinement so the reply is shaped for speech: OnDemand → brief and
+        // conversational; Always → speakable but full (not shortened); Disabled →
+        // none. It only refines the system prompt for THIS turn — never stored,
+        // never in the transcript.
+        let refinement = refinement_for_send(app, &conv_id);
         // Use the command-channel `send_prompt_full` when a model override is
         // staged (model picker) and/or a refinement applies; the high-level
         // `send_prompt` carries neither. `as_commands()` is `Some` on both

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -6,7 +6,7 @@ use ratatui::{
     widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap},
 };
 
-use crate::app::{App, InputMode};
+use crate::app::{AdeleOutput, App, InputMode};
 
 const INPUT_VISIBLE_LINES: u16 = 4;
 const INPUT_TOTAL_HEIGHT: u16 = INPUT_VISIBLE_LINES + 2; // +2 for borders
@@ -368,30 +368,27 @@ fn draw_messages(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
         .and_then(|conv| conv.model_selection.as_ref())
         .map(|sel| format!("  ·  {} · {}", sel.connection_id, sel.model_id))
         .unwrap_or_default();
-    // Persistent cue for the per-conversation read-aloud toggle (adele-tui#73),
-    // so the user can always tell whether replies/say_this will be spoken. Only
-    // shown when ON; OFF (the common default) stays uncluttered.
-    let speech_suffix = if app.current_speech_enabled() {
-        "  ·  🔊 read aloud (Ctrl+S)"
-    } else {
-        ""
+    // Persistent cue for the two per-conversation voice controls (adele-tui#77),
+    // so the user can always see both states. `Adele:` (voice output, Ctrl+S
+    // cycles) shows only when not Disabled — the common default stays
+    // uncluttered; `You:` (voice input, Ctrl+V toggles) shows only when Enabled.
+    // A speaker glyph for Adele, a mic glyph for You so they read distinctly.
+    let adele_suffix = match app.current_adele_output() {
+        AdeleOutput::Disabled => String::new(),
+        level => format!("  ·  🔊 Adele: {} (Ctrl+S)", level.label()),
     };
-    // Persistent cue for soft-sticky voice mode (adele-tui#75). A distinct mic
-    // glyph so it reads differently from read-aloud's speaker glyph; shown only
-    // when ON. Voice mode also narrates, but it adds spoken-style shaping, so it
-    // is surfaced separately even when read-aloud is also on.
-    let voice_suffix = if app.current_voice_mode() {
-        "  ·  🎙 voice mode (Ctrl+V)"
+    let you_suffix = if app.current_voice_in() {
+        "  ·  🎙 You: Enabled (Ctrl+V)"
     } else {
         ""
     };
     let title = if app.scroll_offset > 0 {
         format!(
-            "{chat_title}{model_suffix}{speech_suffix}{voice_suffix} \
+            "{chat_title}{model_suffix}{adele_suffix}{you_suffix} \
              (Ctrl+u/d scroll, Ctrl+e bottom)"
         )
     } else {
-        format!("{chat_title}{model_suffix}{speech_suffix}{voice_suffix}")
+        format!("{chat_title}{model_suffix}{adele_suffix}{you_suffix}")
     };
 
     let block = Block::default()
@@ -534,52 +531,24 @@ mod tests {
         terminal.draw(|f| draw(f, &mut app)).unwrap();
     }
 
-    #[test]
-    fn draw_shows_speech_cue_only_when_enabled() {
-        // The persistent speech indicator (adele-tui#73) appears in the chat
-        // title only while the open conversation's toggle is ON.
+    fn title_dump(app: &mut App) -> String {
         let backend = TestBackend::new(100, 24);
         let mut terminal = Terminal::new(backend).unwrap();
-        let mut app = App::new();
-        app.current_conversation = Some(ConversationDetail {
-            id: "c1".into(),
-            title: "ChatProbe".into(),
-            messages: vec![],
-            model_selection: None,
-            conversation_personality: None,
-        });
-
-        // OFF (default): no "speech" cue in the title.
-        terminal.draw(|f| draw(f, &mut app)).unwrap();
-        let dump: String = terminal
+        terminal.draw(|f| draw(f, app)).unwrap();
+        terminal
             .backend()
             .buffer()
             .content
             .iter()
             .map(|c| c.symbol())
-            .collect();
-        assert!(!dump.contains("speech"));
-
-        // ON: the cue appears (reframed to "read aloud" in #75).
-        assert_eq!(app.toggle_current_speech(), Some(true));
-        terminal.draw(|f| draw(f, &mut app)).unwrap();
-        let dump: String = terminal
-            .backend()
-            .buffer()
-            .content
-            .iter()
-            .map(|c| c.symbol())
-            .collect();
-        assert!(dump.contains("read aloud"));
+            .collect()
     }
 
     #[test]
-    fn draw_shows_voice_mode_cue_only_when_enabled() {
-        // The persistent voice-mode indicator (adele-tui#75) appears in the
-        // chat title only while the open conversation's voice mode is ON, and
-        // is distinct from the read-aloud cue.
-        let backend = TestBackend::new(100, 24);
-        let mut terminal = Terminal::new(backend).unwrap();
+    fn draw_shows_adele_cue_only_when_not_disabled() {
+        // The persistent Adele (voice-output) indicator (adele-tui#77) appears in
+        // the chat title only when the open conversation's level is not Disabled,
+        // and reflects the current level label.
         let mut app = App::new();
         app.current_conversation = Some(ConversationDetail {
             id: "c1".into(),
@@ -589,28 +558,45 @@ mod tests {
             conversation_personality: None,
         });
 
-        // OFF (default): no "voice mode" cue in the title.
-        terminal.draw(|f| draw(f, &mut app)).unwrap();
-        let dump: String = terminal
-            .backend()
-            .buffer()
-            .content
-            .iter()
-            .map(|c| c.symbol())
-            .collect();
-        assert!(!dump.contains("voice mode"));
+        // Disabled (default): no "Adele:" cue in the title.
+        assert!(!title_dump(&mut app).contains("Adele:"));
 
-        // ON: the cue appears.
-        assert_eq!(app.toggle_current_voice_mode(), Some(true));
-        terminal.draw(|f| draw(f, &mut app)).unwrap();
-        let dump: String = terminal
-            .backend()
-            .buffer()
-            .content
-            .iter()
-            .map(|c| c.symbol())
-            .collect();
-        assert!(dump.contains("voice mode"));
+        // On Demand: the cue appears with the level label.
+        assert_eq!(
+            app.cycle_current_adele_output(),
+            Some(AdeleOutput::OnDemand)
+        );
+        let dump = title_dump(&mut app);
+        assert!(dump.contains("Adele:"));
+        assert!(dump.contains("On Demand"));
+
+        // Always: the cue updates to the new level.
+        assert_eq!(app.cycle_current_adele_output(), Some(AdeleOutput::Always));
+        let dump = title_dump(&mut app);
+        assert!(dump.contains("Adele:"));
+        assert!(dump.contains("Always"));
+    }
+
+    #[test]
+    fn draw_shows_you_cue_only_when_enabled() {
+        // The persistent You (voice-input) indicator (adele-tui#77) appears in
+        // the chat title only while the open conversation's You is Enabled, and
+        // is distinct from the Adele cue.
+        let mut app = App::new();
+        app.current_conversation = Some(ConversationDetail {
+            id: "c1".into(),
+            title: "ChatProbe".into(),
+            messages: vec![],
+            model_selection: None,
+            conversation_personality: None,
+        });
+
+        // Disabled (default): no "You:" cue in the title.
+        assert!(!title_dump(&mut app).contains("You:"));
+
+        // Enabled: the cue appears.
+        assert_eq!(app.toggle_current_voice_in(), Some(true));
+        assert!(title_dump(&mut app).contains("You:"));
     }
 
     #[test]

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -54,9 +54,18 @@ use tokio::sync::Mutex;
 /// one-shot push/flush with no streaming, so the time-based flush never fires.
 pub fn into_speakable_sentences(text: &str) -> Vec<String> {
     // Timeout is unused on this synchronous push→flush path; any value works.
-    // STUB (failing-tests commit): chunking not yet implemented.
-    let _ = SentenceBuffer::new(Duration::from_millis(500));
-    Vec::new()
+    let mut buf = SentenceBuffer::new(Duration::from_millis(500));
+    let mut sentences = buf.push(text);
+    let tail = buf.flush();
+    if !tail.is_empty() {
+        sentences.push(tail);
+    }
+    if sentences.is_empty() && !text.trim().is_empty() {
+        // No boundary produced a chunk but there *is* speakable text — speak it
+        // whole rather than dropping it silently.
+        sentences.push(text.trim().to_string());
+    }
+    sentences
 }
 
 /// How the TUI sources voice. Defaults to [`VoiceMode::Off`].

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -10,24 +10,54 @@
 //!
 //! Configuration lives in its own `voice.toml` next to `settings.json`, because
 //! the module's config sections are TOML-native (`Deserialize` + `Default`) and
-//! the daemon uses the same shapes. The [`VoiceMode`] toggle gates everything:
-//! it defaults to [`VoiceMode::Off`] so a TUI with no voice config behaves
-//! exactly as before. [`VoiceMode::Daemon`] is accepted but inert here — the TUI
-//! has no daemon client, so it is treated as "off"; the embedded path is the
-//! capability this module adds.
+//! the daemon uses the same shapes. The [`VoiceMode`] toggle gates the embedded
+//! pipeline: it defaults to [`VoiceMode::Off`] so a TUI with no voice config
+//! behaves exactly as before. [`VoiceMode::Daemon`] is accepted but inert here —
+//! it does not wire the embedded mic/speaker; narration still routes through the
+//! voice daemon (`org.desktopAssistant.Voice`) via [`crate::voice_client`] when
+//! that daemon is running, regardless of this mode (the daemon path is probed
+//! independently and is the preferred speaker — see adele-tui#77).
 //!
 //! Building the embedded pipeline loads ONNX models (hundreds of MB), so it is
 //! done lazily on first use rather than at startup, and only when the mode is
 //! `embedded`.
 
 use std::sync::Arc;
+use std::time::Duration;
 
+use adele_voice_core::sentence_buffer::SentenceBuffer;
 use adele_voice_module::config::{AudioConfig, SttConfig, TtsConfig, VadConfig};
 use adele_voice_module::{Dictation, Speaker, TtsBackend, build_dictation, build_speaker};
 use adele_voice_stt_whisper::WhisperStt;
 use adele_voice_vad_silero::SileroVad;
 use serde::Deserialize;
 use tokio::sync::Mutex;
+
+/// Split `text` into the chunks that should be fed to a one-shot synthesizer.
+///
+/// Both the voice daemon's `SayText` and the embedded [`Speaker`] are
+/// **one-shot**: they assume a single short sentence and apply a per-synth
+/// timeout (`adele_voice_module`'s `DEFAULT_SYNTH_TIMEOUT`, ~20s). A long reply
+/// fed in one go would blow that timeout, so the *client* must chunk it the same
+/// way the daemon's streaming pipeline does — via [`SentenceBuffer`]. This is the
+/// TUI port of adele-gtk#80's `voice_embedded::into_speakable_sentences`; the
+/// chunking *algorithm* itself lives in the shared `adele-voice-core` crate.
+///
+/// This pushes the whole text through a `SentenceBuffer` (collecting every
+/// complete sentence) and then appends the trailing remainder from `flush()`
+/// (the last sentence has no trailing whitespace, so the buffer holds it back).
+/// If chunking yields nothing it falls back to a single chunk of the trimmed
+/// original when that text is non-blank, and to an empty `Vec` for
+/// empty/whitespace input (nothing to speak).
+///
+/// The timeout passed to the buffer is irrelevant here: this is a synchronous,
+/// one-shot push/flush with no streaming, so the time-based flush never fires.
+pub fn into_speakable_sentences(text: &str) -> Vec<String> {
+    // Timeout is unused on this synchronous push→flush path; any value works.
+    // STUB (failing-tests commit): chunking not yet implemented.
+    let _ = SentenceBuffer::new(Duration::from_millis(500));
+    Vec::new()
+}
 
 /// How the TUI sources voice. Defaults to [`VoiceMode::Off`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
@@ -55,11 +85,12 @@ pub enum VoiceMode {
 pub struct VoiceConfig {
     /// The capability toggle (`off` | `embedded` | `daemon`).
     pub mode: VoiceMode,
-    /// Seeds the per-conversation speech toggle's default (adele-tui#73). When
-    /// `true`, new conversations start with speech ON (so existing
-    /// `play_replies = true` users keep audio), but speech is now an in-app
-    /// per-conversation control (`Ctrl+S`), no longer a global always-on gate.
-    /// Only meaningful in `embedded` mode. Defaults `false` (speech off).
+    /// Accepted for config back-compat but no longer seeds any state
+    /// (adele-tui#77). The You/Adele model always starts each conversation at
+    /// `Adele = Disabled` (silent) and `You = Disabled`; voice output is an
+    /// explicit per-conversation choice (`Ctrl+S` cycles Adele), never
+    /// config-seeded. Retained only so an existing `play_replies = true` line
+    /// keeps parsing rather than erroring.
     pub play_replies: bool,
     pub audio: AudioConfig,
     pub vad: VadConfig,
@@ -226,5 +257,56 @@ mod tests {
         // Forward-compat: a newer config key shouldn't fail an older binary.
         let cfg: VoiceConfig = toml::from_str("mode = \"embedded\"\nfuture_knob = 42\n").unwrap();
         assert!(cfg.embedded_enabled());
+    }
+
+    // --- Sentence chunking (adele-tui#77) ---
+
+    /// A multi-sentence reply splits into one chunk per sentence, in order, so
+    /// no single synth call carries the whole paragraph past its ~20s timeout.
+    #[test]
+    fn chunks_multi_sentence_into_sentences() {
+        let chunks = into_speakable_sentences("Hello there. How are you? I am fine.");
+        assert_eq!(chunks, vec!["Hello there.", "How are you?", "I am fine."]);
+    }
+
+    /// A single sentence is one chunk.
+    #[test]
+    fn chunks_single_sentence_into_one() {
+        let chunks = into_speakable_sentences("Just one sentence here.");
+        assert_eq!(chunks, vec!["Just one sentence here."]);
+    }
+
+    /// Text with no trailing punctuation is still spoken — as one chunk (the
+    /// `flush()` tail), not dropped.
+    #[test]
+    fn chunks_text_without_terminal_punctuation_into_one() {
+        let chunks = into_speakable_sentences("no trailing punctuation here");
+        assert_eq!(chunks, vec!["no trailing punctuation here"]);
+    }
+
+    /// Empty / whitespace-only input has nothing to speak → no chunks (so the
+    /// caller makes zero synth calls rather than synthesizing silence).
+    #[test]
+    fn chunks_empty_or_whitespace_into_nothing() {
+        assert!(into_speakable_sentences("").is_empty());
+        assert!(into_speakable_sentences("   \n\t  ").is_empty());
+    }
+
+    /// A long multi-sentence paragraph splits into several chunks, each
+    /// non-empty (the whole point: keep each synth call short).
+    #[test]
+    fn chunks_long_paragraph_into_multiple() {
+        let paragraph = "The quick brown fox jumps over the lazy dog. \
+             It then trots away to find a quiet spot. \
+             Later, the dog wakes up and stretches lazily. \
+             Neither animal pays the other any further mind. \
+             The afternoon sun warms the empty field.";
+        let chunks = into_speakable_sentences(paragraph);
+        assert!(
+            chunks.len() >= 4,
+            "a five-sentence paragraph should split into several chunks, got {}: {chunks:?}",
+            chunks.len()
+        );
+        assert!(chunks.iter().all(|c| !c.trim().is_empty()));
     }
 }

--- a/src/voice_client.rs
+++ b/src/voice_client.rs
@@ -1,0 +1,219 @@
+//! Client for the standalone voice daemon (`org.desktopAssistant.Voice`).
+//!
+//! The voice daemon (`adelie-ai/voice`) is a **separate** D-Bus service from the
+//! orchestrator the rest of the TUI talks to: it owns the bus name
+//! `org.desktopAssistant.Voice` (distinct from `org.desktopAssistant`) and
+//! speaks its own typed interface. The TUI is just another client of it, so this
+//! module talks to it directly over zbus rather than through the orchestrator's
+//! transport. This is the TUI port of adele-gtk#80's `voice_client.rs`.
+//!
+//! Routing narration through the daemon reuses its already-warm TTS models +
+//! shared audio sink, which is far faster than the in-process embedded engine
+//! (the embedded `Speaker` re-loads models and is prone to the per-synth timeout
+//! on long replies). When the daemon is running it is the preferred speaker; the
+//! embedded engine is the fallback when it isn't.
+//!
+//! ## Graceful degradation
+//!
+//! When the daemon isn't running, the bus name has no owner. Each RPC then fails
+//! (zbus returns `ServiceUnknown`/`NameHasNoOwner`); callers treat that as
+//! "voice unavailable" and fall back rather than surfacing an error.
+//! [`VoiceController::is_available`] probes ownership with a cheap round-trip so
+//! the narration path can pick a backend per utterance.
+
+/// Where a push-to-talk turn should be routed.
+///
+/// The pure decision behind dictation: when the user has a conversation open,
+/// the spoken prompt and reply must land in *that* conversation
+/// (`PushToTalkInConversation(<id>)`); with nothing open we fall back to the
+/// daemon's own session (`PushToTalk()`). Kept as a standalone value so the
+/// routing can be unit-tested without a live bus.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PttRoute {
+    /// Dictate into this orchestrator conversation id.
+    InConversation(String),
+    /// No conversation open — use the daemon's own session.
+    DaemonSession,
+}
+
+impl PttRoute {
+    /// Decide the route from the active conversation id. A `Some` with a
+    /// **non-empty** id routes into that conversation; `None` *or* an
+    /// empty/whitespace id falls back to the daemon session (an empty id means
+    /// "daemon session" to the daemon anyway, so we normalise to the explicit
+    /// `PushToTalk()`).
+    pub fn for_conversation(active_conversation: Option<&str>) -> Self {
+        match active_conversation {
+            Some(id) if !id.trim().is_empty() => Self::InConversation(id.to_string()),
+            _ => Self::DaemonSession,
+        }
+    }
+}
+
+/// Typed zbus proxy for the voice daemon.
+///
+/// zbus derives each D-Bus method name by PascalCasing the Rust fn name, which
+/// matches the daemon's own interface (`get_state` → `GetState`,
+/// `push_to_talk` → `PushToTalk`, …), so no per-method `#[zbus(name = …)]`
+/// overrides are needed. Only the methods the TUI drives are declared.
+#[zbus::proxy(
+    interface = "org.desktopAssistant.Voice",
+    default_service = "org.desktopAssistant.Voice",
+    default_path = "/org/desktopAssistant/Voice"
+)]
+pub trait Voice {
+    /// Current pipeline state ("Idle" | "Listening" | "Processing" | "Speaking").
+    fn get_state(&self) -> zbus::Result<String>;
+
+    /// Start listening immediately (push-to-talk; works even with wake off).
+    /// The spoken turn lands in the daemon's own session.
+    fn push_to_talk(&self) -> zbus::Result<()>;
+
+    /// Push-to-talk routed into a specific orchestrator conversation, so the
+    /// spoken prompt and reply appear in the conversation the user is viewing.
+    /// An empty `conversation_id` falls back to the daemon's own session.
+    fn push_to_talk_in_conversation(&self, conversation_id: &str) -> zbus::Result<()>;
+
+    /// Speak `text` through the daemon's warm TTS Speaker + audio sink (maps to
+    /// `SayText`). The daemon's `Speaker` is one-shot and applies a per-synth
+    /// timeout, so callers must hand it **one short sentence at a time**.
+    fn say_text(&self, text: &str) -> zbus::Result<()>;
+
+    /// Stop any in-progress TTS playback (barge-in).
+    fn stop_speaking(&self) -> zbus::Result<()>;
+}
+
+/// Handle to the voice daemon.
+///
+/// Cheap to clone (an `Arc`-backed zbus proxy). A `None` proxy (connect failed
+/// entirely — e.g. no session bus) makes every call a graceful no-op /
+/// "unavailable".
+#[derive(Clone)]
+pub struct VoiceController {
+    /// `None` when even establishing the session-bus connection failed; the
+    /// controller is then inert and reports the service as unavailable.
+    proxy: Option<VoiceProxy<'static>>,
+}
+
+impl VoiceController {
+    /// Connect to the session bus and build the voice proxy. Returns a
+    /// controller whose proxy is `None` only when the bus connection itself
+    /// fails (rare — no session bus at all); a missing *daemon* still yields a
+    /// live proxy, with availability probed separately via
+    /// [`VoiceController::is_available`].
+    pub async fn connect() -> Self {
+        match zbus::Connection::session().await {
+            Ok(conn) => match VoiceProxy::new(&conn).await {
+                Ok(proxy) => Self { proxy: Some(proxy) },
+                Err(error) => {
+                    tracing::debug!(%error, "failed to build voice proxy; daemon narration off");
+                    Self::unavailable()
+                }
+            },
+            Err(error) => {
+                tracing::debug!(%error, "no session bus for voice; daemon narration off");
+                Self::unavailable()
+            }
+        }
+    }
+
+    /// An inert controller with no proxy. Every call is a graceful no-op and
+    /// [`VoiceController::is_available`] reports `false`.
+    pub fn unavailable() -> Self {
+        Self { proxy: None }
+    }
+
+    /// Whether the voice daemon currently owns its bus name. A `false` here is
+    /// normal (daemon not running / models unprovisioned) and must not be
+    /// treated as an error — the caller falls back to the embedded engine.
+    pub async fn is_available(&self) -> bool {
+        let Some(proxy) = &self.proxy else {
+            return false;
+        };
+        // A cheap round-trip that only succeeds when the name has an owner.
+        proxy.get_state().await.is_ok()
+    }
+
+    /// Speak `text` through the daemon's warm Speaker (maps to `SayText`). The
+    /// daemon's `Speaker` is **one-shot**, so the caller must hand this **one
+    /// short sentence at a time** (see
+    /// [`crate::voice::into_speakable_sentences`]).
+    pub async fn say(&self, text: &str) -> Result<(), String> {
+        let Some(proxy) = &self.proxy else {
+            return Err("voice service unavailable".to_string());
+        };
+        proxy.say_text(text).await.map_err(|e| e.to_string())
+    }
+
+    /// Stop any in-progress TTS playback (barge-in).
+    pub async fn stop_speaking(&self) -> Result<(), String> {
+        let Some(proxy) = &self.proxy else {
+            return Err("voice service unavailable".to_string());
+        };
+        proxy.stop_speaking().await.map_err(|e| e.to_string())
+    }
+
+    /// Dispatch a push-to-talk turn according to [`PttRoute::for_conversation`]:
+    /// into the active conversation when one is open, else the daemon session.
+    /// The routing decision itself is the pure [`PttRoute`] so it is unit-tested
+    /// without a bus.
+    pub async fn push_to_talk_routed(
+        &self,
+        active_conversation: Option<&str>,
+    ) -> Result<(), String> {
+        let Some(proxy) = &self.proxy else {
+            return Err("voice service unavailable".to_string());
+        };
+        let result = match PttRoute::for_conversation(active_conversation) {
+            PttRoute::InConversation(id) => proxy.push_to_talk_in_conversation(&id).await,
+            PttRoute::DaemonSession => proxy.push_to_talk().await,
+        };
+        result.map_err(|e| e.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ptt_routes_into_the_active_conversation() {
+        assert_eq!(
+            PttRoute::for_conversation(Some("conv-123")),
+            PttRoute::InConversation("conv-123".to_string())
+        );
+    }
+
+    #[test]
+    fn ptt_falls_back_to_daemon_session_with_no_conversation() {
+        assert_eq!(PttRoute::for_conversation(None), PttRoute::DaemonSession);
+    }
+
+    #[test]
+    fn ptt_treats_empty_conversation_id_as_no_conversation() {
+        // An empty/whitespace id must not be sent as a "real" conversation; it
+        // normalises to the daemon session (which is also how the daemon reads
+        // an empty id), so the explicit PushToTalk() is issued.
+        assert_eq!(
+            PttRoute::for_conversation(Some("")),
+            PttRoute::DaemonSession
+        );
+        assert_eq!(
+            PttRoute::for_conversation(Some("   ")),
+            PttRoute::DaemonSession
+        );
+    }
+
+    /// An inert controller (no proxy) reports unavailable and every RPC is a
+    /// graceful `Err`, never a panic — the narration path then falls back to the
+    /// embedded engine.
+    #[tokio::test]
+    async fn unavailable_controller_is_inert() {
+        let controller = VoiceController::unavailable();
+        assert!(!controller.is_available().await);
+        assert!(controller.say("hello").await.is_err());
+        assert!(controller.stop_speaking().await.is_err());
+        assert!(controller.push_to_talk_routed(Some("c1")).await.is_err());
+        assert!(controller.push_to_talk_routed(None).await.is_err());
+    }
+}


### PR DESCRIPTION
Closes #77

Brings the TUI's voice controls to parity with the live-validated **adele-gtk#80** (`You`/`Adele` model + daemon-routed, sentence-chunked narration), adapted to a terminal UI. Replaces the deployed phase-1/2 (`speech_enabled` read-aloud + `voice_mode` soft-sticky, `Ctrl+S`/`Ctrl+V`, the `play_replies` seed).

## What replaced phase-1/2
Two independent **per-conversation** controls (text input always available):
- **You** (voice input): `Disabled` (type only) | `Enabled` (push-to-talk). Default Disabled.
- **Adele** (voice output): `Disabled` | `On Demand` | `Always`. Default Disabled.

State: `App::voice_in: HashMap<String,bool>` + `App::adele_output: HashMap<String, AdeleOutput>` (`enum AdeleOutput{Disabled,OnDemand,Always}`), replacing the old maps/`speech_default`. Pure, testable gate methods mirror gtk:
- **Narration gate** (`narrate_for`): spoken iff `Adele==Always` OR (`Adele==OnDemand` AND `You==Enabled`).
- **say_this aside gate** (`say_this_spoken_for`): spoken iff `Adele ∈ {OnDemand, Always}`, else inline `(speech mode disabled) <text>`.

## Daemon proxy port
The TUI had **no** `org.desktopAssistant.Voice` proxy (only the in-process `voice.rs` Speaker/Dictation). Ported gtk's `voice_client.rs` to a new **`src/voice_client.rs`**: `#[zbus::proxy] VoiceProxy` (`say_text`→`SayText`, `push_to_talk`, `push_to_talk_in_conversation`, `stop_speaking`, `get_state`) + `VoiceController::{connect, unavailable, is_available, say, stop_speaking, push_to_talk_routed}` + the pure `PttRoute`. Added `zbus` + `adele-voice-core` to `Cargo.toml`.

## Daemon-first chunked narration
`voice::into_speakable_sentences` (ported from gtk's `voice_embedded.rs`; reuses the shared `adele_voice_core::sentence_buffer::SentenceBuffer`) splits the reply into sentences. `main::speak_text` picks **one** backend per utterance — daemon when `is_available().await`, else the embedded `Speaker` — and awaits each sentence **in order**, so a long reply never trips the ~20s one-shot synth timeout. Both reply narration and `say_this` asides route through it. Push-to-talk (`Ctrl+G`, when the daemon is up) uses the daemon's dictation routed into the active conversation (`push_to_talk_routed`), with a `stop_speaking` barge-in first; otherwise it falls back to the embedded one-shot capture.

## Keybinds (replaced Ctrl+S/Ctrl+V)
- **Ctrl+S** cycles `Adele`: `Disabled → On Demand → Always → Disabled` (`CycleAdeleOutput`).
- **Ctrl+V** toggles `You`: `Disabled ↔ Enabled` (`ToggleVoiceIn`).
- Both reachable in Normal + Editing, forwarded to the textarea in Renaming. Chat-title cues show both states (`🔊 Adele: <level>` when not Disabled; `🎙 You: Enabled`).

## Refinement strings (send-time `system_refinement`)
- `On Demand` → brief/conversational/speakable (`ON_DEMAND_SYSTEM_REFINEMENT`).
- `Always` → speakable-but-**full**, explicitly NOT shortened (`ALWAYS_SYSTEM_REFINEMENT`).
- `Disabled` → none.

`request_voice` → `Adele=OnDemand`, `stop_voice` → `Adele=Disabled` (via `ToolEffect::SetAdeleOutput`); both always return a `ClientToolResult`. Registered on every connect/reconnect.

## Tests
TDD: failing tests committed first (`55382aa`, stubbed seams), implementation second (`53f3f65`). New/updated named tests via the pure seams:
- **app.rs**: `adele_output_next_cycles_disabled_on_demand_always`, `defaults_are_you_disabled_and_adele_disabled_silent`, `adele_always_narrates_regardless_of_you`, `adele_on_demand_narrates_only_when_you_enabled`, `adele_disabled_never_narrates_and_say_this_goes_inline`, `toggle_current_voice_in_*`, `cycle_current_adele_output_*`, `set_adele_output_targets_an_explicit_conversation`, `voice_controls_are_per_conversation_isolated`, `current_narrate_is_false_without_a_conversation`, `push_speech_disabled_note_*`.
- **client_tools.rs**: `request_voice_sets_adele_on_demand_with_a_result`, `stop_voice_sets_adele_disabled_with_a_result`, `dispatch_routes_{request,stop}_voice`, `request_voice_with_malformed_args_still_returns_a_result_no_panic`, `say_this_{speaks_when_aside_is_spoken,shows_inline_when_adele_disabled,missing_text_is_an_error_not_a_panic,non_object_payload_is_an_error_not_a_panic}`, `dispatch_unknown_tool_returns_error_result_so_turn_resumes`.
- **keys.rs**: `ctrl_s_cycles_adele_output_in_{normal,editing}`, `ctrl_s_is_not_intercepted_in_renaming`, `ctrl_v_toggles_voice_in_in_{normal,editing}`, `ctrl_v_is_not_intercepted_in_renaming`.
- **voice.rs**: `chunks_{multi_sentence_into_sentences,single_sentence_into_one,text_without_terminal_punctuation_into_one,empty_or_whitespace_into_nothing,long_paragraph_into_multiple}`.
- **voice_client.rs**: `ptt_routes_into_the_active_conversation`, `ptt_falls_back_to_daemon_session_with_no_conversation`, `ptt_treats_empty_conversation_id_as_no_conversation`, `unavailable_controller_is_inert`.
- **ui.rs**: `draw_shows_adele_cue_only_when_not_disabled`, `draw_shows_you_cue_only_when_enabled`.

Counts: **312 lib + 338 bin = 650 tests pass**, 1 pre-existing ignored, 0 failures. No existing tests regressed.

## Gates
- `cargo build`, `cargo test`, `cargo clippy --all-targets -- -D warnings` all clean. No broad `#[allow]`.
- `cargo fmt --check` clean (changed files formatted with `rustfmt --edition 2024`). No pre-push hook in this worktree, so `--no-verify` was not needed.

## Security self-review
- **No panic on malformed args**: `say_this` non-object/missing/non-string `text` → `Err` result (turn resumes); `request_voice`/`stop_voice` ignore args entirely. Covered by tests.
- **No audio while gate false**: narration is gated entirely at the `current_narrate()` check before any `Speak`; `Adele=Disabled` never produces a `Speak` effect (`say_this` → inline). `speak_text` no-ops on empty/blank and when no backend is present.
- **No cross-conversation bleed**: gates key on the call's own `conversation_id`; `push_speech_disabled_note` only writes to the open conversation; per-conversation isolation tested.
- **Result always submitted**: `submit_client_tool_result` runs unconditionally after the effect match, so a parked turn always resumes.
- **Refinement never in transcript**: passed only as `system_refinement` on send; only the user prompt + assistant reply are pushed to `messages`.

## Needs live audio QA
- Daemon-first narration with `org.desktopAssistant.Voice` running: long multi-sentence reply streams in order without the 20s synth timeout; `Always` reads in full, `On Demand` is brief.
- `Ctrl+G` push-to-talk routed into the active conversation via the daemon, with barge-in stopping in-progress narration.
- Embedded fallback (`voice.toml` `mode = "embedded"`, daemon off) still narrates/dictates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)