### PR TITLE
Catch up to desktop-assistant #349 (ConnectionConfigView new fields)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,7 +1487,7 @@ dependencies = [
 [[package]]
 name = "desktop-assistant-api-model"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#dd7229d701a22f84fe357939b0eb9e2e78a675be"
+source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#898eeb12404cd46169f98b422e4f391b9d5f7fa6"
 dependencies = [
  "desktop-assistant-core",
  "serde",
@@ -1497,7 +1497,7 @@ dependencies = [
 [[package]]
 name = "desktop-assistant-auth-jwt"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#dd7229d701a22f84fe357939b0eb9e2e78a675be"
+source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#898eeb12404cd46169f98b422e4f391b9d5f7fa6"
 dependencies = [
  "anyhow",
  "jsonwebtoken",
@@ -1508,7 +1508,7 @@ dependencies = [
 [[package]]
 name = "desktop-assistant-client-common"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#dd7229d701a22f84fe357939b0eb9e2e78a675be"
+source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#898eeb12404cd46169f98b422e4f391b9d5f7fa6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1529,7 +1529,7 @@ dependencies = [
 [[package]]
 name = "desktop-assistant-core"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#dd7229d701a22f84fe357939b0eb9e2e78a675be"
+source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#898eeb12404cd46169f98b422e4f391b9d5f7fa6"
 dependencies = [
  "async-trait",
  "backon",
@@ -1547,7 +1547,7 @@ dependencies = [
 [[package]]
 name = "desktop-assistant-frame-codec"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#dd7229d701a22f84fe357939b0eb9e2e78a675be"
+source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#898eeb12404cd46169f98b422e4f391b9d5f7fa6"
 dependencies = [
  "tokio",
 ]

--- a/src/connections.rs
+++ b/src/connections.rs
@@ -205,22 +205,41 @@ impl EditForm {
             if s.is_empty() { None } else { Some(s) }
         };
 
+        // The create form doesn't expose the advanced knobs (connect/stream
+        // timeouts, the context ceiling, or Ollama's keep-warm flag), so they
+        // default to `None` and the daemon applies its own defaults. The TUI's
+        // edit path doesn't echo config back either (it pre-fills from id/type
+        // only), so there's nothing to round-trip here — `None` is correct for
+        // both create and edit.
         let config = match self.kind {
             ConnectorKind::Anthropic => ConnectionConfigView::Anthropic {
                 base_url: opt(&self.base_url),
                 api_key_env: opt(&self.api_key_env),
+                connect_timeout_secs: None,
+                stream_timeout_secs: None,
+                max_context_tokens: None,
             },
             ConnectorKind::OpenAi => ConnectionConfigView::OpenAi {
                 base_url: opt(&self.base_url),
                 api_key_env: opt(&self.api_key_env),
+                connect_timeout_secs: None,
+                stream_timeout_secs: None,
+                max_context_tokens: None,
             },
             ConnectorKind::Bedrock => ConnectionConfigView::Bedrock {
                 aws_profile: opt(&self.aws_profile),
                 region: opt(&self.region),
                 base_url: opt(&self.base_url),
+                connect_timeout_secs: None,
+                stream_timeout_secs: None,
+                max_context_tokens: None,
             },
             ConnectorKind::Ollama => ConnectionConfigView::Ollama {
                 base_url: opt(&self.base_url),
+                connect_timeout_secs: None,
+                stream_timeout_secs: None,
+                keep_warm: None,
+                max_context_tokens: None,
             },
         };
 
@@ -962,6 +981,7 @@ mod tests {
             ConnectionConfigView::Anthropic {
                 api_key_env,
                 base_url,
+                ..
             } => {
                 assert_eq!(api_key_env.as_deref(), Some("WORK_KEY"));
                 assert!(base_url.is_none());
@@ -984,6 +1004,7 @@ mod tests {
                 aws_profile,
                 region,
                 base_url,
+                ..
             } => {
                 assert_eq!(aws_profile.as_deref(), Some("dev"));
                 assert_eq!(region.as_deref(), Some("us-east-1"));
@@ -1002,7 +1023,7 @@ mod tests {
         let (id, config) = form.submit().unwrap();
         assert_eq!(id, "local");
         match config {
-            ConnectionConfigView::Ollama { base_url } => {
+            ConnectionConfigView::Ollama { base_url, .. } => {
                 assert_eq!(base_url.as_deref(), Some("http://127.0.0.1:11434"));
             }
             other => panic!("expected Ollama, got {other:?}"),


### PR DESCRIPTION
## Why

adele-tui git-deps `desktop-assistant` (`branch = "main"`) for
`desktop-assistant-api-model` and `desktop-assistant-client-common`. Our
`Cargo.lock` was pinned to a pre-#349 commit, so it only compiled against
that stale pin. desktop-assistant **#349** added fields to the
`ConnectionConfigView` enum (`connect_timeout_secs`, `stream_timeout_secs`,
`max_context_tokens` on all variants, plus `keep_warm` on Ollama). A plain
`cargo install` re-resolves the git dep to latest `main` and was failing with
E0063 "missing fields" in `src/connections.rs`.

## What

- **`Cargo.lock`** — bumped the desktop-assistant git deps to current `main`
  (`dd7229d7` → `898eeb12`, 5 workspace crates). This pulls the #349+
  api-model that *has* the new fields.
- **`src/connections.rs`** — set the new fields to `None` in each
  `ConnectionConfigView` variant in the create form's `submit()` (the TUI
  doesn't expose these advanced knobs, and its edit path doesn't echo config
  back, so the daemon applies its own defaults). Added `..` to the test match
  patterns so they stay exhaustive against the wider enum. Mirrors
  adele-gtk #98's `empty_config()`.

No other compile errors surfaced from the dep bump. This is a version
catch-up, not a feature.

## Verification

```
$ timeout 480 cargo build 2>&1 | tail -3
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 11.64s

$ timeout 360 cargo clippy --all-targets -- -D warnings   # (no warnings/errors)
$ cargo fmt --all --check  ->  FMT_OK
$ timeout 360 cargo test
test result: ok. 363 passed; 0 failed; 1 ignored
test result: ok. 15 passed; 0 failed; 0 ignored
test result: ok. 4 passed; 0 failed; 0 ignored
test result: ok. 0 passed; 0 failed; 0 ignored
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)