### PR TITLE
Context-window fill indicator in the status bar (#341)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,7 +1487,7 @@ dependencies = [
 [[package]]
 name = "desktop-assistant-api-model"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#6e176a36aaac2b8db08ba443f5b5c528b7920100"
+source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#dd7229d701a22f84fe357939b0eb9e2e78a675be"
 dependencies = [
  "desktop-assistant-core",
  "serde",
@@ -1497,7 +1497,7 @@ dependencies = [
 [[package]]
 name = "desktop-assistant-auth-jwt"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#6e176a36aaac2b8db08ba443f5b5c528b7920100"
+source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#dd7229d701a22f84fe357939b0eb9e2e78a675be"
 dependencies = [
  "anyhow",
  "jsonwebtoken",
@@ -1508,11 +1508,12 @@ dependencies = [
 [[package]]
 name = "desktop-assistant-client-common"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#6e176a36aaac2b8db08ba443f5b5c528b7920100"
+source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#dd7229d701a22f84fe357939b0eb9e2e78a675be"
 dependencies = [
  "anyhow",
  "async-trait",
  "desktop-assistant-api-model",
+ "desktop-assistant-frame-codec",
  "futures",
  "reqwest 0.13.3",
  "rustls",
@@ -1528,7 +1529,7 @@ dependencies = [
 [[package]]
 name = "desktop-assistant-core"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#6e176a36aaac2b8db08ba443f5b5c528b7920100"
+source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#dd7229d701a22f84fe357939b0eb9e2e78a675be"
 dependencies = [
  "async-trait",
  "backon",
@@ -1540,6 +1541,15 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "desktop-assistant-frame-codec"
+version = "0.1.0"
+source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#dd7229d701a22f84fe357939b0eb9e2e78a675be"
+dependencies = [
+ "tokio",
 ]
 
 [[package]]

--- a/src/app.rs
+++ b/src/app.rs
@@ -7,6 +7,84 @@ use ratatui_textarea::{CursorMove, DataCursor, TextArea};
 
 use crate::tasks::TaskPane;
 
+/// Context-window fill for the current conversation (desktop-assistant#341).
+/// Mirrors the daemon's `SignalEvent::ContextUsage` — token COUNTS only, no
+/// content. Drives the read-only status-bar indicator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ContextUsageView {
+    pub used_tokens: u64,
+    pub budget_tokens: u64,
+    pub compaction_active: bool,
+}
+
+/// Colour bucket for the context-fill indicator, decided by the daemon's
+/// proactive-compaction line (0.85 of budget). Green below 0.85, amber from
+/// 0.85 up to budget, red at/over budget (overflow).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContextFillLevel {
+    Green,
+    Amber,
+    Red,
+}
+
+/// The proactive-compaction ratio the daemon uses (`COMPACTION_TOKEN_RATIO`).
+/// Kept in sync deliberately — this is the colour-threshold contract, not a
+/// recomputation of the budget (the daemon owns the numbers).
+const COMPACTION_RATIO: f64 = 0.85;
+
+impl ContextUsageView {
+    /// Fraction of budget consumed (0.0..). May exceed 1.0 on overflow.
+    /// Returns 0.0 for a zero/unknown budget to avoid a divide-by-zero and
+    /// to render neutrally rather than imply false precision.
+    pub fn fraction(&self) -> f64 {
+        if self.budget_tokens == 0 {
+            0.0
+        } else {
+            self.used_tokens as f64 / self.budget_tokens as f64
+        }
+    }
+
+    pub fn level(&self) -> ContextFillLevel {
+        let f = self.fraction();
+        if f >= 1.0 {
+            ContextFillLevel::Red
+        } else if f >= COMPACTION_RATIO {
+            // Inclusive at exactly 0.85: the daemon's strict-`>` compaction
+            // gate means we are AT the line, the moment to warn (amber).
+            ContextFillLevel::Amber
+        } else {
+            ContextFillLevel::Green
+        }
+    }
+
+    /// Compact human readout, e.g. `12k / 32k (38%)`. A trailing `⟳` marks an
+    /// active compaction/windowing pass. Budgets below 10k show exact counts;
+    /// larger ones are abbreviated to `k` for width.
+    pub fn readout(&self) -> String {
+        let pct = (self.fraction() * 100.0).round() as u64;
+        let mut s = format!(
+            "{} / {} ({pct}%)",
+            abbrev_tokens(self.used_tokens),
+            abbrev_tokens(self.budget_tokens),
+        );
+        if self.compaction_active {
+            s.push_str(" ⟳");
+        }
+        s
+    }
+}
+
+/// Abbreviate a token count for the narrow status bar: `12000 -> "12k"`,
+/// `512 -> "512"`. One decimal under 10k-with-fraction is avoided to keep it
+/// terse; this is a glanceable instrument, not an accounting figure.
+fn abbrev_tokens(n: u64) -> String {
+    if n >= 1_000 {
+        format!("{}k", n / 1_000)
+    } else {
+        n.to_string()
+    }
+}
+
 fn new_textarea() -> TextArea<'static> {
     let mut ta = TextArea::default();
     ta.set_cursor_line_style(Style::default());
@@ -141,6 +219,12 @@ pub struct App {
     /// errors. Distinct from `status_message`, which is sticky user-facing
     /// feedback.
     pub assistant_status: Option<String>,
+    /// Most recent context-window fill for the open conversation (#341).
+    /// Updated by `SignalEvent::ContextUsage` each turn; cleared when the
+    /// open conversation changes so a stale reading never bleeds across
+    /// conversations. `None` = no reading yet (budget unknown / pre-first-turn),
+    /// rendered as nothing.
+    pub context_usage: Option<ContextUsageView>,
     /// Whether the conversation list pane is visible. When `false`, the chat
     /// panel takes the full window width.
     pub show_sidebar: bool,
@@ -213,6 +297,7 @@ impl App {
             renaming_id: None,
             show_debug: false,
             assistant_status: None,
+            context_usage: None,
             show_sidebar: true,
             switch_requested: false,
             kb_requested: false,
@@ -409,6 +494,17 @@ impl App {
             self.assistant_status = None;
         } else {
             self.assistant_status = Some(msg);
+        }
+    }
+
+    /// Record the latest context-window fill (#341). The daemon owns the
+    /// numbers; we only store and render. `conversation_id` lets us drop a
+    /// reading for a conversation that is not the one currently open (e.g. a
+    /// background turn), so the indicator always reflects the visible chat.
+    pub fn set_context_usage(&mut self, conversation_id: &str, usage: ContextUsageView) {
+        let open = self.current_conversation.as_ref().map(|c| c.id.as_str());
+        if open == Some(conversation_id) {
+            self.context_usage = Some(usage);
         }
     }
 
@@ -777,7 +873,14 @@ impl App {
     }
 
     pub fn load_conversation(&mut self, detail: ConversationDetail) {
+        let switching =
+            self.current_conversation.as_ref().map(|c| c.id.as_str()) != Some(detail.id.as_str());
         self.current_conversation = Some(detail);
+        // Drop a stale context-fill reading when the visible conversation
+        // changes; the next turn re-establishes it (#341).
+        if switching {
+            self.context_usage = None;
+        }
     }
 
     pub fn update_conversation_title(&mut self, conversation_id: &str, title: &str) {
@@ -889,6 +992,110 @@ impl Default for App {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- Context-usage indicator (#341) ---
+
+    fn usage(used: u64, budget: u64, compaction: bool) -> ContextUsageView {
+        ContextUsageView {
+            used_tokens: used,
+            budget_tokens: budget,
+            compaction_active: compaction,
+        }
+    }
+
+    #[test]
+    fn context_usage_readout_formats_used_over_budget_with_percent() {
+        assert_eq!(usage(12_000, 32_000, false).readout(), "12k / 32k (38%)");
+        // Small exact counts are not abbreviated.
+        assert_eq!(usage(500, 8_000, false).readout(), "500 / 8k (6%)");
+    }
+
+    #[test]
+    fn context_usage_readout_marks_active_compaction() {
+        assert!(usage(30_000, 32_000, true).readout().ends_with(" ⟳"));
+        assert!(!usage(30_000, 32_000, false).readout().contains('⟳'));
+    }
+
+    #[test]
+    fn context_usage_zero_used_at_turn_start_is_green_zero_percent() {
+        let u = usage(0, 32_000, false);
+        assert_eq!(u.level(), ContextFillLevel::Green);
+        assert_eq!(u.readout(), "0 / 32k (0%)");
+    }
+
+    #[test]
+    fn context_usage_below_threshold_is_green() {
+        // 0.84 of budget — just under the 0.85 line.
+        assert_eq!(
+            usage(26_880, 32_000, false).level(),
+            ContextFillLevel::Green
+        );
+    }
+
+    #[test]
+    fn context_usage_exactly_at_0_85_is_amber_inclusive() {
+        // 0.85 * 32_000 == 27_200. The amber threshold is inclusive at 0.85.
+        assert_eq!(
+            usage(27_200, 32_000, false).level(),
+            ContextFillLevel::Amber
+        );
+    }
+
+    #[test]
+    fn context_usage_between_threshold_and_budget_is_amber() {
+        assert_eq!(
+            usage(30_000, 32_000, false).level(),
+            ContextFillLevel::Amber
+        );
+    }
+
+    #[test]
+    fn context_usage_at_budget_is_red() {
+        assert_eq!(usage(32_000, 32_000, false).level(), ContextFillLevel::Red);
+    }
+
+    #[test]
+    fn context_usage_over_budget_overflow_is_red() {
+        let u = usage(40_000, 32_000, false);
+        assert_eq!(u.level(), ContextFillLevel::Red);
+        // Percent reads over 100 — honest overflow, not clamped.
+        assert_eq!(u.readout(), "40k / 32k (125%)");
+    }
+
+    #[test]
+    fn context_usage_zero_budget_renders_neutrally_without_panic() {
+        // 200K-fallback / unknown budget degenerate guard: no divide-by-zero,
+        // green, 0%.
+        let u = usage(5_000, 0, false);
+        assert_eq!(u.fraction(), 0.0);
+        assert_eq!(u.level(), ContextFillLevel::Green);
+        assert_eq!(u.readout(), "5k / 0 (0%)");
+    }
+
+    #[test]
+    fn set_context_usage_only_applies_to_open_conversation() {
+        let mut app = App::new();
+        app.load_conversation(detail("c1"));
+        // A reading for a different conversation (e.g. background turn) is dropped.
+        app.set_context_usage("c2", usage(10_000, 32_000, false));
+        assert_eq!(app.context_usage, None);
+        // A reading for the open conversation lands.
+        app.set_context_usage("c1", usage(10_000, 32_000, false));
+        assert_eq!(app.context_usage, Some(usage(10_000, 32_000, false)));
+    }
+
+    #[test]
+    fn switching_conversation_clears_stale_context_usage() {
+        let mut app = App::new();
+        app.load_conversation(detail("c1"));
+        app.set_context_usage("c1", usage(10_000, 32_000, false));
+        assert!(app.context_usage.is_some());
+        app.load_conversation(detail("c2"));
+        assert_eq!(
+            app.context_usage, None,
+            "stale reading must not bleed across"
+        );
+    }
 
     fn sample_conversations() -> Vec<ConversationSummary> {
         vec![

--- a/src/main.rs
+++ b/src/main.rs
@@ -1038,6 +1038,22 @@ async fn handle_signal(
         } => {
             app.set_assistant_status(message);
         }
+        SignalEvent::ContextUsage {
+            conversation_id,
+            request_id: _,
+            used_tokens,
+            budget_tokens,
+            compaction_active,
+        } => {
+            app.set_context_usage(
+                &conversation_id,
+                adele::app::ContextUsageView {
+                    used_tokens,
+                    budget_tokens,
+                    compaction_active,
+                },
+            );
+        }
         SignalEvent::TitleChanged {
             conversation_id,
             title,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -20,6 +20,11 @@ const COLOR_USER_PREFIX: Color = Color::Rgb(255, 189, 89);
 const COLOR_ASSISTANT_PREFIX: Color = Color::Rgb(92, 206, 154);
 const COLOR_ASSISTANT_STREAMING: Color = Color::Rgb(132, 218, 193);
 const COLOR_STATUS_DIM: Color = Color::Rgb(143, 153, 174);
+// Context-fill indicator colours (#341): green well under the 0.85
+// compaction line, amber approaching it, red at/over budget.
+const COLOR_CTX_GREEN: Color = Color::Rgb(122, 200, 132);
+const COLOR_CTX_AMBER: Color = Color::Rgb(232, 184, 96);
+const COLOR_CTX_RED: Color = Color::Rgb(232, 106, 106);
 const COLOR_COUNT_DIM: Color = Color::Rgb(124, 132, 148);
 const COLOR_DEBUG_TOOL: Color = Color::Rgb(178, 138, 220);
 const COLOR_DEBUG_SYSTEM: Color = Color::Rgb(140, 156, 196);
@@ -454,6 +459,28 @@ fn draw_status_bar(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
     } else {
         crate::tasks::running_badge(&app.tasks)
     };
+
+    // Right-aligned context-fill indicator (#341). Read-only; reflects the
+    // open conversation's last reported fill. Rendered before the left
+    // status text so a long status can't shove it off the bar.
+    if let Some(usage) = app.context_usage {
+        let (text, color) = context_usage_span(usage);
+        let w = text.chars().count() as u16;
+        if w + 2 <= area.width {
+            let right = ratatui::layout::Rect {
+                x: area.x + area.width - w - 1,
+                y: area.y,
+                width: w + 1,
+                height: area.height,
+            };
+            let para = Paragraph::new(Line::from(Span::styled(
+                text,
+                Style::default().fg(color).add_modifier(Modifier::BOLD),
+            )));
+            f.render_widget(para, right);
+        }
+    }
+
     if app.status_message.is_empty() && badge.is_empty() {
         return;
     }
@@ -476,11 +503,70 @@ fn draw_status_bar(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
     f.render_widget(status, area);
 }
 
+/// Build the context-fill readout text + colour for the status bar (#341).
+/// Pure so the colour-threshold contract is unit-testable without a frame.
+fn context_usage_span(usage: crate::app::ContextUsageView) -> (String, Color) {
+    use crate::app::ContextFillLevel;
+    let color = match usage.level() {
+        ContextFillLevel::Green => COLOR_CTX_GREEN,
+        ContextFillLevel::Amber => COLOR_CTX_AMBER,
+        ContextFillLevel::Red => COLOR_CTX_RED,
+    };
+    (usage.readout(), color)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::app::{ChatMessage, ConversationDetail, ConversationSummary};
     use ratatui::{Terminal, backend::TestBackend};
+
+    #[test]
+    fn context_usage_span_colours_track_thresholds() {
+        use crate::app::ContextUsageView;
+        let mk = |used, budget| ContextUsageView {
+            used_tokens: used,
+            budget_tokens: budget,
+            compaction_active: false,
+        };
+        // Green below 0.85.
+        assert_eq!(context_usage_span(mk(12_000, 32_000)).1, COLOR_CTX_GREEN);
+        // Amber at exactly 0.85 (27_200) and between line and budget.
+        assert_eq!(context_usage_span(mk(27_200, 32_000)).1, COLOR_CTX_AMBER);
+        assert_eq!(context_usage_span(mk(30_000, 32_000)).1, COLOR_CTX_AMBER);
+        // Red at/over budget.
+        assert_eq!(context_usage_span(mk(32_000, 32_000)).1, COLOR_CTX_RED);
+        assert_eq!(context_usage_span(mk(40_000, 32_000)).1, COLOR_CTX_RED);
+        // Text carries the readout.
+        assert_eq!(context_usage_span(mk(12_000, 32_000)).0, "12k / 32k (38%)");
+    }
+
+    #[test]
+    fn draw_with_context_usage_does_not_panic() {
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut app = App::new();
+        app.context_usage = Some(crate::app::ContextUsageView {
+            used_tokens: 30_000,
+            budget_tokens: 32_000,
+            compaction_active: true,
+        });
+        terminal.draw(|f| draw(f, &mut app)).unwrap();
+    }
+
+    #[test]
+    fn draw_with_context_usage_on_tiny_terminal_does_not_panic() {
+        // Narrow terminal: the readout must be skipped rather than overflow.
+        let backend = TestBackend::new(8, 6);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut app = App::new();
+        app.context_usage = Some(crate::app::ContextUsageView {
+            used_tokens: 30_000,
+            budget_tokens: 32_000,
+            compaction_active: false,
+        });
+        terminal.draw(|f| draw(f, &mut app)).unwrap();
+    }
 
     #[test]
     fn draw_empty_app_does_not_panic() {


### PR DESCRIPTION
## What
tui client side of #341. Renders a read-only `used / budget (pct%)` context-fill indicator, right-aligned in the status bar, from the daemon's `SignalEvent::ContextUsage` (token counts only).

Colour tracks the proactive-compaction line: **green** below 0.85 of budget, **amber** from 0.85 up to budget, **red** at/over budget (overflow). A trailing `⟳` marks an active windowing/compaction pass. The reading is per-conversation: it only applies to the open conversation and clears when you switch conversations, so a stale fill never bleeds across.

No client-side token counting — the daemon owns the numbers.

## Testing (named, edge-case-legible)
`context_usage_readout_formats_used_over_budget_with_percent`, `context_usage_readout_marks_active_compaction`, `context_usage_zero_used_at_turn_start_is_green_zero_percent`, `context_usage_below_threshold_is_green`, `context_usage_exactly_at_0_85_is_amber_inclusive`, `context_usage_between_threshold_and_budget_is_amber`, `context_usage_at_budget_is_red`, `context_usage_over_budget_overflow_is_red`, `context_usage_zero_budget_renders_neutrally_without_panic`, `set_context_usage_only_applies_to_open_conversation`, `switching_conversation_clears_stale_context_usage`, `context_usage_span_colours_track_thresholds`, `draw_with_context_usage_does_not_panic`, `draw_with_context_usage_on_tiny_terminal_does_not_panic`.

`just check` green. Depends on the daemon side (desktop-assistant#347, merged).

Refs #341

🤖 Generated with [Claude Code](https://claude.com/claude-code)