### PR TITLE
Review 2026-06-09: terminal lifecycle (TUI-1/3/9) + send-path integrity (TUI-2/7)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -503,8 +503,23 @@ impl App {
     /// `SubmitPrompt` per line (the pre-bracketed-paste failure mode). The
     /// rename input is single-line, so newlines collapse to spaces there.
     /// Normal mode has no focused input; the paste is ignored.
-    pub fn apply_paste(&mut self, _text: &str) {
-        // Stubbed pending TUI-3 implementation.
+    pub fn apply_paste(&mut self, text: &str) {
+        match self.mode {
+            InputMode::Editing => {
+                // `insert_str` splits on '\n' and strips a trailing '\r' per
+                // line, so CRLF pastes normalize to real composer lines.
+                self.textarea.insert_str(text);
+            }
+            InputMode::Renaming => {
+                let single_line = text
+                    .split(['\n', '\r'])
+                    .filter(|piece| !piece.is_empty())
+                    .collect::<Vec<_>>()
+                    .join(" ");
+                self.rename_textarea.insert_str(single_line);
+            }
+            InputMode::Normal => {}
+        }
     }
 
     /// Hard-wrap textarea lines to fit the available editor width.

--- a/src/app.rs
+++ b/src/app.rs
@@ -497,6 +497,16 @@ impl App {
         Some((conv.id.clone(), content))
     }
 
+    /// Apply a bracketed paste (TUI-3 / `Event::Paste`) to whichever input is
+    /// focused. Pasted text is inserted **verbatim** into the composer — each
+    /// newline becomes a real line of the prompt instead of firing
+    /// `SubmitPrompt` per line (the pre-bracketed-paste failure mode). The
+    /// rename input is single-line, so newlines collapse to spaces there.
+    /// Normal mode has no focused input; the paste is ignored.
+    pub fn apply_paste(&mut self, _text: &str) {
+        // Stubbed pending TUI-3 implementation.
+    }
+
     /// Hard-wrap textarea lines to fit the available editor width.
     ///
     /// This gives the TUI composer word-wrap behavior even though the backing
@@ -979,6 +989,68 @@ mod tests {
         assert_eq!(msgs.len(), 1);
         assert_eq!(msgs[0].role, "user");
         assert_eq!(msgs[0].content, "What is Rust?");
+    }
+
+    // --- Bracketed paste (TUI-3) ---
+
+    #[test]
+    fn paste_in_editing_inserts_multiline_text_verbatim() {
+        // Acceptance: a multi-line paste lands in the composer as-is — no
+        // per-newline submit, no dropped lines.
+        let mut app = App::new();
+        app.enter_editing_mode();
+        app.apply_paste("line one\nline two\nline three");
+        assert_eq!(app.textarea_content(), "line one\nline two\nline three");
+    }
+
+    #[test]
+    fn paste_in_editing_normalizes_crlf_to_lf() {
+        let mut app = App::new();
+        app.enter_editing_mode();
+        app.apply_paste("alpha\r\nbeta");
+        assert_eq!(app.textarea_content(), "alpha\nbeta");
+    }
+
+    #[test]
+    fn paste_then_submit_sends_one_prompt_containing_the_newlines() {
+        // Acceptance (TUI-3): a 3-line paste yields ONE submitted prompt with
+        // the newlines intact, not three partial prompts.
+        let mut app = App::new();
+        app.current_conversation = Some(ConversationDetail {
+            id: "c1".into(),
+            title: "Test".into(),
+            messages: vec![],
+            model_selection: None,
+            conversation_personality: None,
+        });
+        app.enter_editing_mode();
+        app.apply_paste("first\nsecond\nthird");
+        let result = app.submit_prompt();
+        assert_eq!(
+            result,
+            Some(("c1".to_string(), "first\nsecond\nthird".to_string()))
+        );
+        let msgs = &app.current_conversation.as_ref().unwrap().messages;
+        assert_eq!(msgs.len(), 1, "exactly one user message appended");
+    }
+
+    #[test]
+    fn paste_in_renaming_collapses_newlines_to_spaces() {
+        // The rename input is single-line; a pasted title with newlines must
+        // not create phantom lines.
+        let mut app = app_with_conversations();
+        app.selected_conversation = Some(0);
+        app.begin_rename();
+        app.rename_textarea = TextArea::default();
+        app.apply_paste("New\nTitle");
+        assert_eq!(app.rename_textarea.lines().join(""), "New Title");
+    }
+
+    #[test]
+    fn paste_in_normal_mode_is_ignored() {
+        let mut app = App::new();
+        app.apply_paste("stray paste");
+        assert_eq!(app.textarea_content(), "");
     }
 
     // --- Streaming tests ---

--- a/src/app.rs
+++ b/src/app.rs
@@ -481,6 +481,35 @@ impl App {
         self.textarea.lines().join("\n")
     }
 
+    /// Gate + mutate for a prompt submission (TUI-2 / TUI-7). Checks the
+    /// preconditions BEFORE touching any state, so a refused submission leaves
+    /// the composer and transcript untouched:
+    ///
+    /// * not connected → refuse with a status message (TUI-2: previously the
+    ///   message was appended to the transcript and the composer cleared, then
+    ///   silently never sent);
+    /// * a reply is still streaming (`pending_request_id` is claimed or the
+    ///   ack sentinel) → refuse with a status message (TUI-7 policy: **block
+    ///   concurrent sends**. The TUI renders a single streaming buffer for the
+    ///   open conversation; interleaving a second stream would cross-wire the
+    ///   request-id claim and drop one reply. Blocking keeps the composer text
+    ///   so nothing is lost — the user sends again once the reply lands).
+    ///
+    /// Only when both gates pass does it delegate to [`App::submit_prompt`].
+    pub fn prepare_submission(&mut self, _connected: bool) -> Option<(String, String)> {
+        // Stubbed pending TUI-2/TUI-7 implementation.
+        self.submit_prompt()
+    }
+
+    /// Roll back a submission whose send RPC failed (TUI-2): remove the
+    /// optimistically appended user message (only when the originating
+    /// conversation is still open and the tail message matches) and put the
+    /// prompt text back into the composer so the user can retry without
+    /// retyping. The caller sets the status message with the send error.
+    pub fn restore_failed_submission(&mut self, _conversation_id: &str, _prompt: &str) {
+        // Stubbed pending TUI-2 implementation.
+    }
+
     /// Returns (conversation_id, prompt) if valid, None otherwise.
     pub fn submit_prompt(&mut self) -> Option<(String, String)> {
         let content = self.textarea_content();
@@ -1066,6 +1095,166 @@ mod tests {
         let mut app = App::new();
         app.apply_paste("stray paste");
         assert_eq!(app.textarea_content(), "");
+    }
+
+    // --- Send-path integrity (TUI-2 / TUI-7) ---
+
+    fn app_ready_to_send(conv_id: &str, prompt: &str) -> App {
+        let mut app = App::new();
+        app.current_conversation = Some(ConversationDetail {
+            id: conv_id.into(),
+            title: "Test".into(),
+            messages: vec![],
+            model_selection: None,
+            conversation_personality: None,
+        });
+        app.enter_editing_mode();
+        app.textarea.insert_str(prompt);
+        app
+    }
+
+    #[test]
+    fn submit_while_disconnected_preserves_composer_and_appends_nothing() {
+        // Acceptance (TUI-2): disconnected submit → composer text preserved,
+        // status message set, nothing appended to the transcript.
+        let mut app = app_ready_to_send("c1", "important prompt");
+        app.status_message.clear();
+
+        let result = app.prepare_submission(false);
+
+        assert!(result.is_none(), "nothing must be sent while disconnected");
+        assert_eq!(
+            app.textarea_content(),
+            "important prompt",
+            "composer text must be preserved"
+        );
+        assert!(
+            app.current_conversation
+                .as_ref()
+                .unwrap()
+                .messages
+                .is_empty(),
+            "transcript must not gain a user message"
+        );
+        assert!(
+            !app.status_message.is_empty(),
+            "the refusal must be surfaced in the status line"
+        );
+    }
+
+    #[test]
+    fn submit_while_streaming_is_blocked_and_composer_preserved() {
+        // Acceptance (TUI-7, chosen policy = block concurrent sends): a second
+        // send while a reply streams is refused with a status message and the
+        // composer keeps its text.
+        let mut app = app_ready_to_send("c1", "second question");
+        app.start_streaming("req-in-flight".into());
+        app.status_message.clear();
+
+        let result = app.prepare_submission(true);
+
+        assert!(result.is_none(), "second send must be blocked mid-stream");
+        assert_eq!(app.textarea_content(), "second question");
+        assert!(
+            app.current_conversation
+                .as_ref()
+                .unwrap()
+                .messages
+                .is_empty()
+        );
+        assert!(!app.status_message.is_empty());
+    }
+
+    #[test]
+    fn submit_while_awaiting_ack_sentinel_is_also_blocked() {
+        // Unhappy path: the window between send and the first chunk uses the
+        // pending sentinel; a send in that window must be blocked too.
+        let mut app = app_ready_to_send("c1", "rapid second send");
+        app.start_streaming_without_request_id();
+
+        assert!(app.prepare_submission(true).is_none());
+        assert_eq!(app.textarea_content(), "rapid second send");
+    }
+
+    #[test]
+    fn submit_when_connected_and_idle_goes_through() {
+        let mut app = app_ready_to_send("c1", "hello");
+        let result = app.prepare_submission(true);
+        assert_eq!(result, Some(("c1".to_string(), "hello".to_string())));
+        assert_eq!(app.textarea_content(), "");
+        assert_eq!(app.current_conversation.as_ref().unwrap().messages.len(), 1);
+    }
+
+    #[test]
+    fn restore_failed_submission_pops_message_and_refills_composer() {
+        // Acceptance (TUI-2): a failed send RPC rolls back the optimistic
+        // transcript append and puts the prompt back in the composer.
+        let mut app = app_ready_to_send("c1", "doomed prompt");
+        let (conv_id, prompt) = app.prepare_submission(true).unwrap();
+
+        app.restore_failed_submission(&conv_id, &prompt);
+
+        assert!(
+            app.current_conversation
+                .as_ref()
+                .unwrap()
+                .messages
+                .is_empty(),
+            "optimistic user message must be rolled back"
+        );
+        assert_eq!(app.textarea_content(), "doomed prompt");
+    }
+
+    #[test]
+    fn restore_failed_submission_after_switching_conversations_keeps_other_transcript() {
+        // Unhappy path: the user switched conversations between submit and the
+        // send failure. The other conversation's tail message must NOT be
+        // popped; the composer still gets the text back.
+        let mut app = app_ready_to_send("c1", "prompt for c1");
+        let (conv_id, prompt) = app.prepare_submission(true).unwrap();
+
+        // Switch to a different conversation that already has a user message.
+        app.load_conversation(ConversationDetail {
+            id: "c2".into(),
+            title: "Other".into(),
+            messages: vec![ChatMessage {
+                role: "user".into(),
+                content: "prompt for c1".into(), // same text, different conv
+            }],
+            model_selection: None,
+            conversation_personality: None,
+        });
+
+        app.restore_failed_submission(&conv_id, &prompt);
+
+        assert_eq!(
+            app.current_conversation.as_ref().unwrap().messages.len(),
+            1,
+            "the other conversation's transcript must be untouched"
+        );
+        assert_eq!(app.textarea_content(), "prompt for c1");
+    }
+
+    #[test]
+    fn restore_failed_submission_does_not_pop_a_non_matching_tail() {
+        // Unhappy path: something else (e.g. an inline note) landed after the
+        // optimistic append; only an exact matching tail is rolled back.
+        let mut app = app_ready_to_send("c1", "prompt");
+        let (conv_id, prompt) = app.prepare_submission(true).unwrap();
+        app.current_conversation
+            .as_mut()
+            .unwrap()
+            .messages
+            .push(ChatMessage {
+                role: "assistant".into(),
+                content: "(speech mode disabled) aside".into(),
+            });
+
+        app.restore_failed_submission(&conv_id, &prompt);
+
+        let msgs = &app.current_conversation.as_ref().unwrap().messages;
+        assert_eq!(msgs.len(), 2, "non-matching tail must not be popped");
+        assert_eq!(app.textarea_content(), "prompt");
     }
 
     // --- Streaming tests ---

--- a/src/app.rs
+++ b/src/app.rs
@@ -496,8 +496,18 @@ impl App {
     ///   so nothing is lost — the user sends again once the reply lands).
     ///
     /// Only when both gates pass does it delegate to [`App::submit_prompt`].
-    pub fn prepare_submission(&mut self, _connected: bool) -> Option<(String, String)> {
-        // Stubbed pending TUI-2/TUI-7 implementation.
+    pub fn prepare_submission(&mut self, connected: bool) -> Option<(String, String)> {
+        if !connected {
+            self.status_message =
+                "Not connected — message not sent (your text is preserved)".into();
+            return None;
+        }
+        if self.pending_request_id.is_some() {
+            self.status_message =
+                "A reply is still streaming — wait for it to finish (your text is preserved)"
+                    .into();
+            return None;
+        }
         self.submit_prompt()
     }
 
@@ -506,8 +516,20 @@ impl App {
     /// conversation is still open and the tail message matches) and put the
     /// prompt text back into the composer so the user can retry without
     /// retyping. The caller sets the status message with the send error.
-    pub fn restore_failed_submission(&mut self, _conversation_id: &str, _prompt: &str) {
-        // Stubbed pending TUI-2 implementation.
+    pub fn restore_failed_submission(&mut self, conversation_id: &str, prompt: &str) {
+        if let Some(conv) = self
+            .current_conversation
+            .as_mut()
+            .filter(|c| c.id == conversation_id)
+            && conv
+                .messages
+                .last()
+                .is_some_and(|m| m.role == "user" && m.content == prompt)
+        {
+            conv.messages.pop();
+        }
+        self.textarea = new_textarea();
+        self.textarea.insert_str(prompt);
     }
 
     /// Returns (conversation_id, prompt) if valid, None otherwise.

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,6 +154,22 @@ impl From<CliArgs> for ConnectionConfig {
     }
 }
 
+/// Best-effort terminal restoration (TUI-1): undo everything `main`'s setup
+/// pushed — raw mode, the kitty keyboard-enhancement flags, the alternate
+/// screen, and bracketed paste — and re-show the cursor. Every step is
+/// `let _ =` because this runs on panic/exit paths where some state may
+/// already be gone; restoring as much as possible beats bailing early.
+fn restore_terminal() {
+    // Stubbed pending TUI-1 implementation.
+}
+
+/// Install a panic hook that restores the terminal before delegating to the
+/// previously installed hook (TUI-1), so a panic prints its message onto a
+/// usable screen instead of a raw-mode alternate-screen mess.
+fn install_panic_hook() {
+    // Stubbed pending TUI-1 implementation.
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Both `ring` and `aws-lc-rs` end up enabled in rustls because reqwest 0.12
@@ -1437,6 +1453,34 @@ mod tests {
         let rendered = error.to_string();
         assert!(rendered.contains("ws"));
         assert!(rendered.contains("dbus"));
+    }
+
+    // --- Panic hook (TUI-1) ---
+
+    #[test]
+    fn panic_hook_chains_the_previously_installed_hook() {
+        // Acceptance: installing our hook must not swallow the previous one —
+        // the default hook's backtrace/message printing has to still run after
+        // the terminal is restored.
+        use std::sync::atomic::{AtomicBool, Ordering};
+        static PREV_CALLED: AtomicBool = AtomicBool::new(false);
+
+        let original = std::panic::take_hook();
+        std::panic::set_hook(Box::new(|_| PREV_CALLED.store(true, Ordering::SeqCst)));
+        install_panic_hook();
+
+        let result = std::panic::catch_unwind(|| panic!("deliberate test panic"));
+        assert!(result.is_err());
+
+        // Put the original hook back before asserting so a failure here
+        // doesn't leave the silent test hook installed for other tests.
+        let _ = std::panic::take_hook();
+        std::panic::set_hook(original);
+
+        assert!(
+            PREV_CALLED.load(Ordering::SeqCst),
+            "previous panic hook must be chained, not replaced"
+        );
     }
 
     // --- Reconnect backoff tests ---

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ use anyhow::Result;
 use clap::{CommandFactory, FromArgMatches, Parser, parser::ValueSource};
 use crossterm::{
     event::{
-        DisableMouseCapture, EnableMouseCapture, Event, KeyEventKind, KeyboardEnhancementFlags,
+        DisableBracketedPaste, EnableBracketedPaste, Event, KeyEventKind, KeyboardEnhancementFlags,
         PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
     },
     execute,
@@ -160,14 +160,28 @@ impl From<CliArgs> for ConnectionConfig {
 /// `let _ =` because this runs on panic/exit paths where some state may
 /// already be gone; restoring as much as possible beats bailing early.
 fn restore_terminal() {
-    // Stubbed pending TUI-1 implementation.
+    let mut stdout = io::stdout();
+    let _ = disable_raw_mode();
+    // Pop the kitty flags first (pushed last); harmless if the terminal never
+    // accepted the push.
+    let _ = execute!(stdout, PopKeyboardEnhancementFlags);
+    let _ = execute!(
+        stdout,
+        DisableBracketedPaste,
+        LeaveAlternateScreen,
+        crossterm::cursor::Show
+    );
 }
 
 /// Install a panic hook that restores the terminal before delegating to the
 /// previously installed hook (TUI-1), so a panic prints its message onto a
 /// usable screen instead of a raw-mode alternate-screen mess.
 fn install_panic_hook() {
-    // Stubbed pending TUI-1 implementation.
+    let previous = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        restore_terminal();
+        previous(info);
+    }));
 }
 
 #[tokio::main]
@@ -185,9 +199,18 @@ async fn main() -> Result<()> {
     let cli = CliArgs::from_arg_matches(&matches)?;
     let cli_explicit = any_explicit_connection_arg(&matches);
 
+    // Restore the terminal on panic BEFORE any state is pushed, chaining the
+    // default hook so the panic message lands on a usable screen (TUI-1).
+    install_panic_hook();
+
     enable_raw_mode()?;
     let mut stdout = io::stdout();
-    execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+    // Mouse capture is deliberately NOT enabled (TUI-9): the TUI handles no
+    // mouse events, and capturing them hijacks the terminal's native text
+    // selection/copy and scrollback. Keyboard scrolling (Ctrl+U/D/E,
+    // PageUp/Down) covers navigation. Bracketed paste keeps a multi-line
+    // paste as ONE Event::Paste instead of a stream of per-line Enters (TUI-3).
+    execute!(stdout, EnterAlternateScreen, EnableBracketedPaste)?;
     let _ = execute!(
         stdout,
         PushKeyboardEnhancementFlags(
@@ -202,14 +225,8 @@ async fn main() -> Result<()> {
 
     let result = run_app(&mut terminal, cli, cli_explicit).await;
 
-    // Restore terminal
-    disable_raw_mode()?;
-    let _ = execute!(terminal.backend_mut(), PopKeyboardEnhancementFlags);
-    execute!(
-        terminal.backend_mut(),
-        LeaveAlternateScreen,
-        DisableMouseCapture
-    )?;
+    // Restore terminal (same best-effort path the panic hook uses).
+    restore_terminal();
     terminal.show_cursor()?;
 
     result
@@ -519,6 +536,14 @@ async fn run(
 
         tokio::select! {
             Some(Ok(evt)) = event_stream.next() => {
+                // Bracketed paste (TUI-3): the whole paste arrives as one
+                // event and goes verbatim into the focused input — never
+                // through the key map, so embedded newlines can't fire
+                // SubmitPrompt per line.
+                if let Event::Paste(text) = &evt {
+                    app.apply_paste(text);
+                    continue;
+                }
                 if let Event::Key(key) = evt {
                     if key.kind == KeyEventKind::Release {
                         continue;

--- a/src/main.rs
+++ b/src/main.rs
@@ -813,11 +813,22 @@ async fn handle_action(app: &mut App, connector: &Option<Connector>, action: Act
             }
         }
         Action::DeleteConversation => {
+            // Check connectivity BEFORE mutating local state (TUI-2's shape):
+            // previously the row vanished locally while the daemon never heard
+            // about the delete, resurrecting it on the next refresh.
+            let Some(client) = client else {
+                app.status_message = "Not connected — conversation not deleted".into();
+                return;
+            };
             if let Some(id) = app.delete_selected_conversation()
-                && let Some(client) = client
                 && let Err(e) = client.delete_conversation(&id).await
             {
                 app.status_message = format!("Delete error: {e}");
+                // Resync the sidebar with the daemon so the optimistic local
+                // removal doesn't linger after a failed delete.
+                if let Ok(convs) = fetch_conversations(client, app.show_archived).await {
+                    app.set_conversations(convs);
+                }
             }
         }
         Action::NewConversation => {
@@ -1281,8 +1292,13 @@ fn insert_dictated_text(app: &mut App, text: &str) {
 /// transport. Shared by the keyboard submit (`Enter`) and the dictation path
 /// (which appends a transcript to the input, then submits via the same route),
 /// so both honor the staged model override and the same ack handling.
+///
+/// The connected/streaming gates run BEFORE any state mutation
+/// (`App::prepare_submission`, TUI-2/TUI-7), and a failed send RPC rolls the
+/// optimistic transcript append back and refills the composer
+/// (`App::restore_failed_submission`).
 async fn send_prompt_from_input(app: &mut App, connector: &Option<Connector>) {
-    if let Some((conv_id, prompt)) = app.submit_prompt()
+    if let Some((conv_id, prompt)) = app.prepare_submission(connector.is_some())
         && let Some(connector) = connector.as_ref()
     {
         let client = connector.client();
@@ -1320,7 +1336,10 @@ async fn send_prompt_from_input(app: &mut App, connector: &Option<Connector>) {
         };
         match result {
             Ok(task_id) => app.apply_prompt_ack(task_id),
-            Err(e) => app.status_message = format!("Send error: {e}"),
+            Err(e) => {
+                app.restore_failed_submission(&conv_id, &prompt);
+                app.status_message = format!("Send error: {e} (your text is preserved)");
+            }
         }
     }
 }


### PR DESCRIPTION
Two TDD batches from CODE_REVIEW_2026-06-09 §6 (failing tests committed first in each batch).

## Terminal lifecycle
- **TUI-1 — panic hook**: `install_panic_hook()` restores raw mode / kitty flags / alt screen / bracketed paste / cursor, then chains the previous hook so the panic message prints on a usable screen. The normal exit path reuses the same `restore_terminal()`.
- **TUI-3 — bracketed paste**: `EnableBracketedPaste` + an `Event::Paste` arm; the whole paste goes verbatim into the focused input (`App::apply_paste`), so embedded newlines no longer fire `SubmitPrompt` per line. CRLF normalizes; the single-line rename input collapses newlines to spaces; Normal mode ignores pastes.
- **TUI-9 — mouse capture dropped** (chosen design): the TUI handles no mouse events, and capture hijacked native selection/copy and scrollback. Keyboard scrolling (Ctrl+U/D/E, PageUp/Down) covers navigation; ScrollUp/Down mapping can be added later without re-capturing.

## Send-path integrity
- **TUI-2 — check before mutate**: `App::prepare_submission(connected)` gates BEFORE touching state — disconnected submits refuse with a status message, composer and transcript untouched; a failed send RPC rolls back the optimistic transcript append and refills the composer (`restore_failed_submission`). `DeleteConversation` gets the same shape (connectivity gate + resync on failed delete).
- **TUI-7 — concurrent sends blocked** (chosen policy): a second send while `pending_request_id` is set (claimed id or the ack sentinel) is refused with a status message, composer preserved. Blocking is the safe policy for a single-streaming-buffer UI; per-conversation stream keying can lift it later.

Tests: 14 new (panic-hook chaining, paste happy/CRLF/rename/normal-mode/submit-once, disconnected & mid-stream & sentinel-window submits, failed-send rollback incl. switched-conversation and non-matching-tail unhappy paths).

Gate: `just check` green (fmt, clippy -D warnings, build, 351 tests).

Closes #79
Closes #80
Closes #81
Closes #85
Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)