### PR TITLE
Review 2026-06-09: the stream knows its conversation (TUI-4/8/10) + single narration queue (TUI-11)

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -120,6 +120,10 @@ pub struct App {
     pub textarea: TextArea<'static>,
     pub streaming_buffer: String,
     pub pending_request_id: Option<String>,
+    /// The conversation the in-flight stream was sent to (TUI-4). `Some` iff
+    /// `pending_request_id` is `Some`. Completion appends to — and narration
+    /// gates on — THIS conversation, not whichever one is open at the time.
+    pub streaming_conversation_id: Option<String>,
     pub mode: InputMode,
     pub status_message: String,
     pub should_quit: bool,
@@ -201,6 +205,7 @@ impl App {
             textarea: new_textarea(),
             streaming_buffer: String::new(),
             pending_request_id: None,
+            streaming_conversation_id: None,
             mode: InputMode::Normal,
             status_message: "Connected".to_string(),
             should_quit: false,
@@ -639,17 +644,24 @@ impl App {
     }
 
     // --- Streaming ---
+    //
+    // The stream knows its conversation (TUI-4): `start_streaming` records the
+    // conversation the prompt was sent to, and completion/rendering/narration
+    // all target THAT conversation rather than whichever one is open when the
+    // event arrives.
 
-    pub fn start_streaming(&mut self, request_id: String) {
+    pub fn start_streaming(&mut self, request_id: String, conversation_id: String) {
         self.pending_request_id = Some(request_id);
+        self.streaming_conversation_id = Some(conversation_id);
         self.streaming_buffer.clear();
     }
 
-    pub fn start_streaming_without_request_id(&mut self) {
-        self.start_streaming(Self::PENDING_STREAM_REQUEST_ID.to_string());
+    pub fn start_streaming_without_request_id(&mut self, conversation_id: String) {
+        self.start_streaming(Self::PENDING_STREAM_REQUEST_ID.to_string(), conversation_id);
     }
 
-    /// Apply the result of a `send_prompt` ack from the daemon.
+    /// Apply the result of a `send_prompt` ack from the daemon, recording the
+    /// conversation the prompt targeted (TUI-4).
     ///
     /// The wire value is either a `task_id` (post-desktop-assistant #114
     /// `SendMessageAck`) or an empty string (legacy `Ack`). Neither is the
@@ -657,8 +669,31 @@ impl App {
     /// embedded in the first `AssistantDelta`. We therefore ignore the
     /// ack payload and seed the sentinel; the first chunk claims it via
     /// `stream_matches_or_claims_request_id`. See issue #52.
-    pub fn apply_prompt_ack(&mut self, _task_id: String) {
-        self.start_streaming_without_request_id();
+    pub fn apply_prompt_ack(&mut self, _task_id: String, conversation_id: String) {
+        self.start_streaming_without_request_id(conversation_id);
+    }
+
+    /// Whether the in-flight stream belongs to the open conversation (TUI-4).
+    /// Gates rendering of the live streaming buffer so a backgrounded turn's
+    /// chunks never paint into a conversation the user switched to.
+    pub fn streaming_is_for_current(&self) -> bool {
+        // Stubbed pending TUI-4 implementation.
+        self.pending_request_id.is_some()
+    }
+
+    /// Reset all in-flight streaming state (TUI-8). Called on `Disconnected`:
+    /// the stream is dead, so the frozen `▌` buffer must not linger and the
+    /// ack sentinel must not mis-claim the first stream after reconnecting.
+    pub fn clear_streaming_state(&mut self) {
+        // Stubbed pending TUI-8 implementation.
+    }
+
+    /// Move the sidebar selection to the conversation with `id`, returning
+    /// whether it was found (TUI-8: selection is positional, so after a
+    /// reconnect's list refresh we reselect by id, not index).
+    pub fn select_conversation_by_id(&mut self, _id: &str) -> bool {
+        // Stubbed pending TUI-8 implementation.
+        false
     }
 
     fn stream_matches_or_claims_request_id(&mut self, request_id: &str) -> bool {
@@ -680,9 +715,17 @@ impl App {
         self.scroll_offset = 0;
     }
 
-    pub fn complete_streaming(&mut self, request_id: &str, full_response: &str) {
+    /// Finish the in-flight stream. Returns the ORIGINATING conversation id
+    /// when the event matched the pending stream (TUI-4) — the caller gates
+    /// narration on that conversation — or `None` when the event was unrelated.
+    /// The reply is appended to the transcript only when the originating
+    /// conversation is the open one; otherwise the daemon already persisted it
+    /// and it appears when that conversation is next opened.
+    pub fn complete_streaming(&mut self, request_id: &str, full_response: &str) -> Option<String> {
+        // Stubbed pending TUI-4 implementation (legacy behavior: appends to
+        // whichever conversation is open).
         if !self.stream_matches_or_claims_request_id(request_id) {
-            return;
+            return None;
         }
         if let Some(conv) = self.current_conversation.as_mut() {
             conv.messages.push(ChatMessage {
@@ -693,6 +736,7 @@ impl App {
         self.streaming_buffer.clear();
         self.pending_request_id = None;
         self.assistant_status = None;
+        self.streaming_conversation_id.take()
     }
 
     pub fn streaming_error(&mut self, request_id: &str, error: &str) {
@@ -702,6 +746,7 @@ impl App {
         self.status_message = format!("Error: {error}");
         self.streaming_buffer.clear();
         self.pending_request_id = None;
+        self.streaming_conversation_id = None;
         self.assistant_status = None;
     }
 
@@ -1170,7 +1215,7 @@ mod tests {
         // send while a reply streams is refused with a status message and the
         // composer keeps its text.
         let mut app = app_ready_to_send("c1", "second question");
-        app.start_streaming("req-in-flight".into());
+        app.start_streaming("req-in-flight".into(), "c1".into());
         app.status_message.clear();
 
         let result = app.prepare_submission(true);
@@ -1192,7 +1237,7 @@ mod tests {
         // Unhappy path: the window between send and the first chunk uses the
         // pending sentinel; a send in that window must be blocked too.
         let mut app = app_ready_to_send("c1", "rapid second send");
-        app.start_streaming_without_request_id();
+        app.start_streaming_without_request_id("c1".into());
 
         assert!(app.prepare_submission(true).is_none());
         assert_eq!(app.textarea_content(), "rapid second send");
@@ -1279,6 +1324,150 @@ mod tests {
         assert_eq!(app.textarea_content(), "prompt");
     }
 
+    // --- Conversation-id threading (TUI-4) + disconnect reset (TUI-8) ---
+
+    fn detail(id: &str) -> ConversationDetail {
+        ConversationDetail {
+            id: id.into(),
+            title: format!("Conv {id}"),
+            messages: vec![],
+            model_selection: None,
+            conversation_personality: None,
+        }
+    }
+
+    #[test]
+    fn complete_after_switching_conversations_targets_the_originating_one() {
+        // Acceptance (TUI-4): a Complete arriving after the user switched
+        // conversations must NOT append to the newly opened conversation; it
+        // reports the ORIGINATING conversation id so narration gates there.
+        let mut app = App::new();
+        app.current_conversation = Some(detail("c1"));
+        app.apply_prompt_ack("task-1".into(), "c1".into());
+        app.receive_chunk("req-1", "partial ");
+
+        // User switches to c2 mid-stream.
+        app.load_conversation(detail("c2"));
+
+        let origin = app.complete_streaming("req-1", "partial reply done");
+        assert_eq!(origin.as_deref(), Some("c1"), "origin must be reported");
+        assert!(
+            app.current_conversation
+                .as_ref()
+                .unwrap()
+                .messages
+                .is_empty(),
+            "the reply must not bleed into the switched-to conversation"
+        );
+        assert_eq!(app.pending_request_id, None, "stream state must clear");
+        assert_eq!(app.streaming_buffer, "");
+    }
+
+    #[test]
+    fn complete_appends_when_user_switched_away_and_back() {
+        // Switching away and back re-opens the originating conversation; the
+        // completion then lands in its transcript.
+        let mut app = App::new();
+        app.current_conversation = Some(detail("c1"));
+        app.apply_prompt_ack("task-1".into(), "c1".into());
+        app.load_conversation(detail("c2"));
+        app.load_conversation(detail("c1")); // back again (fresh fetch)
+
+        let origin = app.complete_streaming("req-1", "the reply");
+        assert_eq!(origin.as_deref(), Some("c1"));
+        let msgs = &app.current_conversation.as_ref().unwrap().messages;
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].content, "the reply");
+    }
+
+    #[test]
+    fn unmatched_complete_reports_no_origin() {
+        // An unrelated Complete (wrong request id) must not be narrated or
+        // appended anywhere — no origin is reported.
+        let mut app = App::new();
+        app.current_conversation = Some(detail("c1"));
+        app.start_streaming("req-1".into(), "c1".into());
+        assert_eq!(app.complete_streaming("other-req", "noise"), None);
+        assert!(app.pending_request_id.is_some(), "stream still pending");
+    }
+
+    #[test]
+    fn streaming_buffer_renders_only_into_the_originating_conversation() {
+        // The UI gate (TUI-4): mid-stream chunks must not paint into a
+        // conversation the user switched to.
+        let mut app = App::new();
+        app.current_conversation = Some(detail("c1"));
+        app.start_streaming("req-1".into(), "c1".into());
+        app.receive_chunk("req-1", "partial");
+        assert!(app.streaming_is_for_current());
+
+        app.load_conversation(detail("c2"));
+        assert!(
+            !app.streaming_is_for_current(),
+            "stream belongs to c1, not the open c2"
+        );
+    }
+
+    #[test]
+    fn chunks_for_a_backgrounded_stream_do_not_reset_scroll() {
+        // Scroll position belongs to the OPEN conversation; a backgrounded
+        // stream's chunks must not yank it.
+        let mut app = App::new();
+        app.current_conversation = Some(detail("c1"));
+        app.start_streaming("req-1".into(), "c1".into());
+        app.load_conversation(detail("c2"));
+        app.scroll_up(7);
+        app.receive_chunk("req-1", "background chunk");
+        assert_eq!(app.scroll_offset, 7);
+    }
+
+    #[test]
+    fn clear_streaming_state_resets_everything_on_disconnect() {
+        // Acceptance (TUI-8): after a disconnect there is no frozen ▌ buffer
+        // and no stale pending id.
+        let mut app = App::new();
+        app.current_conversation = Some(detail("c1"));
+        app.apply_prompt_ack("task-1".into(), "c1".into());
+        app.receive_chunk("req-1", "now-dead partial");
+        app.set_assistant_status("Calling tool…");
+
+        app.clear_streaming_state();
+
+        assert_eq!(app.pending_request_id, None);
+        assert_eq!(app.streaming_buffer, "");
+        assert!(app.streaming_conversation_id.is_none());
+        assert!(app.assistant_status.is_none());
+    }
+
+    #[test]
+    fn cleared_sentinel_cannot_misclaim_the_next_stream() {
+        // Unhappy path (TUI-8): a leftover ack sentinel from before the
+        // disconnect must not claim the first post-reconnect stream.
+        let mut app = App::new();
+        app.current_conversation = Some(detail("c1"));
+        app.apply_prompt_ack("task-1".into(), "c1".into()); // sentinel armed
+        app.clear_streaming_state();
+
+        app.receive_chunk("post-reconnect-req", "someone else's chunk");
+        assert_eq!(app.streaming_buffer, "", "chunk must be ignored");
+        assert_eq!(app.pending_request_id, None);
+    }
+
+    #[test]
+    fn select_conversation_by_id_moves_selection() {
+        let mut app = app_with_conversations();
+        assert!(app.select_conversation_by_id("3"));
+        assert_eq!(app.selected_conversation, Some(2));
+    }
+
+    #[test]
+    fn select_conversation_by_id_missing_keeps_selection() {
+        let mut app = app_with_conversations();
+        app.selected_conversation = Some(1);
+        assert!(!app.select_conversation_by_id("nope"));
+        assert_eq!(app.selected_conversation, Some(1));
+    }
+
     // --- Streaming tests ---
 
     #[test]
@@ -1292,7 +1481,7 @@ mod tests {
             conversation_personality: None,
         });
 
-        app.start_streaming("req1".into());
+        app.start_streaming("req1".into(), "c1".into());
         assert_eq!(app.pending_request_id, Some("req1".to_string()));
 
         app.receive_chunk("req1", "Hello ");
@@ -1320,7 +1509,7 @@ mod tests {
             conversation_personality: None,
         });
 
-        app.start_streaming("req1".into());
+        app.start_streaming("req1".into(), "c1".into());
         app.receive_chunk("wrong_id", "bad data");
         assert_eq!(app.streaming_buffer, "");
 
@@ -1331,7 +1520,7 @@ mod tests {
     #[test]
     fn streaming_error_sets_status() {
         let mut app = App::new();
-        app.start_streaming("req1".into());
+        app.start_streaming("req1".into(), "c1".into());
         app.streaming_error("req1", "LLM timeout");
         assert_eq!(app.status_message, "Error: LLM timeout");
         assert_eq!(app.pending_request_id, None);
@@ -1348,7 +1537,7 @@ mod tests {
             model_selection: None,
             conversation_personality: None,
         });
-        app.start_streaming("req1".into());
+        app.start_streaming("req1".into(), "c1".into());
         app.set_assistant_status("Searching knowledge base...");
         assert_eq!(
             app.assistant_status.as_deref(),
@@ -1362,7 +1551,7 @@ mod tests {
     #[test]
     fn assistant_status_cleared_on_error() {
         let mut app = App::new();
-        app.start_streaming("req1".into());
+        app.start_streaming("req1".into(), "c1".into());
         app.set_assistant_status("Calling tool...");
         app.streaming_error("req1", "boom");
         assert!(app.assistant_status.is_none());
@@ -1387,7 +1576,7 @@ mod tests {
             conversation_personality: None,
         });
 
-        app.start_streaming_without_request_id();
+        app.start_streaming_without_request_id("c1".into());
         app.receive_chunk("ws-req-1", "Hello ");
         app.receive_chunk("ws-req-1", "world");
         app.complete_streaming("ws-req-1", "Hello world");
@@ -1401,7 +1590,7 @@ mod tests {
     #[test]
     fn pending_stream_rejects_unrelated_request_after_claim() {
         let mut app = App::new();
-        app.start_streaming_without_request_id();
+        app.start_streaming_without_request_id("c1".into());
 
         app.receive_chunk("ws-req-1", "good");
         app.receive_chunk("ws-req-2", "ignored");
@@ -1435,7 +1624,7 @@ mod tests {
         });
 
         // Daemon ack carries a task_id (post-#114 wire protocol).
-        app.apply_prompt_ack("task-abc123".to_string());
+        app.apply_prompt_ack("task-abc123".to_string(), "c1".to_string());
 
         // Streaming chunks then arrive with a *different* server-generated
         // request_id. They must be accepted, not filtered out.
@@ -1713,12 +1902,27 @@ mod tests {
     }
 
     #[test]
-    fn receive_chunk_resets_scroll() {
+    fn receive_chunk_at_bottom_keeps_following() {
+        // TUI-10: when the user is at the bottom (offset 0), streaming keeps
+        // auto-following.
         let mut app = App::new();
-        app.start_streaming("req1".into());
-        app.scroll_up(10);
+        app.current_conversation = Some(detail("c1"));
+        app.start_streaming("req1".into(), "c1".into());
         app.receive_chunk("req1", "data");
         assert_eq!(app.scroll_offset, 0);
+    }
+
+    #[test]
+    fn receive_chunk_while_scrolled_up_preserves_position() {
+        // Acceptance (TUI-10): the user can read scrollback during a long
+        // reply — chunks must not yank the view back to the bottom.
+        let mut app = App::new();
+        app.current_conversation = Some(detail("c1"));
+        app.start_streaming("req1".into(), "c1".into());
+        app.scroll_up(10);
+        app.receive_chunk("req1", "data");
+        assert_eq!(app.scroll_offset, 10);
+        assert_eq!(app.streaming_buffer, "data", "chunk still buffered");
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -310,15 +310,6 @@ impl App {
         }
     }
 
-    /// Whether a reply is spoken for the currently-open conversation. `false`
-    /// when no conversation is open. The reply-narration gate the streaming
-    /// completion path consults.
-    pub fn current_narrate(&self) -> bool {
-        self.current_conversation
-            .as_ref()
-            .is_some_and(|c| self.narrate_for(&c.id))
-    }
-
     /// Whether a `say_this` aside is spoken for `conversation_id` (adele-tui#77):
     /// spoken iff `Adele ∈ {OnDemand, Always}` (independent of `You`). `Disabled`
     /// downgrades the aside to inline text.
@@ -677,23 +668,32 @@ impl App {
     /// Gates rendering of the live streaming buffer so a backgrounded turn's
     /// chunks never paint into a conversation the user switched to.
     pub fn streaming_is_for_current(&self) -> bool {
-        // Stubbed pending TUI-4 implementation.
         self.pending_request_id.is_some()
+            && self.streaming_conversation_id.as_deref()
+                == self.current_conversation.as_ref().map(|c| c.id.as_str())
     }
 
     /// Reset all in-flight streaming state (TUI-8). Called on `Disconnected`:
     /// the stream is dead, so the frozen `▌` buffer must not linger and the
     /// ack sentinel must not mis-claim the first stream after reconnecting.
     pub fn clear_streaming_state(&mut self) {
-        // Stubbed pending TUI-8 implementation.
+        self.pending_request_id = None;
+        self.streaming_conversation_id = None;
+        self.streaming_buffer.clear();
+        self.assistant_status = None;
     }
 
     /// Move the sidebar selection to the conversation with `id`, returning
     /// whether it was found (TUI-8: selection is positional, so after a
     /// reconnect's list refresh we reselect by id, not index).
-    pub fn select_conversation_by_id(&mut self, _id: &str) -> bool {
-        // Stubbed pending TUI-8 implementation.
-        false
+    pub fn select_conversation_by_id(&mut self, id: &str) -> bool {
+        match self.conversations.iter().position(|c| c.id == id) {
+            Some(idx) => {
+                self.selected_conversation = Some(idx);
+                true
+            }
+            None => false,
+        }
     }
 
     fn stream_matches_or_claims_request_id(&mut self, request_id: &str) -> bool {
@@ -712,7 +712,11 @@ impl App {
             return;
         }
         self.streaming_buffer.push_str(chunk);
-        self.scroll_offset = 0;
+        // Follow-only-at-bottom (TUI-10): the transcript renders anchored to
+        // the bottom, so `scroll_offset == 0` keeps following new chunks by
+        // itself. A non-zero offset means the user scrolled up to read —
+        // never yank them back down (and a backgrounded stream's chunks must
+        // never touch the OPEN conversation's scroll at all, TUI-4).
     }
 
     /// Finish the in-flight stream. Returns the ORIGINATING conversation id
@@ -722,12 +726,15 @@ impl App {
     /// conversation is the open one; otherwise the daemon already persisted it
     /// and it appears when that conversation is next opened.
     pub fn complete_streaming(&mut self, request_id: &str, full_response: &str) -> Option<String> {
-        // Stubbed pending TUI-4 implementation (legacy behavior: appends to
-        // whichever conversation is open).
         if !self.stream_matches_or_claims_request_id(request_id) {
             return None;
         }
-        if let Some(conv) = self.current_conversation.as_mut() {
+        let origin = self.streaming_conversation_id.take();
+        if let Some(conv) = self
+            .current_conversation
+            .as_mut()
+            .filter(|c| origin.as_deref() == Some(c.id.as_str()))
+        {
             conv.messages.push(ChatMessage {
                 role: "assistant".to_string(),
                 content: full_response.to_string(),
@@ -736,7 +743,7 @@ impl App {
         self.streaming_buffer.clear();
         self.pending_request_id = None;
         self.assistant_status = None;
-        self.streaming_conversation_id.take()
+        origin
     }
 
     pub fn streaming_error(&mut self, request_id: &str, error: &str) {
@@ -2095,7 +2102,7 @@ mod tests {
             "Adele defaults Disabled"
         );
         assert!(
-            !app.current_narrate(),
+            !app.narrate_for("c1"),
             "default gate is closed (no narration)"
         );
         assert!(
@@ -2150,7 +2157,7 @@ mod tests {
             let mut app = app_with_open_conversation("c1");
             app.voice_in.insert("c1".to_string(), you);
             app.set_adele_output("c1", AdeleOutput::Always);
-            assert!(app.current_narrate(), "Always must narrate (You={you})");
+            assert!(app.narrate_for("c1"), "Always must narrate (You={you})");
             assert!(
                 app.say_this_spoken_for("c1"),
                 "Always always speaks say_this (You={you})"
@@ -2167,7 +2174,7 @@ mod tests {
         // You Disabled → reply text-only, but say_this aside still spoken.
         app.voice_in.insert("c1".to_string(), false);
         assert!(
-            !app.current_narrate(),
+            !app.narrate_for("c1"),
             "OnDemand + You=Disabled: no narration"
         );
         assert!(
@@ -2177,7 +2184,7 @@ mod tests {
 
         // You Enabled → reply narrated.
         app.voice_in.insert("c1".to_string(), true);
-        assert!(app.current_narrate(), "OnDemand + You=Enabled narrates");
+        assert!(app.narrate_for("c1"), "OnDemand + You=Enabled narrates");
         assert!(app.say_this_spoken_for("c1"));
     }
 
@@ -2188,7 +2195,7 @@ mod tests {
         for you in [false, true] {
             app.voice_in.insert("c1".to_string(), you);
             assert!(
-                !app.current_narrate(),
+                !app.narrate_for("c1"),
                 "Disabled never narrates (You={you})"
             );
             assert!(
@@ -2230,11 +2237,20 @@ mod tests {
     }
 
     #[test]
-    fn current_narrate_is_false_without_a_conversation() {
-        let mut app = App::new();
-        // Even with stale per-conversation state, no open conversation → silent.
+    fn narration_gates_on_the_originating_conversation_not_the_open_one() {
+        // TUI-4: a backgrounded turn's reply is narrated per ITS
+        // conversation's settings, not the open conversation's. c1 narrates
+        // (Always), the open c2 is Disabled — the completion still reports c1
+        // and the c1 gate holds.
+        let mut app = app_with_open_conversation("c1");
         app.set_adele_output("c1", AdeleOutput::Always);
-        assert!(!app.current_narrate());
+        app.apply_prompt_ack("task-1".into(), "c1".into());
+        app.load_conversation(detail("c2"));
+
+        let origin = app.complete_streaming("req-1", "spoken reply");
+        assert_eq!(origin.as_deref(), Some("c1"));
+        assert!(app.narrate_for("c1"), "origin's gate holds");
+        assert!(!app.narrate_for("c2"), "open conversation stays silent");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1335,7 +1335,7 @@ async fn send_prompt_from_input(app: &mut App, connector: &Option<Connector>) {
             }
         };
         match result {
-            Ok(task_id) => app.apply_prompt_ack(task_id),
+            Ok(task_id) => app.apply_prompt_ack(task_id, conv_id.clone()),
             Err(e) => {
                 app.restore_failed_submission(&conv_id, &prompt);
                 app.status_message = format!("Send error: {e} (your text is preserved)");

--- a/src/main.rs
+++ b/src/main.rs
@@ -609,16 +609,21 @@ async fn run(
                         app.receive_chunk(&request_id, &chunk);
                     }
                     SignalEvent::Complete { request_id, full_response } => {
-                        app.complete_streaming(&request_id, &full_response);
-                        // Narrate the finalized reply only when the OPEN
-                        // conversation's gate holds (adele-tui#77): `Adele ==
-                        // Always` OR (`Adele == OnDemand` AND `You == Enabled`).
-                        // The completing reply streams into the open conversation,
-                        // so that gate is right. Route daemon-first + chunked via
-                        // `speak_text`; fire-and-forget so synth never blocks the
-                        // UI. Gated entirely here so the cut-off holds: when the
-                        // gate is false nothing is spoken on any path.
-                        if app.current_narrate() && !full_response.trim().is_empty() {
+                        // `complete_streaming` reports the ORIGINATING
+                        // conversation (TUI-4) — the one the prompt was sent
+                        // to, not whichever is open now — and the narration
+                        // gate (adele-tui#77: `Adele == Always` OR `Adele ==
+                        // OnDemand` AND `You == Enabled`) is evaluated against
+                        // THAT conversation's settings. Route daemon-first +
+                        // chunked via `speak_text`; fire-and-forget so synth
+                        // never blocks the UI. Gated entirely here so the
+                        // cut-off holds: when the gate is false nothing is
+                        // spoken on any path.
+                        let origin = app.complete_streaming(&request_id, &full_response);
+                        if let Some(origin) = origin
+                            && app.narrate_for(&origin)
+                            && !full_response.trim().is_empty()
+                        {
                             let voice = Some(voice_daemon.clone());
                             let embedded = voice_session.as_ref().map(VoiceSession::speaker);
                             tokio::spawn(speak_text(voice, embedded, full_response));
@@ -637,7 +642,11 @@ async fn run(
                     SignalEvent::Disconnected { reason } => {
                         // Drop the connector (closing its transport + fanout
                         // task) and reset to the not-connected sentinel receiver
-                        // so the backoff loop owns reconnection.
+                        // so the backoff loop owns reconnection. Any in-flight
+                        // stream died with the connection (TUI-8): clear it so
+                        // no frozen ▌ buffer lingers and the ack sentinel can't
+                        // mis-claim the first post-reconnect stream.
+                        app.clear_streaming_state();
                         connector = None;
                         signal_rx = unbounded_channel().1;
                         reconnect = schedule_reconnect(None);
@@ -727,6 +736,24 @@ async fn run(
                         match conn.client().list_conversations().await {
                             Ok(convs) => app.set_conversations(convs),
                             Err(e) => app.status_message = format!("Error loading conversations: {e}"),
+                        }
+                        // Resync the open conversation after the gap (TUI-8):
+                        // re-fetch its transcript (turns may have completed
+                        // while we were away — the dead stream's reply only
+                        // exists daemon-side) and reselect it by ID — the
+                        // sidebar selection is positional and the refreshed
+                        // list may have reordered.
+                        if let Some(open_id) =
+                            app.current_conversation.as_ref().map(|c| c.id.clone())
+                        {
+                            app.select_conversation_by_id(&open_id);
+                            match conn.client().get_conversation(&open_id).await {
+                                Ok(detail) => app.load_conversation(detail),
+                                Err(e) => {
+                                    app.status_message =
+                                        format!("Error refreshing conversation: {e}");
+                                }
+                            }
                         }
                         init_background_tasks(&mut app, conn.client()).await;
                         // Re-advertise client tools — the daemon replaces the

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,7 @@ use desktop_assistant_client_common::{
 use futures::StreamExt;
 use ratatui::{Terminal, backend::CrosstermBackend};
 use tokio::{
-    sync::mpsc::{UnboundedReceiver, unbounded_channel},
+    sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel},
     time::{Instant, sleep_until},
 };
 
@@ -424,6 +424,17 @@ async fn run(
     // — a missing daemon yields an inert controller probed per-utterance.
     let voice_daemon = VoiceController::connect().await;
     let mut voice_session: Option<VoiceSession> = None;
+    // Single serialized narration queue (TUI-11): both reply narration and
+    // `say_this` asides enqueue here, and one long-lived task speaks them
+    // strictly one-at-a-time, so a `say_this` aside firing mid-reply no longer
+    // interleaves sentence-by-sentence on the shared sink. The task ends when
+    // this sender is dropped (loop teardown). Spawned, not awaited, so synth +
+    // playback never block the UI.
+    let (narration_tx, narration_rx) = unbounded_channel::<NarrationRequest>();
+    tokio::spawn(voice::run_narration_loop(
+        narration_rx,
+        |req: NarrationRequest| speak_text(req.voice, req.embedded, req.text),
+    ));
     let mut dictating = false;
     let (dictation_tx, mut dictation_rx) = unbounded_channel::<DictationOutcome>();
     let mut session_rx: Option<tokio::sync::oneshot::Receiver<anyhow::Result<VoiceSession>>> = None;
@@ -614,19 +625,23 @@ async fn run(
                         // to, not whichever is open now — and the narration
                         // gate (adele-tui#77: `Adele == Always` OR `Adele ==
                         // OnDemand` AND `You == Enabled`) is evaluated against
-                        // THAT conversation's settings. Route daemon-first +
-                        // chunked via `speak_text`; fire-and-forget so synth
-                        // never blocks the UI. Gated entirely here so the
-                        // cut-off holds: when the gate is false nothing is
-                        // spoken on any path.
+                        // THAT conversation's settings. Routed daemon-first +
+                        // chunked through the single narration queue (TUI-11) so
+                        // it can't interleave with a `say_this` aside; the queue
+                        // task speaks it so synth never blocks the UI. Gated
+                        // entirely here so the cut-off holds: when the gate is
+                        // false nothing is spoken on any path.
                         let origin = app.complete_streaming(&request_id, &full_response);
                         if let Some(origin) = origin
                             && app.narrate_for(&origin)
                             && !full_response.trim().is_empty()
                         {
-                            let voice = Some(voice_daemon.clone());
-                            let embedded = voice_session.as_ref().map(VoiceSession::speaker);
-                            tokio::spawn(speak_text(voice, embedded, full_response));
+                            enqueue_narration(
+                                &narration_tx,
+                                &voice_daemon,
+                                &voice_session,
+                                full_response,
+                            );
                         }
                     }
                     SignalEvent::Error { request_id, error } => {
@@ -712,6 +727,7 @@ async fn run(
                             &connector,
                             &voice_daemon,
                             &voice_session,
+                            &narration_tx,
                             call,
                         )
                         .await;
@@ -1111,11 +1127,41 @@ async fn handle_action(app: &mut App, connector: &Option<Connector>, action: Act
     }
 }
 
+/// One utterance to narrate, with the backends resolved at enqueue time
+/// (adele-tui#77 / TUI-11). Carried over the narration queue so the single
+/// serializing task can speak it; the backend handles are captured here (the
+/// daemon controller is cheap to clone, the embedded `Speaker` shares `Arc`s) so
+/// the queue task needs no shared mutable view of voice state.
+struct NarrationRequest {
+    voice: Option<VoiceController>,
+    embedded: Option<adele_voice_module::Speaker<adele_voice_module::TtsBackend>>,
+    text: String,
+}
+
+/// Enqueue `text` onto the single narration queue (TUI-11) so it plays after any
+/// in-flight utterance rather than interleaving with it. The backends are
+/// resolved now (daemon clone + the current embedded speaker, if any). A closed
+/// queue (app shutting down) silently drops the request — narration is a
+/// convenience, never load-bearing.
+fn enqueue_narration(
+    tx: &UnboundedSender<NarrationRequest>,
+    voice_daemon: &VoiceController,
+    voice_session: &Option<VoiceSession>,
+    text: String,
+) {
+    let _ = tx.send(NarrationRequest {
+        voice: Some(voice_daemon.clone()),
+        embedded: voice_session.as_ref().map(VoiceSession::speaker),
+        text,
+    });
+}
+
 /// Speak `text` aloud, daemon-first and chunked (adele-tui#77, mirroring
 /// adele-gtk#80's `window::speak_text`).
 ///
-/// Single entry point shared by reply narration and `say_this` asides so routing
-/// + chunking live in one place:
+/// The narration queue loop (TUI-11) invokes this one utterance at a time, so
+/// reply narration and `say_this` asides never overlap on the sink. It is the
+/// single entry point where routing + chunking live, in three steps:
 ///
 /// 1. **Chunk.** `text` is split into one-short-sentence-per-call pieces via
 ///    [`voice::into_speakable_sentences`]. Both backends' synth is one-shot with
@@ -1128,8 +1174,8 @@ async fn handle_action(app: &mut App, connector: &Option<Connector>, action: Act
 /// 3. **Order.** Sentences are awaited **sequentially**, so the daemon/embedded
 ///    sink receives — and plays — them in order; they are never fired unordered.
 ///
-/// Spawned fire-and-forget by callers so synthesis + playback never blocks the
-/// UI. Errors are logged once (the first failing sentence) and the rest of the
+/// Run on the narration queue task so synthesis + playback never block the UI.
+/// Errors are logged once (the first failing sentence) and the rest of the
 /// utterance is abandoned.
 async fn speak_text(
     voice: Option<VoiceController>,
@@ -1177,6 +1223,7 @@ async fn handle_client_tool_call(
     connector: &Option<Connector>,
     voice_daemon: &VoiceController,
     voice_session: &Option<VoiceSession>,
+    narration_tx: &UnboundedSender<NarrationRequest>,
     call: client_tools::ClientToolCall,
 ) {
     // Gate on the call's OWN conversation, not the open one, so the per-
@@ -1187,15 +1234,15 @@ async fn handle_client_tool_call(
 
     match outcome.effect {
         client_tools::ToolEffect::Speak(text) => {
-            // Speak the aside daemon-first + chunked, fire-and-forget so we don't
+            // Speak the aside daemon-first + chunked through the single narration
+            // queue (TUI-11) so it serializes behind any in-flight reply
+            // narration instead of interleaving on the sink; enqueueing doesn't
             // block submitting the result. When neither the daemon nor the
-            // embedded engine is present, `speak_text` is a no-op; degrade to
+            // embedded engine is present there is nothing to speak; degrade to
             // showing the text inline instead of dropping it silently.
             let has_backend = voice_daemon.is_available().await || voice_session.is_some();
             if has_backend {
-                let voice = Some(voice_daemon.clone());
-                let embedded = voice_session.as_ref().map(VoiceSession::speaker);
-                tokio::spawn(speak_text(voice, embedded, text));
+                enqueue_narration(narration_tx, voice_daemon, voice_session, text);
             } else {
                 app.push_speech_disabled_note(&call.conversation_id, &text);
             }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -611,7 +611,7 @@ mod tests {
             model_selection: None,
             conversation_personality: None,
         });
-        app.start_streaming("req1".into());
+        app.start_streaming("req1".into(), "1".into());
         app.receive_chunk("req1", "Partial response...");
         terminal.draw(|f| draw(f, &mut app)).unwrap();
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -344,8 +344,11 @@ fn draw_messages(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
 
         // Show streaming buffer as in-progress assistant message. Markdown is
         // applied to the partial buffer too — unclosed fences just show
-        // their literal backticks until the stream catches up.
-        if !app.streaming_buffer.is_empty() {
+        // their literal backticks until the stream catches up. Only painted
+        // when the in-flight stream belongs to THIS conversation (TUI-4): a
+        // backgrounded turn keeps buffering invisibly and re-appears when the
+        // user switches back to its conversation.
+        if !app.streaming_buffer.is_empty() && app.streaming_is_for_current() {
             let style = Style::default().fg(COLOR_ASSISTANT_STREAMING);
             push_assistant_markdown(&mut lines, &app.streaming_buffer, style);
             // Cursor on last line

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -318,4 +318,98 @@ mod tests {
         );
         assert!(chunks.iter().all(|c| !c.trim().is_empty()));
     }
+
+    // --- Narration queue (TUI-11) ---
+    //
+    // Reply narration and `say_this` asides both speak through ONE serialized
+    // queue, so two utterances never interleave sentence-by-sentence on the
+    // shared sink. The serialization invariant is testable without real audio
+    // by driving the shared loop with a stub `speak` that records start/end
+    // ordering and flags any overlap.
+
+    use std::sync::{Arc, Mutex as StdMutex};
+    use tokio::sync::mpsc::unbounded_channel;
+    use tokio::sync::oneshot;
+
+    /// Records each utterance's start/end and whether any two overlapped.
+    #[derive(Default)]
+    struct SpeakRecorder {
+        active: usize,
+        overlapped: bool,
+        log: Vec<String>,
+    }
+
+    #[tokio::test]
+    async fn narration_queue_serializes_overlapping_utterances() {
+        // Two utterances are queued back to back while the first is still
+        // "playing"; the loop must finish the first before starting the second
+        // (no overlap) and preserve submission order.
+        let recorder = Arc::new(StdMutex::new(SpeakRecorder::default()));
+        let (tx, rx) = unbounded_channel::<String>();
+
+        // A barrier so the first utterance can be held "in flight" until both
+        // requests are queued, proving the second waits rather than racing.
+        let (release_first_tx, release_first_rx) = oneshot::channel::<()>();
+        let release_first = Arc::new(StdMutex::new(Some(release_first_rx)));
+
+        let rec = Arc::clone(&recorder);
+        let loop_handle = tokio::spawn(async move {
+            run_narration_loop(rx, move |text| {
+                let rec = Arc::clone(&rec);
+                let release_first = Arc::clone(&release_first);
+                async move {
+                    {
+                        let mut r = rec.lock().unwrap();
+                        if r.active > 0 {
+                            r.overlapped = true;
+                        }
+                        r.active += 1;
+                        r.log.push(format!("start:{text}"));
+                    }
+                    // The first utterance blocks on the barrier; later ones run
+                    // immediately. If serialization is broken the second would
+                    // start while the first is parked here.
+                    if let Some(rx) = release_first.lock().unwrap().take() {
+                        let _ = rx.await;
+                    }
+                    {
+                        let mut r = rec.lock().unwrap();
+                        r.active -= 1;
+                        r.log.push(format!("end:{text}"));
+                    }
+                }
+            })
+            .await;
+        });
+
+        tx.send("first".to_string()).unwrap();
+        tx.send("second".to_string()).unwrap();
+
+        // Give the loop a chance to (incorrectly) start the second before the
+        // first is released.
+        tokio::task::yield_now().await;
+        release_first_tx.send(()).unwrap();
+
+        drop(tx); // closes the channel so the loop exits
+        loop_handle.await.unwrap();
+
+        let r = recorder.lock().unwrap();
+        assert!(!r.overlapped, "utterances must never overlap on the sink");
+        assert_eq!(
+            r.log,
+            vec!["start:first", "end:first", "start:second", "end:second"],
+            "utterances must play fully, in submission order"
+        );
+    }
+
+    #[tokio::test]
+    async fn narration_loop_exits_when_the_sender_is_dropped() {
+        // The queue task is long-lived but must terminate cleanly when the app
+        // drops its sender (shutdown), not hang forever.
+        let (tx, rx) = unbounded_channel::<String>();
+        let handle = tokio::spawn(run_narration_loop(rx, |_text| async {}));
+        drop(tx);
+        // Must return promptly; the test harness would hang otherwise.
+        handle.await.unwrap();
+    }
 }

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -68,6 +68,32 @@ pub fn into_speakable_sentences(text: &str) -> Vec<String> {
     sentences
 }
 
+/// Drive a serialized narration loop: pull utterances off `rx` and speak each
+/// one to completion before starting the next (TUI-11).
+///
+/// Reply narration and `say_this` asides previously each `tokio::spawn`ed their
+/// own playback task, so a `say_this` aside firing mid-reply interleaved
+/// sentence-by-sentence with the reply on the shared audio sink. Funnelling both
+/// through this one loop makes utterances strictly sequential: the next text is
+/// not even dequeued until `speak` for the current one has returned.
+///
+/// `speak` is the per-utterance side effect (in production: chunk + route the
+/// utterance daemon-first); it is injected, and the item type `T` is generic, so
+/// the serialization invariant can be unit-tested without an audio device. The
+/// loop returns when the channel closes (all senders dropped), so a sender held
+/// by the app for its lifetime keeps it alive and a clean shutdown ends it.
+pub async fn run_narration_loop<T, F, Fut>(
+    mut rx: tokio::sync::mpsc::UnboundedReceiver<T>,
+    speak: F,
+) where
+    F: Fn(T) -> Fut,
+    Fut: std::future::Future<Output = ()>,
+{
+    while let Some(item) = rx.recv().await {
+        speak(item).await;
+    }
+}
+
 /// How the TUI sources voice. Defaults to [`VoiceMode::Off`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -368,8 +394,11 @@ mod tests {
                     }
                     // The first utterance blocks on the barrier; later ones run
                     // immediately. If serialization is broken the second would
-                    // start while the first is parked here.
-                    if let Some(rx) = release_first.lock().unwrap().take() {
+                    // start while the first is parked here. Take the receiver
+                    // out (dropping the guard) BEFORE awaiting so the closure's
+                    // future stays `Send`.
+                    let held = release_first.lock().unwrap().take();
+                    if let Some(rx) = held {
                         let _ = rx.await;
                     }
                     {


### PR DESCRIPTION
Code-review batch from `CODE_REVIEW_2026-06-09.md` §6 — the cross-conversation / cross-stream family in the TUI, plus the narration-interleave low finding.

## TUI-4 — replies land in whichever conversation is open at completion (#82)
The stream now knows its conversation. `start_streaming`/`apply_prompt_ack` record the conversation the prompt was sent to; `complete_streaming` reports that **originating** conversation and appends the reply only when it is still open (otherwise the daemon already persisted it and it re-appears on reopen). Narration gates on the originating conversation's settings, not whichever is open at completion. The live streaming buffer is painted only when the in-flight stream belongs to the open conversation.

## TUI-8 — disconnect/reconnect leaves stale state (#86)
`Disconnected` clears all streaming state (no frozen `▌` buffer; the ack sentinel can't mis-claim the next stream). On reconnect the open conversation is re-fetched (turns may have completed while away — the dead stream's reply only exists daemon-side) and reselected **by id** (the sidebar selection is positional and the refreshed list may have reordered).

## TUI-10 — every chunk yanks scroll to the bottom (#88)
`receive_chunk` no longer forces `scroll_offset = 0`. The transcript renders anchored to the bottom, so offset 0 keeps following by itself; a non-zero offset (user scrolled up to read) is preserved. A backgrounded stream's chunks never touch the open conversation's scroll.

## TUI-11 — single narration queue (part of #89)
Reply narration and `say_this` asides each `tokio::spawn`ed their own `speak_text` task, so an aside firing mid-reply interleaved sentence-by-sentence on the shared sink. Both now enqueue onto one serialized queue; a long-lived task speaks each utterance to completion before dequeuing the next, so utterances never overlap and play in submission order. The per-utterance worker and backend-resolution-at-enqueue-time semantics are unchanged.

## Tests (TDD — failing first, in their own commits)
- TUI-4/8/10 (`b9268cf`): origin-targeted completion after switching, buffer renders only into the originating conversation, backgrounded chunks don't reset scroll, `clear_streaming_state` reset, cleared sentinel can't mis-claim, `select_conversation_by_id`, chunks-while-scrolled-up preserve position, narration gates on the originating conversation.
- TUI-11 (`ff7d0c2`): a stub-driven `run_narration_loop` test proving no overlap + in-order playback, and clean exit on sender drop.

Gates: `cargo fmt --check`, `cargo clippy --all-targets -D warnings` (zero), `cargo test` (699 pass), `just check` all green.

Closes #82
Closes #86
Closes #88

Refs #89 (TUI-11 only — TUI-12 + the sub-screen/voice-plumbing refactors in that issue remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)