### PR TITLE
Adopt shared adele-voice-client-common crate (drop voice-output dupes)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,7 +6,7 @@ version = 4
 name = "adele"
 version = "0.1.0"
 dependencies = [
- "adele-voice-core",
+ "adele-voice-client-common",
  "adele-voice-module",
  "adele-voice-stt-whisper",
  "adele-voice-vad-silero",
@@ -50,10 +50,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "adele-voice-client-common"
+version = "0.1.0"
+dependencies = [
+ "adele-voice-core",
+]
+
+[[package]]
 name = "adele-voice-core"
 version = "0.1.0"
 dependencies = [
  "pulldown-cmark",
+ "rubato",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
@@ -93,7 +101,6 @@ version = "0.1.0"
 dependencies = [
  "adele-voice-core",
  "ort",
- "rubato",
  "tokio",
  "tracing",
 ]
@@ -104,7 +111,6 @@ version = "0.1.0"
 dependencies = [
  "adele-voice-core",
  "anyhow",
- "rubato",
  "tokio",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,12 +51,15 @@ desktop-assistant-api-model = { git = "https://github.com/adelie-ai/desktop-assi
 [dependencies.adele-voice-module]
 path = "../voice/crates/module"
 
-# Shared voice domain crate: its `SentenceBuffer` carries the sentence-chunking
-# algorithm so a long reply is spoken one short sentence at a time (each synth is
-# one-shot with a ~20s timeout). Used by `voice::into_speakable_sentences`,
-# mirroring adele-gtk#80's `voice_embedded::into_speakable_sentences`.
-[dependencies.adele-voice-core]
-path = "../voice/crates/core"
+# Shared client-side voice-output plumbing (desktop-assistant#274): the
+# `AdeleOutput` level + narration gate, the byte-identical system-refinement
+# constants, and `into_speakable_sentences` (the sentence chunker, so a long
+# reply is spoken one short sentence at a time — each synth is one-shot with a
+# ~20s timeout). Owned once here instead of triplicated across the clients;
+# pulls in `adele-voice-core` transitively for its `SentenceBuffer`. Same
+# `../voice` symlink path-dep as the module above.
+[dependencies.adele-voice-client-common]
+path = "../voice/crates/client-voice"
 
 [dependencies.adele-voice-vad-silero]
 path = "../voice/crates/vad-silero"

--- a/src/app.rs
+++ b/src/app.rs
@@ -100,48 +100,16 @@ pub enum InputMode {
     Renaming,
 }
 
-/// The `Adele:` voice-output level for a conversation (adele-tui#77, mirroring
-/// adele-gtk#80's `AdeleOutput`). Decides reply narration (with `You`), the
-/// `say_this` aside gate, and the send-time `system_refinement`. Defaults to
-/// [`AdeleOutput::Disabled`].
+/// The `Adele:` voice-output level for a conversation. Decides reply narration
+/// (with `You`), the `say_this` aside gate, and the send-time
+/// `system_refinement`. Defaults to `Disabled`.
 ///
-/// * `Disabled` — never speaks; a `say_this` aside downgrades to inline text.
-/// * `OnDemand` — speaks replies only while `You == Enabled` (shaped for the ear,
-///   brief and conversational) and always speaks `say_this` asides. Selected by
-///   the model's `request_voice`.
-/// * `Always` — reads every reply aloud, in full but made speakable (not
-///   shortened).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum AdeleOutput {
-    /// Never speaks (the default). `say_this` → inline note.
-    #[default]
-    Disabled,
-    /// Speaks replies when `You == Enabled`; always speaks `say_this` asides.
-    OnDemand,
-    /// Reads every reply aloud, in full, made speakable.
-    Always,
-}
-
-impl AdeleOutput {
-    /// The next level when the user cycles the control
-    /// (`Disabled → OnDemand → Always → Disabled`).
-    pub fn next(self) -> Self {
-        match self {
-            Self::Disabled => Self::OnDemand,
-            Self::OnDemand => Self::Always,
-            Self::Always => Self::Disabled,
-        }
-    }
-
-    /// Short label for the status line / chat title cue.
-    pub fn label(self) -> &'static str {
-        match self {
-            Self::Disabled => "Disabled",
-            Self::OnDemand => "On Demand",
-            Self::Always => "Always",
-        }
-    }
-}
+/// Now owned by the shared `adele-voice-client-common` crate
+/// (desktop-assistant#274) so the GTK and TUI clients share one definition + the
+/// narration gate (`next`/`label`/`narrates_reply`/`speaks_aside`/
+/// `send_refinement`); re-exported here so existing `crate::app::AdeleOutput`
+/// paths keep resolving unchanged.
+pub use adele_voice_client_common::AdeleOutput;
 
 pub struct App {
     pub conversations: Vec<ConversationSummary>,
@@ -331,23 +299,19 @@ impl App {
 
     /// Whether a *reply* is spoken for `conversation_id` (adele-tui#77, the
     /// narration gate): `Adele == Always` OR (`Adele == OnDemand` AND
-    /// `You == Enabled`). `Disabled` never narrates.
+    /// `You == Enabled`). `Disabled` never narrates. Delegates to the shared
+    /// gate (desktop-assistant#274).
     pub fn narrate_for(&self, conversation_id: &str) -> bool {
-        match self.adele_output_for(conversation_id) {
-            AdeleOutput::Always => true,
-            AdeleOutput::OnDemand => self.voice_in_for(conversation_id),
-            AdeleOutput::Disabled => false,
-        }
+        self.adele_output_for(conversation_id)
+            .narrates_reply(self.voice_in_for(conversation_id))
     }
 
     /// Whether a `say_this` aside is spoken for `conversation_id` (adele-tui#77):
     /// spoken iff `Adele ∈ {OnDemand, Always}` (independent of `You`). `Disabled`
-    /// downgrades the aside to inline text.
+    /// downgrades the aside to inline text. Delegates to the shared gate
+    /// (desktop-assistant#274).
     pub fn say_this_spoken_for(&self, conversation_id: &str) -> bool {
-        !matches!(
-            self.adele_output_for(conversation_id),
-            AdeleOutput::Disabled
-        )
+        self.adele_output_for(conversation_id).speaks_aside()
     }
 
     /// Render a `say_this` call whose aside is NOT spoken (Adele == Disabled) as

--- a/src/main.rs
+++ b/src/main.rs
@@ -238,44 +238,21 @@ enum ReconnectState {
 const RECONNECT_INITIAL_SECS: u64 = 2;
 const RECONNECT_MAX_SECS: u64 = 30;
 
-/// System refinement attached on send while `Adele == OnDemand` (adele-tui#77,
-/// mirroring adele-gtk#80). Replies are spoken only while conversing by voice,
-/// so shape them **for the ear**: brief, conversational, no markdown,
-/// symbols/acronyms spelled out. Deliberately free of markdown markers so it
-/// can't itself leak formatting. Refines the system prompt for THIS turn only —
-/// never stored, never in the transcript.
-const ON_DEMAND_SYSTEM_REFINEMENT: &str = "This reply will be read aloud, so write it to be heard, \
-    not read. Keep it brief and conversational — a few short sentences — and lead with the answer. \
-    Use no markdown or formatting of any kind (no asterisks, backticks, bullets, or emoji); write \
-    plain spoken prose. Spell out symbols, abbreviations, and acronyms as words (say \"and\" not \
-    \"&\", \"percent\" not \"%\", \"for example\" not \"e.g.\"), and don't read out URLs, file \
-    paths, or email addresses — describe them instead.";
-
-/// System refinement attached on send while `Adele == Always` (adele-tui#77,
-/// mirroring adele-gtk#80). Every reply is read aloud for accessibility, so make
-/// it **speakable but not shortened**: keep the full content, just strip
-/// formatting and spell out symbols. Crucially it does NOT ask for brevity
-/// (that's the OnDemand job) — Always reads the whole answer. Free of markdown
-/// markers itself.
-const ALWAYS_SYSTEM_REFINEMENT: &str = "This reply will be read aloud in full, so write it to be \
-    heard, not read, without leaving anything out. Do not shorten or summarize — cover everything \
-    you would normally say, just phrased for the ear. Use no markdown or formatting of any kind \
-    (no asterisks, backticks, bullets, or emoji); write plain spoken prose. Spell out symbols, \
-    abbreviations, and acronyms as words (say \"and\" not \"&\", \"percent\" not \"%\", \"for \
-    example\" not \"e.g.\"), and don't read out URLs, file paths, or email addresses — describe \
-    them instead.";
-
-/// The system refinement to attach on the next send for `conversation_id`
-/// (adele-tui#77), chosen by its `Adele:` level: `OnDemand` →
-/// brief/conversational/speakable; `Always` → speakable-but-full (don't
-/// shorten); `Disabled` → none. Pure decision the send path consults to choose
-/// the refinement string (empty = none).
+/// The system refinement to attach on the next send for `conversation_id`,
+/// chosen by its `Adele:` level: `OnDemand` → brief/conversational/speakable;
+/// `Always` → speakable-but-full (don't shorten); `Disabled` → none. Pure
+/// decision the send path consults to choose the refinement string (empty =
+/// none).
+///
+/// The refinement prose + the level→refinement mapping now live in the shared
+/// `adele-voice-client-common` crate (desktop-assistant#274) so the GTK and TUI
+/// clients send byte-identical refinements. The shared helper returns
+/// `Option<&str>`; we keep this client's empty-string-means-none convention so
+/// the send call sites are untouched.
 fn refinement_for_send(app: &App, conversation_id: &str) -> &'static str {
-    match app.adele_output_for(conversation_id) {
-        AdeleOutput::OnDemand => ON_DEMAND_SYSTEM_REFINEMENT,
-        AdeleOutput::Always => ALWAYS_SYSTEM_REFINEMENT,
-        AdeleOutput::Disabled => "",
-    }
+    app.adele_output_for(conversation_id)
+        .send_refinement()
+        .unwrap_or("")
 }
 
 fn next_backoff(prev_secs: u64) -> u64 {

--- a/src/voice.rs
+++ b/src/voice.rs
@@ -22,9 +22,7 @@
 //! `embedded`.
 
 use std::sync::Arc;
-use std::time::Duration;
 
-use adele_voice_core::sentence_buffer::SentenceBuffer;
 use adele_voice_module::config::{AudioConfig, SttConfig, TtsConfig, VadConfig};
 use adele_voice_module::{Dictation, Speaker, TtsBackend, build_dictation, build_speaker};
 use adele_voice_stt_whisper::WhisperStt;
@@ -32,40 +30,11 @@ use adele_voice_vad_silero::SileroVad;
 use serde::Deserialize;
 use tokio::sync::Mutex;
 
-/// Split `text` into the chunks that should be fed to a one-shot synthesizer.
-///
-/// Both the voice daemon's `SayText` and the embedded [`Speaker`] are
-/// **one-shot**: they assume a single short sentence and apply a per-synth
-/// timeout (`adele_voice_module`'s `DEFAULT_SYNTH_TIMEOUT`, ~20s). A long reply
-/// fed in one go would blow that timeout, so the *client* must chunk it the same
-/// way the daemon's streaming pipeline does — via [`SentenceBuffer`]. This is the
-/// TUI port of adele-gtk#80's `voice_embedded::into_speakable_sentences`; the
-/// chunking *algorithm* itself lives in the shared `adele-voice-core` crate.
-///
-/// This pushes the whole text through a `SentenceBuffer` (collecting every
-/// complete sentence) and then appends the trailing remainder from `flush()`
-/// (the last sentence has no trailing whitespace, so the buffer holds it back).
-/// If chunking yields nothing it falls back to a single chunk of the trimmed
-/// original when that text is non-blank, and to an empty `Vec` for
-/// empty/whitespace input (nothing to speak).
-///
-/// The timeout passed to the buffer is irrelevant here: this is a synchronous,
-/// one-shot push/flush with no streaming, so the time-based flush never fires.
-pub fn into_speakable_sentences(text: &str) -> Vec<String> {
-    // Timeout is unused on this synchronous push→flush path; any value works.
-    let mut buf = SentenceBuffer::new(Duration::from_millis(500));
-    let mut sentences = buf.push(text);
-    let tail = buf.flush();
-    if !tail.is_empty() {
-        sentences.push(tail);
-    }
-    if sentences.is_empty() && !text.trim().is_empty() {
-        // No boundary produced a chunk but there *is* speakable text — speak it
-        // whole rather than dropping it silently.
-        sentences.push(text.trim().to_string());
-    }
-    sentences
-}
+/// The speakable-sentence chunker now lives in the shared `client-voice` crate
+/// (desktop-assistant#274) so the GTK and TUI clients can't drift. Re-exported
+/// at its original path so the narration path keeps calling
+/// `voice::into_speakable_sentences`.
+pub use adele_voice_client_common::into_speakable_sentences;
 
 /// Drive a serialized narration loop: pull utterances off `rx` and speak each
 /// one to completion before starting the next (TUI-11).
@@ -280,56 +249,8 @@ mod tests {
         assert!(cfg.embedded_enabled());
     }
 
-    // --- Sentence chunking (adele-tui#77) ---
-
-    /// A multi-sentence reply splits into one chunk per sentence, in order, so
-    /// no single synth call carries the whole paragraph past its ~20s timeout.
-    #[test]
-    fn chunks_multi_sentence_into_sentences() {
-        let chunks = into_speakable_sentences("Hello there. How are you? I am fine.");
-        assert_eq!(chunks, vec!["Hello there.", "How are you?", "I am fine."]);
-    }
-
-    /// A single sentence is one chunk.
-    #[test]
-    fn chunks_single_sentence_into_one() {
-        let chunks = into_speakable_sentences("Just one sentence here.");
-        assert_eq!(chunks, vec!["Just one sentence here."]);
-    }
-
-    /// Text with no trailing punctuation is still spoken — as one chunk (the
-    /// `flush()` tail), not dropped.
-    #[test]
-    fn chunks_text_without_terminal_punctuation_into_one() {
-        let chunks = into_speakable_sentences("no trailing punctuation here");
-        assert_eq!(chunks, vec!["no trailing punctuation here"]);
-    }
-
-    /// Empty / whitespace-only input has nothing to speak → no chunks (so the
-    /// caller makes zero synth calls rather than synthesizing silence).
-    #[test]
-    fn chunks_empty_or_whitespace_into_nothing() {
-        assert!(into_speakable_sentences("").is_empty());
-        assert!(into_speakable_sentences("   \n\t  ").is_empty());
-    }
-
-    /// A long multi-sentence paragraph splits into several chunks, each
-    /// non-empty (the whole point: keep each synth call short).
-    #[test]
-    fn chunks_long_paragraph_into_multiple() {
-        let paragraph = "The quick brown fox jumps over the lazy dog. \
-             It then trots away to find a quiet spot. \
-             Later, the dog wakes up and stretches lazily. \
-             Neither animal pays the other any further mind. \
-             The afternoon sun warms the empty field.";
-        let chunks = into_speakable_sentences(paragraph);
-        assert!(
-            chunks.len() >= 4,
-            "a five-sentence paragraph should split into several chunks, got {}: {chunks:?}",
-            chunks.len()
-        );
-        assert!(chunks.iter().all(|c| !c.trim().is_empty()));
-    }
+    // The `into_speakable_sentences` chunking tests moved with the function to
+    // the shared `adele-voice-client-common` crate (desktop-assistant#274).
 
     // --- Narration queue (TUI-11) ---
     //


### PR DESCRIPTION
Part 3 of 3 (final) for desktop-assistant#274 — adopt the shared client-voice crate, deleting the TUI's local copies.

## What

Replaces the TUI's triplicated client-side voice-output plumbing with `adele-voice-client-common` (added in **voice#102**):

- `AdeleOutput` (in `app.rs`) → a re-export of the shared enum (with its `next`/`label`/gate methods). Every `crate::app::AdeleOutput` path resolves unchanged.
- The narration gate (`narrate_for`, `say_this_spoken_for`) delegates to the shared enum methods (`narrates_reply`, `speaks_aside`).
- `refinement_for_send` (in `main.rs`) delegates to the shared `send_refinement()`, mapping `None -> ""` to keep this client's empty-means-none convention so the send call sites are untouched. The two local `*_SYSTEM_REFINEMENT` constants are dropped.
- `into_speakable_sentences` moves to the shared crate; `voice` re-exports it at its original path. Its chunking tests moved with it.

The TUI's direct `adele-voice-core` dep is replaced by `adele-voice-client-common` (pulls `adele-voice-core` transitively for `SentenceBuffer`) — no new crates in the graph.

## Behavior — one intended de-drift

The TUI's refinement prose ("read aloud ... to be **heard**, not read") differed *textually* from gtk's ("... to be **spoken, not read**"). That divergence is exactly what desktop-assistant#274 calls out: these constants **must be byte-identical across clients**, which copy-paste failed. The shared crate canonicalizes to the gtk #80 lineage (tui #77 declared itself a mirror of it), so the exact refinement string the TUI now sends matches gtk. Same instruction intent (speak it, no markdown, spell out symbols) — a de-drift, not a functional regression.

Everything else is behavior-preserving. All 349 lib tests pass; `cargo fmt` + `cargo clippy --all-targets -- -D warnings` clean.

## Merge order

**Requires voice#102 merged to voice `main` first** (TUI consumes `../voice/crates/*` via a symlink to the voice primary checkout). Verified locally against the voice branch; CI here will go green once voice#102 lands. Lands together with / after the gtk adoption (adele-gtk#95).

Closes desktop-assistant#274

🤖 Generated with [Claude Code](https://claude.com/claude-code)