### PR TITLE
Render externally-initiated (voice) turns live in the open conversation (#1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,7 +1487,7 @@ dependencies = [
 [[package]]
 name = "desktop-assistant-api-model"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#898eeb12404cd46169f98b422e4f391b9d5f7fa6"
+source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#61a70ff6cbba05b3824919f0c01c0037d4c5957a"
 dependencies = [
  "desktop-assistant-core",
  "serde",
@@ -1497,7 +1497,7 @@ dependencies = [
 [[package]]
 name = "desktop-assistant-auth-jwt"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#898eeb12404cd46169f98b422e4f391b9d5f7fa6"
+source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#61a70ff6cbba05b3824919f0c01c0037d4c5957a"
 dependencies = [
  "anyhow",
  "jsonwebtoken",
@@ -1508,7 +1508,7 @@ dependencies = [
 [[package]]
 name = "desktop-assistant-client-common"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#898eeb12404cd46169f98b422e4f391b9d5f7fa6"
+source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#61a70ff6cbba05b3824919f0c01c0037d4c5957a"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1529,7 +1529,7 @@ dependencies = [
 [[package]]
 name = "desktop-assistant-core"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#898eeb12404cd46169f98b422e4f391b9d5f7fa6"
+source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#61a70ff6cbba05b3824919f0c01c0037d4c5957a"
 dependencies = [
  "async-trait",
  "backon",
@@ -1547,7 +1547,7 @@ dependencies = [
 [[package]]
 name = "desktop-assistant-frame-codec"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#898eeb12404cd46169f98b422e4f391b9d5f7fa6"
+source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#61a70ff6cbba05b3824919f0c01c0037d4c5957a"
 dependencies = [
  "tokio",
 ]

--- a/src/app.rs
+++ b/src/app.rs
@@ -200,6 +200,13 @@ pub struct App {
     /// `pending_request_id` is `Some`. Completion appends to — and narration
     /// gates on — THIS conversation, not whichever one is open at the time.
     pub streaming_conversation_id: Option<String>,
+    /// `true` when the in-flight turn was NOT initiated by this client — adopted
+    /// from a `UserMessageAdded` for a turn started elsewhere (a voice turn, or
+    /// another client on the same account) so its reply streams live (#1).
+    /// Suppresses tui's own reply narration for it: the originator (e.g. the
+    /// voice daemon) already speaks the reply, so narrating again would
+    /// double-speak. Reset whenever the in-flight slot is (re)set or cleared.
+    pub streaming_is_external: bool,
     pub mode: InputMode,
     pub status_message: String,
     pub should_quit: bool,
@@ -288,6 +295,7 @@ impl App {
             streaming_buffer: String::new(),
             pending_request_id: None,
             streaming_conversation_id: None,
+            streaming_is_external: false,
             mode: InputMode::Normal,
             status_message: "Connected".to_string(),
             should_quit: false,
@@ -744,6 +752,9 @@ impl App {
         self.pending_request_id = Some(request_id);
         self.streaming_conversation_id = Some(conversation_id);
         self.streaming_buffer.clear();
+        // A turn entering the slot via the normal send path is this client's
+        // own; only `user_message_added` flips this true for an adopted turn.
+        self.streaming_is_external = false;
     }
 
     pub fn start_streaming_without_request_id(&mut self, conversation_id: String) {
@@ -780,6 +791,7 @@ impl App {
         self.streaming_conversation_id = None;
         self.streaming_buffer.clear();
         self.assistant_status = None;
+        self.streaming_is_external = false;
     }
 
     /// Move the sidebar selection to the conversation with `id`, returning
@@ -842,6 +854,7 @@ impl App {
         self.streaming_buffer.clear();
         self.pending_request_id = None;
         self.assistant_status = None;
+        self.streaming_is_external = false;
         origin
     }
 
@@ -854,6 +867,48 @@ impl App {
         self.pending_request_id = None;
         self.streaming_conversation_id = None;
         self.assistant_status = None;
+        self.streaming_is_external = false;
+    }
+
+    /// Handle a `UserMessageAdded` (#1): the daemon announces a user message and
+    /// the turn it begins. For a turn this client did NOT initiate (a voice turn,
+    /// or another client on the same account) showing in the open conversation,
+    /// render the user bubble and adopt the turn so its reply streams live;
+    /// dedupe this client's own send (already shown optimistically).
+    pub fn user_message_added(&mut self, conversation_id: &str, request_id: &str, content: &str) {
+        // Case 1 — our own send, echoed back. `prepare_submission` already
+        // appended the user message and `apply_prompt_ack` pinned the sentinel
+        // (both run inline before any signal is processed). Claim the real
+        // request_id off the sentinel — it precedes the first chunk — and render
+        // nothing more. This also resolves the stream's request_id earlier and
+        // more reliably than the claim-on-first-chunk fallback.
+        if self.pending_request_id.as_deref() == Some(Self::PENDING_STREAM_REQUEST_ID)
+            && self.streaming_conversation_id.as_deref() == Some(conversation_id)
+        {
+            self.pending_request_id = Some(request_id.to_string());
+            return;
+        }
+        // Case 2 — a turn this client did NOT initiate, for the conversation on
+        // screen, with no turn already occupying the single in-flight slot. Adopt
+        // it so the existing chunk/completion path streams the reply live, append
+        // the user message now, and mark it external so its reply is NOT narrated
+        // here (the originator already speaks it). A turn for a background
+        // conversation, or one arriving while our own turn is in flight, is left
+        // to the reload-on-switch path (the daemon persists it).
+        let is_displayed =
+            self.current_conversation.as_ref().map(|c| c.id.as_str()) == Some(conversation_id);
+        if self.pending_request_id.is_none() && is_displayed {
+            self.pending_request_id = Some(request_id.to_string());
+            self.streaming_conversation_id = Some(conversation_id.to_string());
+            self.streaming_buffer.clear();
+            self.streaming_is_external = true;
+            if let Some(conv) = self.current_conversation.as_mut() {
+                conv.messages.push(ChatMessage {
+                    role: "user".to_string(),
+                    content: content.to_string(),
+                });
+            }
+        }
     }
 
     // --- Conversation management ---
@@ -1839,6 +1894,139 @@ mod tests {
         assert_eq!(app.status_message, "Error: LLM timeout");
         assert_eq!(app.pending_request_id, None);
         assert_eq!(app.streaming_buffer, "");
+    }
+
+    // --- Live external-turn rendering (#1) --------------------------------
+
+    /// A `UserMessageAdded` for the open conversation, with no turn in flight,
+    /// is a turn this client did not initiate (voice / another client). It
+    /// renders the user message and adopts the turn so the reply streams live.
+    #[test]
+    fn external_user_message_in_open_conversation_renders_and_adopts() {
+        let mut app = app_with_open_conversation("c1");
+        app.user_message_added("c1", "voice-req", "what's the weather?");
+
+        let msgs = &app.current_conversation.as_ref().unwrap().messages;
+        assert_eq!(msgs.len(), 1, "the external user message must be rendered");
+        assert_eq!(msgs[0].role, "user");
+        assert_eq!(msgs[0].content, "what's the weather?");
+        assert_eq!(
+            app.pending_request_id.as_deref(),
+            Some("voice-req"),
+            "the turn must be adopted so its reply streams live"
+        );
+        assert_eq!(app.streaming_conversation_id.as_deref(), Some("c1"));
+        assert!(
+            app.streaming_is_external,
+            "an adopted turn is external so tui does not also narrate it"
+        );
+    }
+
+    /// This client's own send is echoed back as `UserMessageAdded`. The user
+    /// message was already appended optimistically and the sentinel pinned, so
+    /// the echo renders nothing — it only claims the real request_id.
+    #[test]
+    fn own_send_echo_dedupes_and_claims_request_id() {
+        let mut app = app_with_open_conversation("c1");
+        // Mirror the local send: optimistic append + sentinel via the ack.
+        app.current_conversation
+            .as_mut()
+            .unwrap()
+            .messages
+            .push(ChatMessage {
+                role: "user".to_string(),
+                content: "typed this".to_string(),
+            });
+        app.apply_prompt_ack(String::new(), "c1".to_string());
+
+        app.user_message_added("c1", "real-req", "typed this");
+
+        assert_eq!(
+            app.current_conversation.as_ref().unwrap().messages.len(),
+            1,
+            "our own send's echo must not double-append the user message"
+        );
+        assert_eq!(
+            app.pending_request_id.as_deref(),
+            Some("real-req"),
+            "the echo must claim the real request_id off the sentinel"
+        );
+        assert!(
+            !app.streaming_is_external,
+            "our own turn must NOT be flagged external (tui owns its narration)"
+        );
+    }
+
+    /// An adopted external turn is narrated by its originator — tui must not
+    /// also speak it even when the conversation's gate is open. Verifies the
+    /// flag main.rs captures (`was_external`) to suppress `enqueue_narration`.
+    #[test]
+    fn adopted_external_turn_suppresses_tui_narration() {
+        let mut app = app_with_open_conversation("c1");
+        app.set_adele_output("c1", AdeleOutput::Always);
+        assert!(
+            app.narrate_for("c1"),
+            "precondition: the gate alone would narrate (Adele=Always)"
+        );
+
+        app.user_message_added("c1", "voice-req", "a question");
+        // main.rs captures this BEFORE complete_streaming resets it, then gates
+        // narration on `!was_external && narrate_for(origin)`.
+        let was_external = app.streaming_is_external;
+        let origin = app.complete_streaming("voice-req", "the spoken answer");
+
+        assert!(was_external, "external turn must suppress tui narration");
+        assert_eq!(origin.as_deref(), Some("c1"));
+        assert!(
+            !app.streaming_is_external,
+            "the external flag must reset at turn completion"
+        );
+    }
+
+    /// A `UserMessageAdded` for a conversation NOT on screen is left to the
+    /// reload-on-switch path — it must not touch the open transcript or the
+    /// in-flight slot.
+    #[test]
+    fn external_turn_for_background_conversation_is_ignored() {
+        let mut app = app_with_open_conversation("c1");
+        app.user_message_added("c2", "bg-req", "background");
+
+        assert!(
+            app.current_conversation
+                .as_ref()
+                .unwrap()
+                .messages
+                .is_empty(),
+            "a background turn must not render into the open transcript"
+        );
+        assert!(
+            app.pending_request_id.is_none(),
+            "a background turn must not be adopted into the in-flight slot"
+        );
+    }
+
+    /// While this client's own turn is in flight, a concurrent external turn is
+    /// NOT adopted — the single in-flight slot stays bound to our turn.
+    #[test]
+    fn external_turn_ignored_while_own_turn_in_flight() {
+        let mut app = app_with_open_conversation("c1");
+        app.start_streaming("mine".to_string(), "c1".to_string());
+
+        app.user_message_added("c1", "other", "concurrent");
+
+        assert_eq!(
+            app.pending_request_id.as_deref(),
+            Some("mine"),
+            "the in-flight turn's slot must be preserved"
+        );
+        assert!(
+            app.current_conversation
+                .as_ref()
+                .unwrap()
+                .messages
+                .is_empty(),
+            "must not append a second user message while a turn is in flight"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1004,12 +1004,28 @@ async fn handle_signal(
     signal: SignalEvent,
 ) -> SignalAction {
     match signal {
-        SignalEvent::Chunk { request_id, chunk } => {
+        // A user message was committed and a turn started (#1). For our own send
+        // this dedupes (the bubble was drawn optimistically); for a turn started
+        // elsewhere (a voice turn) in the open conversation it renders the user
+        // bubble and adopts the turn so its reply streams live. All streaming
+        // events now carry `conversation_id` too, but the in-flight slot routes
+        // them by `request_id`, so it is dropped on those arms.
+        SignalEvent::UserMessageAdded {
+            conversation_id,
+            request_id,
+            content,
+        } => {
+            app.user_message_added(&conversation_id, &request_id, &content);
+        }
+        SignalEvent::Chunk {
+            request_id, chunk, ..
+        } => {
             app.receive_chunk(&request_id, &chunk);
         }
         SignalEvent::Complete {
             request_id,
             full_response,
+            ..
         } => {
             // `complete_streaming` reports the ORIGINATING conversation (TUI-4) —
             // the one the prompt was sent to, not whichever is open now — and the
@@ -1020,21 +1036,29 @@ async fn handle_signal(
             // `say_this` aside; the queue task speaks it so synth never blocks the
             // UI. Gated entirely here so the cut-off holds: when the gate is false
             // nothing is spoken on any path.
+            // An adopted external turn (a voice turn, or another client) is
+            // narrated by its originator — tui must not also speak it. Capture
+            // the flag before `complete_streaming` resets it.
+            let was_external = app.streaming_is_external;
             let origin = app.complete_streaming(&request_id, &full_response);
             if let Some(origin) = origin
+                && !was_external
                 && app.narrate_for(&origin)
                 && !full_response.trim().is_empty()
             {
                 enqueue_narration(narration_tx, voice_daemon, voice_session, full_response);
             }
         }
-        SignalEvent::Error { request_id, error } => {
+        SignalEvent::Error {
+            request_id, error, ..
+        } => {
             app.streaming_error(&request_id, &error);
             app.status_message = format!("Error: {error}");
         }
         SignalEvent::Status {
             request_id: _,
             message,
+            ..
         } => {
             app.set_assistant_status(message);
         }


### PR DESCRIPTION
## Problem

tui routed streaming events **only** by matching its own in-flight stream's `request_id` (set on its own sends via the `__pending_stream_request_id__` sentinel). A turn started elsewhere — a **voice** turn, or another client on the same account — never established that state, so even while its conversation was on screen its chunks were dropped. The turn only appeared after switching away and back (reload pulls the daemon-persisted messages).

## Fix

Consume the new `UserMessageAdded` event (desktop-assistant #353), mirroring adele-gtk #102:

- **Own send echo** — tui already appended the user message optimistically (`prepare_submission`) and pinned the sentinel (`apply_prompt_ack`), both inline before any signal is processed; the echo just claims the real `request_id` (it precedes the first chunk) and renders nothing.
- **External turn for the open conversation, no turn in flight** — adopt it into the in-flight slot so the existing chunk/completion path streams the reply live, append the user message now, and set `streaming_is_external` so the reply is **not** narrated here — the originator (e.g. the voice daemon) already speaks it. `handle_signal` captures the flag before `complete_streaming` resets it and gates `enqueue_narration` on `!was_external`.
- **Background / concurrent** — a turn for a conversation not on screen, or one arriving while tui's own turn is in flight, is left to the reload-on-switch path (unchanged).

## Graceful degradation

No hard dependency on the new event: against an older daemon that doesn't emit `UserMessageAdded`, tui behaves exactly as before. Bumps the desktop-assistant git pin to #353 (`61a70ff`).

## Tests

5 new `App` cases — adopt+render, own-echo dedupe, external-suppresses-narration, background-ignored, in-flight-ignored. 368 pass; `fmt`/`clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)