### PR TITLE
Subscribe to the open conversation for live multi-client turn sync (#1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1487,7 +1487,7 @@ dependencies = [
 [[package]]
 name = "desktop-assistant-api-model"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#61a70ff6cbba05b3824919f0c01c0037d4c5957a"
+source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#7487119ddffe6d9c137e3693abf58fc8862a8071"
 dependencies = [
  "desktop-assistant-core",
  "serde",
@@ -1497,7 +1497,7 @@ dependencies = [
 [[package]]
 name = "desktop-assistant-auth-jwt"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#61a70ff6cbba05b3824919f0c01c0037d4c5957a"
+source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#7487119ddffe6d9c137e3693abf58fc8862a8071"
 dependencies = [
  "anyhow",
  "jsonwebtoken",
@@ -1508,7 +1508,7 @@ dependencies = [
 [[package]]
 name = "desktop-assistant-client-common"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#61a70ff6cbba05b3824919f0c01c0037d4c5957a"
+source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#7487119ddffe6d9c137e3693abf58fc8862a8071"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1529,7 +1529,7 @@ dependencies = [
 [[package]]
 name = "desktop-assistant-core"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#61a70ff6cbba05b3824919f0c01c0037d4c5957a"
+source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#7487119ddffe6d9c137e3693abf58fc8862a8071"
 dependencies = [
  "async-trait",
  "backon",
@@ -1547,7 +1547,7 @@ dependencies = [
 [[package]]
 name = "desktop-assistant-frame-codec"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#61a70ff6cbba05b3824919f0c01c0037d4c5957a"
+source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#7487119ddffe6d9c137e3693abf58fc8862a8071"
 dependencies = [
  "tokio",
 ]

--- a/src/app.rs
+++ b/src/app.rs
@@ -420,6 +420,10 @@ impl App {
             return false;
         }
         conv.messages.push(ChatMessage {
+            // Local-only inline note (never persisted daemon-side), so it has no
+            // daemon-assigned message id (#1): the dedupe/ordering cursor is only
+            // meaningful for daemon-sourced messages.
+            id: String::new(),
             role: "assistant".to_string(),
             content: format!("(speech mode disabled) {text}"),
         });
@@ -634,6 +638,11 @@ impl App {
         }
         let conv = self.current_conversation.as_mut()?;
         conv.messages.push(ChatMessage {
+            // Optimistic local echo of our own send; the daemon assigns the real
+            // message id (#1) when it persists the turn. Dedupe of the echoed-back
+            // `UserMessageAdded` is by request_id, not message id (see
+            // `user_message_added`), so an empty id here is correct.
+            id: String::new(),
             role: "user".to_string(),
             content: content.clone(),
         });
@@ -847,6 +856,11 @@ impl App {
             .filter(|c| origin.as_deref() == Some(c.id.as_str()))
         {
             conv.messages.push(ChatMessage {
+                // Local copy of the just-streamed reply; the daemon already
+                // persisted the authoritative message (with its #1 id), which is
+                // re-fetched on the next open. Streaming dedupe is by request_id,
+                // so an empty id here is correct.
+                id: String::new(),
                 role: "assistant".to_string(),
                 content: full_response.to_string(),
             });
@@ -904,6 +918,11 @@ impl App {
             self.streaming_is_external = true;
             if let Some(conv) = self.current_conversation.as_mut() {
                 conv.messages.push(ChatMessage {
+                    // Adopted external user bubble (#1 live sync). The turn is
+                    // tracked by request_id, not message id, so an empty id is
+                    // correct; the persisted message (with its real id) is
+                    // re-fetched on the next open.
+                    id: String::new(),
                     role: "user".to_string(),
                     content: content.to_string(),
                 });
@@ -1654,6 +1673,7 @@ mod tests {
             id: "c2".into(),
             title: "Other".into(),
             messages: vec![ChatMessage {
+                id: String::new(),
                 role: "user".into(),
                 content: "prompt for c1".into(), // same text, different conv
             }],
@@ -1682,6 +1702,7 @@ mod tests {
             .unwrap()
             .messages
             .push(ChatMessage {
+                id: String::new(),
                 role: "assistant".into(),
                 content: "(speech mode disabled) aside".into(),
             });
@@ -1934,6 +1955,7 @@ mod tests {
             .unwrap()
             .messages
             .push(ChatMessage {
+                id: String::new(),
                 role: "user".to_string(),
                 content: "typed this".to_string(),
             });

--- a/src/main.rs
+++ b/src/main.rs
@@ -824,7 +824,15 @@ async fn run(
             // and redraw never wait on a slow/wedged daemon round-trip. When no
             // RPC is in flight this arm is pending-forever (an inert branch).
             Some(outcome) = in_flight.next() => {
-                apply_rpc_outcome(&mut app, outcome);
+                // When the open conversation changed (open/create), (re)point the
+                // daemon's live turn-event fan-out at the now-open conversation
+                // (#1 multi-client sync) so turns started elsewhere — another
+                // client, or the voice daemon — render live here.
+                if apply_rpc_outcome(&mut app, outcome)
+                    && let Some(conn) = connector.as_ref()
+                {
+                    subscribe_to_open_conversation(&mut app, conn).await;
+                }
             }
         }
     }
@@ -891,7 +899,13 @@ enum RpcOutcome {
 /// Apply a completed [`RpcOutcome`] to `App` (TUI-5 / #83). This is the only
 /// place RPC results touch `App`; it runs on the event loop after the RPC has
 /// resolved off it.
-fn apply_rpc_outcome(app: &mut App, outcome: RpcOutcome) {
+///
+/// Returns `true` when the open conversation changed (an open/create succeeded),
+/// so the caller can (re)send `SubscribeConversations` for the now-open
+/// conversation (#1 live multi-client sync) — this function stays transport-free,
+/// so the actual command send happens on the event loop where the connector
+/// lives.
+fn apply_rpc_outcome(app: &mut App, outcome: RpcOutcome) -> bool {
     match outcome {
         RpcOutcome::ConversationOpened {
             result,
@@ -902,6 +916,7 @@ fn apply_rpc_outcome(app: &mut App, outcome: RpcOutcome) {
                 if enter_editing {
                     app.enter_editing_mode();
                 }
+                return true;
             }
             Err(e) => app.status_message = format!("Error: {e}"),
         },
@@ -914,7 +929,7 @@ fn apply_rpc_outcome(app: &mut App, outcome: RpcOutcome) {
                 Ok(id) => id,
                 Err(e) => {
                     app.status_message = format!("Create error: {e}");
-                    return;
+                    return false;
                 }
             };
             match list {
@@ -932,6 +947,7 @@ fn apply_rpc_outcome(app: &mut App, outcome: RpcOutcome) {
                 Some(Ok(detail)) => {
                     app.load_conversation(detail);
                     app.enter_editing_mode();
+                    return true;
                 }
                 Some(Err(e)) => app.status_message = format!("Error opening: {e}"),
                 None => {}
@@ -972,6 +988,8 @@ fn apply_rpc_outcome(app: &mut App, outcome: RpcOutcome) {
             }
         }
     }
+    // No open-conversation change on any path that reached here.
+    false
 }
 
 /// What [`handle_signal`] asks its caller to do after handling a signal. Almost
@@ -1750,6 +1768,12 @@ async fn subscribe_and_load(app: &mut App, conn: &Connector) -> UnboundedReceive
 /// reconnect paths so the two can't drift.
 async fn finish_connection_init(app: &mut App, conn: &Connector) {
     init_background_tasks(app, conn.client()).await;
+    // (Re)establish the live turn-event subscription for the currently-open
+    // conversation (#1 multi-client sync) on every (re)connect — on the initial
+    // connect nothing is open yet, so this sends an empty set; on a reconnect the
+    // open conversation was already re-fetched by the reconnect resync before this
+    // call, so this re-points the daemon's fan-out at it.
+    subscribe_to_open_conversation(app, conn).await;
     register_client_tools(conn).await;
     app.status_message = conn.label().to_string();
 }
@@ -1936,6 +1960,42 @@ async fn init_background_tasks(
     }
 }
 
+/// The set of conversation ids the TUI is currently viewing, for
+/// `SubscribeConversations` (#1 live multi-client sync). The TUI shows exactly
+/// one conversation at a time, so this is `[open id]` when a conversation is
+/// open and empty otherwise. The command is set-replace, so an empty list tells
+/// the daemon to stop fanning any conversation's turn events to this connection.
+fn open_conversation_ids(app: &App) -> Vec<String> {
+    app.current_conversation
+        .as_ref()
+        .map(|c| vec![c.id.clone()])
+        .unwrap_or_default()
+}
+
+/// Tell the daemon which conversation this connection is viewing (#1 live
+/// multi-client sync) so it fans that conversation's turn events
+/// (`UserMessageAdded`/`AssistantDelta`/`AssistantCompleted`/`AssistantError`/
+/// `AssistantStatus`) here — including turns started by another client or the
+/// voice daemon. Sent on (re)connect and whenever the open conversation changes;
+/// it is set-replace, so each send carries the WHOLE viewed set.
+///
+/// Rides the shared command channel (`as_commands`), like
+/// [`init_background_tasks`]. Best-effort: a send failure (or a transport that
+/// doesn't accept the command) only surfaces a status hint — live sync is an
+/// enhancement, and turns this connection initiates still arrive via its own
+/// request stream regardless.
+async fn subscribe_to_open_conversation(app: &mut App, conn: &Connector) {
+    let Some(commands) = conn.client().as_commands() else {
+        return;
+    };
+    let cmd = desktop_assistant_api_model::Command::SubscribeConversations {
+        conversation_ids: open_conversation_ids(app),
+    };
+    if let Err(e) = commands.send_command(cmd).await {
+        app.status_message = format!("Live-sync subscribe failed: {e}");
+    }
+}
+
 async fn fetch_conversations(
     client: &desktop_assistant_client_common::TransportClient,
     include_archived: bool,
@@ -2116,5 +2176,49 @@ mod tests {
             ReconnectState::Pending { delay_secs, .. } => assert_eq!(delay_secs, 8),
             _ => panic!("expected Pending"),
         }
+    }
+
+    // --- Live conversation subscription (#1 multi-client sync) ---
+    //
+    // `open_conversation_ids` computes the `SubscribeConversations` set the TUI
+    // sends on (re)connect and on every conversation switch. The TUI views one
+    // conversation at a time, so the set is `[open id]` or empty.
+
+    fn detail(id: &str) -> ConversationDetail {
+        ConversationDetail {
+            id: id.into(),
+            title: format!("Conv {id}"),
+            messages: vec![],
+            model_selection: None,
+            conversation_personality: None,
+        }
+    }
+
+    #[test]
+    fn open_conversation_ids_is_empty_with_nothing_open() {
+        let app = App::new();
+        assert!(app.current_conversation.is_none());
+        // Set-replace semantics: an empty set tells the daemon to stop fanning
+        // any conversation's turn events here (e.g. the initial connect, before
+        // anything is opened).
+        assert!(open_conversation_ids(&app).is_empty());
+    }
+
+    #[test]
+    fn open_conversation_ids_is_the_single_open_conversation() {
+        let mut app = App::new();
+        app.load_conversation(detail("conv-42"));
+        assert_eq!(open_conversation_ids(&app), vec!["conv-42".to_string()]);
+    }
+
+    #[test]
+    fn open_conversation_ids_follows_a_switch() {
+        let mut app = App::new();
+        app.load_conversation(detail("conv-1"));
+        assert_eq!(open_conversation_ids(&app), vec!["conv-1".to_string()]);
+        // Switching conversations re-points the subscription at the new one (the
+        // whole set, since it's set-replace, not a delta).
+        app.load_conversation(detail("conv-2"));
+        assert_eq!(open_conversation_ids(&app), vec!["conv-2".to_string()]);
     }
 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -609,10 +609,12 @@ mod tests {
             title: "Test".into(),
             messages: vec![
                 ChatMessage {
+                    id: String::new(),
                     role: "user".into(),
                     content: "Hello".into(),
                 },
                 ChatMessage {
+                    id: String::new(),
                     role: "assistant".into(),
                     content: "Hi there!".into(),
                 },
@@ -795,22 +797,27 @@ mod tests {
             title: "Test".into(),
             messages: vec![
                 ChatMessage {
+                    id: String::new(),
                     role: "user".into(),
                     content: "Hello".into(),
                 },
                 ChatMessage {
+                    id: String::new(),
                     role: "tool".into(),
                     content: "ran search(foo)".into(),
                 },
                 ChatMessage {
+                    id: String::new(),
                     role: "system".into(),
                     content: "context updated".into(),
                 },
                 ChatMessage {
+                    id: String::new(),
                     role: "assistant".into(),
                     content: "".into(), // empty — only shown in debug
                 },
                 ChatMessage {
+                    id: String::new(),
                     role: "assistant".into(),
                     content: "Hi there!".into(),
                 },
@@ -921,6 +928,7 @@ mod tests {
             id: "1".into(),
             title: "Test".into(),
             messages: vec![ChatMessage {
+                id: String::new(),
                 role: "assistant".into(),
                 content: "answer with **strong** word".into(),
             }],


### PR DESCRIPTION
## What

Make the TUI tell the daemon which conversation it is viewing, so the daemon fans that conversation's turn events to it — the live multi-client sync delivery that just landed in desktop-assistant.

The daemon now exposes `Command::SubscribeConversations { conversation_ids: Vec<String> }`. It is **set-replace**: the client sends the WHOLE set of conversations it is currently viewing each time that set changes, and the daemon fans turn events (`UserMessageAdded` / `AssistantDelta` / `AssistantCompleted` / `AssistantError` / `AssistantStatus`) for those conversations to this connection — including turns started by **other clients or the voice daemon**.

The rendering side already landed in #100 (it adopts an externally-initiated `UserMessageAdded` and streams the reply live). This PR only **sends the subscription at the right times** so those events start arriving.

## Where/when the subscription is sent

The TUI shows one conversation at a time, so the set is `[open conversation id]` (or empty when nothing is open). Sent:

- **Whenever the open conversation changes.** `apply_rpc_outcome` now returns whether the open conversation changed (a successful open/create), and the event-loop arm fires `subscribe_to_open_conversation` when it did. `apply_rpc_outcome` stays transport-free; the actual command send happens on the loop, where the connector lives.
- **On (re)connect.** `finish_connection_init` — run on both the initial connect and every reconnect — sends it for the currently-open conversation. On the initial connect nothing is open yet, so this sends an empty set; on a reconnect the open conversation was already re-fetched by the reconnect resync before this call, so this re-points the daemon's fan-out at it.

The send rides the shared command channel (`as_commands`), mirroring how `SubscribeBackgroundTasks` is sent, and is best-effort (a failure only surfaces a status hint; turns this connection initiates still arrive via its own request stream regardless).

## Lock bump + ChatMessage catch-up

Bumps the `desktop-assistant` git-dep lock (`61a70ff` → `7487119`) to pick up the new daemon code (the `SubscribeConversations` command). That revision also widened `ChatMessage` with a `#1` UUIDv7 `id` field, so the locally-constructed (optimistic / local-only) messages now set it — empty, since TUI dedupe is by `request_id`, not message id, and daemon-sourced messages get the real id via `From<api::MessageView>`.

## No rendering changes

Rendering of incoming external-turn events already exists (#100). This PR does not touch it.

## Tests

- `cargo build`, `cargo test` (all pass), `cargo fmt --all -- --check` (clean), `cargo clippy --all-targets` (clean — warnings are denied).
- Added focused tests for the pure `open_conversation_ids` helper: empty when nothing is open, the single open id, and that it follows a switch.

Part of #1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)