### PR TITLE
Migrate adele-tui onto the shared client-ui-common core (CC-3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,7 @@ dependencies = [
  "adele-voice-vad-silero",
  "anyhow",
  "clap",
+ "client-ui-common",
  "crossterm",
  "desktop-assistant-api-model",
  "desktop-assistant-client-common",
@@ -1154,6 +1155,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "client-ui-common"
+version = "0.1.0"
+dependencies = [
+ "adele-voice-client-common",
+ "desktop-assistant-api-model",
+ "desktop-assistant-client-common",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1487,7 +1499,6 @@ dependencies = [
 [[package]]
 name = "desktop-assistant-api-model"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#41ea81311efa2e028da571744fb2e9c580066ec6"
 dependencies = [
  "desktop-assistant-core",
  "serde",
@@ -1497,7 +1508,6 @@ dependencies = [
 [[package]]
 name = "desktop-assistant-auth-jwt"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#41ea81311efa2e028da571744fb2e9c580066ec6"
 dependencies = [
  "anyhow",
  "jsonwebtoken",
@@ -1508,7 +1518,6 @@ dependencies = [
 [[package]]
 name = "desktop-assistant-client-common"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#41ea81311efa2e028da571744fb2e9c580066ec6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1529,7 +1538,6 @@ dependencies = [
 [[package]]
 name = "desktop-assistant-core"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#41ea81311efa2e028da571744fb2e9c580066ec6"
 dependencies = [
  "async-trait",
  "backon",
@@ -1547,7 +1555,6 @@ dependencies = [
 [[package]]
 name = "desktop-assistant-frame-codec"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/desktop-assistant.git?branch=main#41ea81311efa2e028da571744fb2e9c580066ec6"
 dependencies = [
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,9 @@ zbus = { version = "5", default-features = false, features = ["tokio"] }
 desktop-assistant-client-common = { git = "https://github.com/adelie-ai/desktop-assistant.git", branch = "main" }
 desktop-assistant-api-model = { git = "https://github.com/adelie-ai/desktop-assistant.git", branch = "main" }
 
+# The shared view-agnostic model+controller (CC-3, desktop-assistant#358).
+client-ui-common = { path = "../client-ui-common" }
+
 # Embeddable voice module (adelie-ai/voice phase 1) for in-app dictation +
 # reply playback with no voice daemon — see adele-tui#67 / voice#34. Path-dep
 # of the sibling `voice` checkout, mirroring how we path-dep desktop-assistant
@@ -66,6 +69,15 @@ path = "../voice/crates/vad-silero"
 
 [dependencies.adele-voice-stt-whisper]
 path = "../voice/crates/stt-whisper"
+
+# Option D dep-sourcing: client-ui-common path-deps the desktop-assistant crates
+# while adele keeps its git pin above. Redirect those transitive deps onto the SAME
+# path so cargo resolves exactly ONE client-common / api-model (a git source and a
+# path source otherwise split SignalEvent into two incompatible types -> E0308).
+[patch."https://github.com/adelie-ai/desktop-assistant.git"]
+desktop-assistant-client-common = { path = "../desktop-assistant/crates/client-common" }
+desktop-assistant-api-model = { path = "../desktop-assistant/crates/api-model" }
+
 
 [lints.rust]
 warnings = "deny"

--- a/src/app.rs
+++ b/src/app.rs
@@ -10,7 +10,7 @@ use crate::tasks::TaskPane;
 // slice (CC-3). First slice: per-conversation voice state lives in `core`;
 // `App`'s voice methods are thin wrappers that read core's accessors and route
 // writes through `core.apply(...)`.
-use client_ui_common::{UiMessage, WindowState};
+use client_ui_common::{Effect, UiMessage, WindowState};
 
 /// Context-window fill view + colour bucket (#341), shared via client-ui-common;
 /// re-exported so existing crate::app::ContextUsageView paths in ui.rs/main.rs resolve.
@@ -124,19 +124,12 @@ pub struct App {
     pub selected_conversation: Option<usize>,
     pub current_conversation: Option<ConversationDetail>,
     pub textarea: TextArea<'static>,
-    pub streaming_buffer: String,
-    pub pending_request_id: Option<String>,
-    /// The conversation the in-flight stream was sent to (TUI-4). `Some` iff
-    /// `pending_request_id` is `Some`. Completion appends to — and narration
-    /// gates on — THIS conversation, not whichever one is open at the time.
-    pub streaming_conversation_id: Option<String>,
-    /// `true` when the in-flight turn was NOT initiated by this client — adopted
-    /// from a `UserMessageAdded` for a turn started elsewhere (a voice turn, or
-    /// another client on the same account) so its reply streams live (#1).
-    /// Suppresses tui's own reply narration for it: the originator (e.g. the
-    /// voice daemon) already speaks the reply, so narrating again would
-    /// double-speak. Reset whenever the in-flight slot is (re)set or cleared.
-    pub streaming_is_external: bool,
+    // The in-flight streaming state (buffer, pending request/conversation id,
+    // external-turn flag, ack sentinel, narration gate) now lives in the shared
+    // `core` (CC-3): the reducer owns the state machine and the view reads it
+    // back through `streaming_buffer()` / `streaming_is_active_for_view()` /
+    // `is_streaming()`. `App` keeps only the rendered transcript
+    // (`current_conversation`) and mirrors core's streaming *effects* onto it.
     pub mode: InputMode,
     pub status_message: String,
     /// Whether the daemon connection is currently live. The run loop projects
@@ -212,29 +205,28 @@ pub struct App {
     /// say "cancelling t-1..." while we wait.
     pub pending_task_cancel: Option<TaskId>,
     /// The shared, view-agnostic model+controller (client-ui-common). `App` is
-    /// migrating its chat-core state onto it slice by slice (CC-3). Currently it
-    /// owns the per-conversation voice state (`You:` input enablement and
-    /// `Adele:` output level, adele-tui#77 / adele-gtk#80) — both default to
-    /// Disabled for an absent conversation and never bleed across conversations.
-    /// `App`'s voice methods read core's accessors and route writes through
-    /// `core.apply(...)`. The remaining `core` fields are not yet authoritative
-    /// for the TUI and stay at their defaults until later slices adopt them.
+    /// migrating its chat-core state onto it slice by slice (CC-3). It owns the
+    /// per-conversation voice state (`You:` input enablement and `Adele:` output
+    /// level, adele-tui#77 / adele-gtk#80) and the **in-flight streaming state**
+    /// — the buffer, the pending request/conversation ids, the external-turn
+    /// flag, the ack sentinel, and the reply-narration gate. Daemon stream events
+    /// route through `core.apply(...)` (see [`App::apply_core`]); `App` mirrors
+    /// the resulting view-effects onto its own rendered transcript and surfaces
+    /// `core`'s streaming state to the view via `streaming_buffer()` /
+    /// `streaming_is_active_for_view()` / `is_streaming()`. The open
+    /// conversation's id is dual-written into `core` on load so its
+    /// originating-conversation checks (TUI-4 / GTK-2) judge against the
+    /// conversation actually in view.
     core: WindowState,
 }
 
 impl App {
-    const PENDING_STREAM_REQUEST_ID: &str = "__pending_stream_request_id__";
-
     pub fn new() -> Self {
         Self {
             conversations: Vec::new(),
             selected_conversation: None,
             current_conversation: None,
             textarea: new_textarea(),
-            streaming_buffer: String::new(),
-            pending_request_id: None,
-            streaming_conversation_id: None,
-            streaming_is_external: false,
             mode: InputMode::Normal,
             status_message: "Connected".to_string(),
             connected: true,
@@ -465,17 +457,6 @@ impl App {
         }
     }
 
-    /// Record the latest context-window fill (#341). The daemon owns the
-    /// numbers; we only store and render. `conversation_id` lets us drop a
-    /// reading for a conversation that is not the one currently open (e.g. a
-    /// background turn), so the indicator always reflects the visible chat.
-    pub fn set_context_usage(&mut self, conversation_id: &str, usage: ContextUsageView) {
-        let open = self.current_conversation.as_ref().map(|c| c.id.as_str());
-        if open == Some(conversation_id) {
-            self.context_usage = Some(usage);
-        }
-    }
-
     pub fn quit(&mut self) {
         self.should_quit = true;
     }
@@ -556,7 +537,7 @@ impl App {
                 "Not connected — message not sent (your text is preserved)".into();
             return None;
         }
-        if self.pending_request_id.is_some() {
+        if self.is_streaming() {
             self.status_message =
                 "A reply is still streaming — wait for it to finish (your text is preserved)"
                     .into();
@@ -706,61 +687,135 @@ impl App {
         self.mode = InputMode::Normal;
     }
 
-    // --- Streaming ---
+    // --- Streaming (delegated to the shared core, CC-3) ---
     //
-    // The stream knows its conversation (TUI-4): `start_streaming` records the
-    // conversation the prompt was sent to, and completion/rendering/narration
-    // all target THAT conversation rather than whichever one is open when the
-    // event arrives.
+    // The stream knows its conversation (TUI-4 / GTK-2): the reducer records the
+    // conversation a prompt was sent to and keys chunk rendering, completion, and
+    // reply narration off THAT conversation, not whichever one is open when an
+    // event arrives. `App` holds none of that state — it feeds daemon stream
+    // events into `core.apply` via `apply_core` and mirrors the resulting
+    // view-effects onto its own transcript.
 
-    pub fn start_streaming(&mut self, request_id: String, conversation_id: String) {
-        self.pending_request_id = Some(request_id);
-        self.streaming_conversation_id = Some(conversation_id);
-        self.streaming_buffer.clear();
-        // A turn entering the slot via the normal send path is this client's
-        // own; only `user_message_added` flips this true for an adopted turn.
-        self.streaming_is_external = false;
-    }
-
-    pub fn start_streaming_without_request_id(&mut self, conversation_id: String) {
-        self.start_streaming(Self::PENDING_STREAM_REQUEST_ID.to_string(), conversation_id);
-    }
-
-    /// Apply the result of a `send_prompt` ack from the daemon, recording the
-    /// conversation the prompt targeted (TUI-4).
+    /// Feed a daemon-derived [`UiMessage`] into the shared core, apply the
+    /// *view-level* effects to `App`'s own state in place, and return the
+    /// *controller-level* effects the view can't perform itself (today:
+    /// [`Effect::Speak`] narration and [`Effect::FetchScratchpad`], which need
+    /// handles `App` doesn't hold). The caller (`main`'s signal loop) runs those.
     ///
-    /// The wire value is either a `task_id` (post-desktop-assistant #114
-    /// `SendMessageAck`) or an empty string (legacy `Ack`). Neither is the
-    /// chunk-stream `request_id` — that is server-generated and arrives
-    /// embedded in the first `AssistantDelta`. We therefore ignore the
-    /// ack payload and seed the sentinel; the first chunk claims it via
-    /// `stream_matches_or_claims_request_id`. See issue #52.
-    pub fn apply_prompt_ack(&mut self, _task_id: String, conversation_id: String) {
-        self.start_streaming_without_request_id(conversation_id);
+    /// View-effects are applied here because the TUI redraws from state every
+    /// frame: a streamed chunk is already on screen once it lands in
+    /// `core.streaming_buffer()`, so [`Effect::ReceiveChunk`] is a no-op; only
+    /// the transcript-finalizing and status effects need a write.
+    pub fn apply_core(&mut self, msg: UiMessage) -> Vec<Effect> {
+        let effects = self.core.apply(msg);
+        effects
+            .into_iter()
+            .filter_map(|effect| self.run_view_effect(effect))
+            .collect()
+    }
+
+    /// Apply one effect's view-level part to `App`, returning `Some(effect)` for
+    /// the controller-level effects the caller must still run (narration, RPCs).
+    fn run_view_effect(&mut self, effect: Effect) -> Option<Effect> {
+        match effect {
+            // The transcript view re-reads `core.streaming_buffer()` each frame,
+            // so the chunk is already visible — nothing to do. (Scroll follows
+            // only at the bottom, TUI-10, which needs no write either.)
+            Effect::ReceiveChunk(_) => None,
+            // Finalize the streamed reply into the open conversation. The reducer
+            // only emits this when the originating conversation is the one in view
+            // (TUI-4), so it always targets the right transcript.
+            Effect::CompleteStreaming(full) => {
+                self.append_message("assistant", full);
+                None
+            }
+            // Render the user bubble for an adopted external turn (#1 live sync).
+            Effect::AddUserMessage(content) => {
+                self.append_message("user", content);
+                None
+            }
+            Effect::SetChatStatus(message) => {
+                self.set_assistant_status(message);
+                None
+            }
+            Effect::ClearChatStatus => {
+                self.assistant_status = None;
+                None
+            }
+            Effect::SetContextUsage(usage) => {
+                self.context_usage = usage;
+                None
+            }
+            Effect::SetStatusText(text) => {
+                self.status_message = text;
+                None
+            }
+            // Controller-level effects (narration, scratchpad, and — in later
+            // CC-3 slices — the conversation/model/task/RPC effects) need handles
+            // the view doesn't hold; bubble them up to `main`'s executor.
+            other => Some(other),
+        }
+    }
+
+    /// Append a finalized message of `role` to the open conversation's transcript
+    /// (no-op when none is open). Mirrors the streaming effects the reducer emits;
+    /// the daemon assigns the authoritative id (#1), re-fetched on the next open,
+    /// so the local copy carries an empty id (streaming dedupe is by request_id).
+    fn append_message(&mut self, role: &str, content: String) {
+        if let Some(conv) = self.current_conversation.as_mut() {
+            conv.messages.push(ChatMessage {
+                id: String::new(),
+                role: role.to_string(),
+                content,
+            });
+        }
+    }
+
+    /// The live streaming partial for the open conversation, read back from the
+    /// shared core. Empty when nothing is buffering, or when the in-flight stream
+    /// belongs to a backgrounded conversation.
+    pub fn streaming_buffer(&self) -> &str {
+        self.core.streaming_buffer()
+    }
+
+    /// Whether the in-flight stream (if any) belongs to the open conversation
+    /// (TUI-4) — the render guard the transcript view consults before painting
+    /// the live partial.
+    pub fn streaming_is_active_for_view(&self) -> bool {
+        self.core.streaming_is_active_for_view()
+    }
+
+    /// Whether a streamed reply is currently in flight. The submit path gates on
+    /// this so a second prompt can't be sent mid-stream (TUI-7).
+    pub fn is_streaming(&self) -> bool {
+        self.core.is_streaming()
+    }
+
+    /// Record a `send_prompt` ack: register the in-flight turn (and its
+    /// originating conversation, TUI-4) in the shared core. The wire value is a
+    /// `task_id` (post-desktop-assistant#114 `SendMessageAck`) or an empty string
+    /// (legacy `Ack`) — neither is the chunk-stream `request_id` (server-generated,
+    /// arriving in the first `AssistantDelta`), so the reducer seeds a sentinel the
+    /// first stream event claims (#52). `PromptSent` emits no effects.
+    pub fn apply_prompt_ack(&mut self, task_id: String, conversation_id: String) {
+        let _ = self.core.apply(UiMessage::PromptSent {
+            task_id,
+            conversation_id,
+        });
         // Immediate feedback in the gap between Enter and the first streamed
         // token. The daemon's own `Status` events (e.g. "Searching…") overwrite
-        // this, and completion/error clears it (see `set_assistant_status`).
+        // this, and completion/error clears it.
         self.set_assistant_status("Adele is thinking…");
     }
 
-    /// Whether the in-flight stream belongs to the open conversation (TUI-4).
-    /// Gates rendering of the live streaming buffer so a backgrounded turn's
-    /// chunks never paint into a conversation the user switched to.
-    pub fn streaming_is_for_current(&self) -> bool {
-        self.pending_request_id.is_some()
-            && self.streaming_conversation_id.as_deref()
-                == self.current_conversation.as_ref().map(|c| c.id.as_str())
-    }
-
-    /// Reset all in-flight streaming state (TUI-8). Called on `Disconnected`:
-    /// the stream is dead, so the frozen `▌` buffer must not linger and the
-    /// ack sentinel must not mis-claim the first stream after reconnecting.
+    /// Drop all in-flight streaming state on a connection teardown (TUI-8): the
+    /// stream died with the link, so the frozen `▌` buffer must not linger and the
+    /// ack sentinel must not mis-claim the first post-reconnect stream. Delegates
+    /// to the core (which owns the streaming state); also clears the TUI-only
+    /// transient assistant-status line.
     pub fn clear_streaming_state(&mut self) {
-        self.pending_request_id = None;
-        self.streaming_conversation_id = None;
-        self.streaming_buffer.clear();
+        self.core.reset_streaming_state();
         self.assistant_status = None;
-        self.streaming_is_external = false;
     }
 
     /// Move the sidebar selection to the conversation with `id`, returning
@@ -773,120 +828,6 @@ impl App {
                 true
             }
             None => false,
-        }
-    }
-
-    fn stream_matches_or_claims_request_id(&mut self, request_id: &str) -> bool {
-        match self.pending_request_id.as_deref() {
-            Some(Self::PENDING_STREAM_REQUEST_ID) => {
-                self.pending_request_id = Some(request_id.to_string());
-                true
-            }
-            Some(current) => current == request_id,
-            None => false,
-        }
-    }
-
-    pub fn receive_chunk(&mut self, request_id: &str, chunk: &str) {
-        if !self.stream_matches_or_claims_request_id(request_id) {
-            return;
-        }
-        self.streaming_buffer.push_str(chunk);
-        // Follow-only-at-bottom (TUI-10): the transcript renders anchored to
-        // the bottom, so `scroll_offset == 0` keeps following new chunks by
-        // itself. A non-zero offset means the user scrolled up to read —
-        // never yank them back down (and a backgrounded stream's chunks must
-        // never touch the OPEN conversation's scroll at all, TUI-4).
-    }
-
-    /// Finish the in-flight stream. Returns the ORIGINATING conversation id
-    /// when the event matched the pending stream (TUI-4) — the caller gates
-    /// narration on that conversation — or `None` when the event was unrelated.
-    /// The reply is appended to the transcript only when the originating
-    /// conversation is the open one; otherwise the daemon already persisted it
-    /// and it appears when that conversation is next opened.
-    pub fn complete_streaming(&mut self, request_id: &str, full_response: &str) -> Option<String> {
-        if !self.stream_matches_or_claims_request_id(request_id) {
-            return None;
-        }
-        let origin = self.streaming_conversation_id.take();
-        if let Some(conv) = self
-            .current_conversation
-            .as_mut()
-            .filter(|c| origin.as_deref() == Some(c.id.as_str()))
-        {
-            conv.messages.push(ChatMessage {
-                // Local copy of the just-streamed reply; the daemon already
-                // persisted the authoritative message (with its #1 id), which is
-                // re-fetched on the next open. Streaming dedupe is by request_id,
-                // so an empty id here is correct.
-                id: String::new(),
-                role: "assistant".to_string(),
-                content: full_response.to_string(),
-            });
-        }
-        self.streaming_buffer.clear();
-        self.pending_request_id = None;
-        self.assistant_status = None;
-        self.streaming_is_external = false;
-        origin
-    }
-
-    pub fn streaming_error(&mut self, request_id: &str, error: &str) {
-        if !self.stream_matches_or_claims_request_id(request_id) {
-            return;
-        }
-        self.status_message = format!("Error: {error}");
-        self.streaming_buffer.clear();
-        self.pending_request_id = None;
-        self.streaming_conversation_id = None;
-        self.assistant_status = None;
-        self.streaming_is_external = false;
-    }
-
-    /// Handle a `UserMessageAdded` (#1): the daemon announces a user message and
-    /// the turn it begins. For a turn this client did NOT initiate (a voice turn,
-    /// or another client on the same account) showing in the open conversation,
-    /// render the user bubble and adopt the turn so its reply streams live;
-    /// dedupe this client's own send (already shown optimistically).
-    pub fn user_message_added(&mut self, conversation_id: &str, request_id: &str, content: &str) {
-        // Case 1 — our own send, echoed back. `prepare_submission` already
-        // appended the user message and `apply_prompt_ack` pinned the sentinel
-        // (both run inline before any signal is processed). Claim the real
-        // request_id off the sentinel — it precedes the first chunk — and render
-        // nothing more. This also resolves the stream's request_id earlier and
-        // more reliably than the claim-on-first-chunk fallback.
-        if self.pending_request_id.as_deref() == Some(Self::PENDING_STREAM_REQUEST_ID)
-            && self.streaming_conversation_id.as_deref() == Some(conversation_id)
-        {
-            self.pending_request_id = Some(request_id.to_string());
-            return;
-        }
-        // Case 2 — a turn this client did NOT initiate, for the conversation on
-        // screen, with no turn already occupying the single in-flight slot. Adopt
-        // it so the existing chunk/completion path streams the reply live, append
-        // the user message now, and mark it external so its reply is NOT narrated
-        // here (the originator already speaks it). A turn for a background
-        // conversation, or one arriving while our own turn is in flight, is left
-        // to the reload-on-switch path (the daemon persists it).
-        let is_displayed =
-            self.current_conversation.as_ref().map(|c| c.id.as_str()) == Some(conversation_id);
-        if self.pending_request_id.is_none() && is_displayed {
-            self.pending_request_id = Some(request_id.to_string());
-            self.streaming_conversation_id = Some(conversation_id.to_string());
-            self.streaming_buffer.clear();
-            self.streaming_is_external = true;
-            if let Some(conv) = self.current_conversation.as_mut() {
-                conv.messages.push(ChatMessage {
-                    // Adopted external user bubble (#1 live sync). The turn is
-                    // tracked by request_id, not message id, so an empty id is
-                    // correct; the persisted message (with its real id) is
-                    // re-fetched on the next open.
-                    id: String::new(),
-                    role: "user".to_string(),
-                    content: content.to_string(),
-                });
-            }
         }
     }
 
@@ -909,6 +850,11 @@ impl App {
     pub fn load_conversation(&mut self, detail: ConversationDetail) {
         let switching =
             self.current_conversation.as_ref().map(|c| c.id.as_str()) != Some(detail.id.as_str());
+        // Dual-write the open-conversation id into the shared core so its
+        // streaming originating-conversation checks (TUI-4 / GTK-2) judge against
+        // the conversation actually in view. `App` still owns the rendered
+        // transcript; only the id `core` needs for routing is mirrored (CC-3).
+        self.core.current_conversation_id = Some(detail.id.clone());
         self.current_conversation = Some(detail);
         // Drop a stale context-fill reading when the visible conversation
         // changes; the next turn re-establishes it (#341).
@@ -997,13 +943,16 @@ impl App {
         let id = self.conversations[idx].id.clone();
         self.conversations.remove(idx);
 
-        // Clear current conversation if it was the deleted one
+        // Clear current conversation if it was the deleted one (and mirror the
+        // clear into the shared core so its streaming active-checks don't keep
+        // pointing at a gone conversation, CC-3).
         if self
             .current_conversation
             .as_ref()
             .is_some_and(|c| c.id == id)
         {
             self.current_conversation = None;
+            self.core.current_conversation_id = None;
         }
 
         // Fix selection
@@ -1107,14 +1056,30 @@ mod tests {
     }
 
     #[test]
-    fn set_context_usage_only_applies_to_open_conversation() {
+    fn context_usage_signal_updates_the_indicator_only_for_the_open_conversation() {
+        // The reducer gates the `ContextUsage` signal on the open conversation
+        // (#341); apply_core wires the resulting `SetContextUsage` effect onto
+        // App's indicator. A background turn's reading must not paint.
         let mut app = App::new();
         app.load_conversation(detail("c1"));
-        // A reading for a different conversation (e.g. background turn) is dropped.
-        app.set_context_usage("c2", usage(10_000, 32_000, false));
-        assert_eq!(app.context_usage, None);
-        // A reading for the open conversation lands.
-        app.set_context_usage("c1", usage(10_000, 32_000, false));
+
+        app.apply_core(UiMessage::ContextUsage {
+            conversation_id: "c2".into(),
+            used_tokens: 10_000,
+            budget_tokens: 32_000,
+            compaction_active: false,
+        });
+        assert_eq!(
+            app.context_usage, None,
+            "a background reading must not paint"
+        );
+
+        app.apply_core(UiMessage::ContextUsage {
+            conversation_id: "c1".into(),
+            used_tokens: 10_000,
+            budget_tokens: 32_000,
+            compaction_active: false,
+        });
         assert_eq!(app.context_usage, Some(usage(10_000, 32_000, false)));
     }
 
@@ -1122,7 +1087,12 @@ mod tests {
     fn switching_conversation_clears_stale_context_usage() {
         let mut app = App::new();
         app.load_conversation(detail("c1"));
-        app.set_context_usage("c1", usage(10_000, 32_000, false));
+        app.apply_core(UiMessage::ContextUsage {
+            conversation_id: "c1".into(),
+            used_tokens: 10_000,
+            budget_tokens: 32_000,
+            compaction_active: false,
+        });
         assert!(app.context_usage.is_some());
         app.load_conversation(detail("c2"));
         assert_eq!(
@@ -1516,7 +1486,9 @@ mod tests {
 
     fn app_ready_to_send(conv_id: &str, prompt: &str) -> App {
         let mut app = App::new();
-        app.current_conversation = Some(ConversationDetail {
+        // `load_conversation` (not a raw field write) so the open-conversation id
+        // is dual-written into core — the streaming gate/render checks key off it.
+        app.load_conversation(ConversationDetail {
             id: conv_id.into(),
             title: "Test".into(),
             messages: vec![],
@@ -1563,7 +1535,13 @@ mod tests {
         // send while a reply streams is refused with a status message and the
         // composer keeps its text.
         let mut app = app_ready_to_send("c1", "second question");
-        app.start_streaming("req-in-flight".into(), "c1".into());
+        // Drive a genuine in-flight stream through the core: ack arms the slot,
+        // the first chunk claims the real request id.
+        app.apply_prompt_ack("task".into(), "c1".into());
+        app.apply_core(UiMessage::StreamChunk {
+            request_id: "req-in-flight".into(),
+            chunk: "partial".into(),
+        });
         app.status_message.clear();
 
         let result = app.prepare_submission(true);
@@ -1585,7 +1563,8 @@ mod tests {
         // Unhappy path: the window between send and the first chunk uses the
         // pending sentinel; a send in that window must be blocked too.
         let mut app = app_ready_to_send("c1", "rapid second send");
-        app.start_streaming_without_request_id("c1".into());
+        // Ack received but no chunk yet: the slot holds the pending sentinel.
+        app.apply_prompt_ack("task".into(), "c1".into());
 
         assert!(app.prepare_submission(true).is_none());
         assert_eq!(app.textarea_content(), "rapid second send");
@@ -1686,21 +1665,73 @@ mod tests {
         }
     }
 
+    // These exercise the TUI's *integration* with the shared core — that
+    // `apply_core` applies the reducer's streaming effects onto `App`'s own
+    // transcript / buffer / status, and routes the `clear_streaming_state`
+    // teardown through core. The streaming *state machine itself* (request-id
+    // claiming, originating-conversation targeting, external-turn handling,
+    // error/disconnect finalization) is spec'd by client-ui-common's reducer
+    // tests; we don't re-test that logic here, only the wiring.
+
     #[test]
-    fn complete_after_switching_conversations_targets_the_originating_one() {
-        // Acceptance (TUI-4): a Complete arriving after the user switched
-        // conversations must NOT append to the newly opened conversation; it
-        // reports the ORIGINATING conversation id so narration gates there.
+    fn apply_core_finalizes_an_open_streams_reply_into_the_transcript() {
+        // The ack carries a task id; the chunks carry a DIFFERENT server request
+        // id (#52). They must still be accepted, buffer live, and finalize into
+        // the open conversation's transcript on completion.
         let mut app = App::new();
-        app.current_conversation = Some(detail("c1"));
+        app.load_conversation(detail("c1"));
+        app.apply_prompt_ack("task-abc".into(), "c1".into());
+
+        app.apply_core(UiMessage::StreamChunk {
+            request_id: "server-xyz".into(),
+            chunk: "Hello ".into(),
+        });
+        app.apply_core(UiMessage::StreamChunk {
+            request_id: "server-xyz".into(),
+            chunk: "world!".into(),
+        });
+        assert_eq!(
+            app.streaming_buffer(),
+            "Hello world!",
+            "the partial buffers live"
+        );
+
+        app.apply_core(UiMessage::StreamComplete {
+            request_id: "server-xyz".into(),
+            full_response: "Hello world!".into(),
+        });
+
+        assert!(!app.is_streaming(), "the slot clears on completion");
+        assert_eq!(app.streaming_buffer(), "", "the live partial is gone");
+        let msgs = &app.current_conversation.as_ref().unwrap().messages;
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].role, "assistant");
+        assert_eq!(msgs[0].content, "Hello world!");
+    }
+
+    #[test]
+    fn apply_core_does_not_bleed_a_backgrounded_completion_into_the_open_chat() {
+        // TUI-4: a Complete arriving after the user switched conversations must
+        // NOT append to the newly opened conversation, emits no narration, and
+        // still clears the slot.
+        let mut app = App::new();
+        app.load_conversation(detail("c1"));
         app.apply_prompt_ack("task-1".into(), "c1".into());
-        app.receive_chunk("req-1", "partial ");
+        app.apply_core(UiMessage::StreamChunk {
+            request_id: "req-1".into(),
+            chunk: "partial ".into(),
+        });
 
-        // User switches to c2 mid-stream.
-        app.load_conversation(detail("c2"));
+        app.load_conversation(detail("c2")); // switch away mid-stream
 
-        let origin = app.complete_streaming("req-1", "partial reply done");
-        assert_eq!(origin.as_deref(), Some("c1"), "origin must be reported");
+        let controller = app.apply_core(UiMessage::StreamComplete {
+            request_id: "req-1".into(),
+            full_response: "done".into(),
+        });
+        assert!(
+            controller.is_empty(),
+            "a backgrounded completion emits no controller effect (no narration)"
+        );
         assert!(
             app.current_conversation
                 .as_ref()
@@ -1709,83 +1740,51 @@ mod tests {
                 .is_empty(),
             "the reply must not bleed into the switched-to conversation"
         );
-        assert_eq!(app.pending_request_id, None, "stream state must clear");
-        assert_eq!(app.streaming_buffer, "");
+        assert!(!app.is_streaming(), "the slot still clears");
     }
 
     #[test]
-    fn complete_appends_when_user_switched_away_and_back() {
-        // Switching away and back re-opens the originating conversation; the
-        // completion then lands in its transcript.
+    fn backgrounded_stream_chunks_do_not_reset_the_open_conversations_scroll() {
+        // Scroll belongs to the OPEN conversation; a backgrounded stream's chunks
+        // must neither yank it nor paint into the open chat (TUI-4 / TUI-10).
         let mut app = App::new();
-        app.current_conversation = Some(detail("c1"));
+        app.load_conversation(detail("c1"));
         app.apply_prompt_ack("task-1".into(), "c1".into());
         app.load_conversation(detail("c2"));
-        app.load_conversation(detail("c1")); // back again (fresh fetch)
+        app.scroll_up(7);
 
-        let origin = app.complete_streaming("req-1", "the reply");
-        assert_eq!(origin.as_deref(), Some("c1"));
-        let msgs = &app.current_conversation.as_ref().unwrap().messages;
-        assert_eq!(msgs.len(), 1);
-        assert_eq!(msgs[0].content, "the reply");
-    }
+        app.apply_core(UiMessage::StreamChunk {
+            request_id: "req-1".into(),
+            chunk: "background chunk".into(),
+        });
 
-    #[test]
-    fn unmatched_complete_reports_no_origin() {
-        // An unrelated Complete (wrong request id) must not be narrated or
-        // appended anywhere — no origin is reported.
-        let mut app = App::new();
-        app.current_conversation = Some(detail("c1"));
-        app.start_streaming("req-1".into(), "c1".into());
-        assert_eq!(app.complete_streaming("other-req", "noise"), None);
-        assert!(app.pending_request_id.is_some(), "stream still pending");
-    }
-
-    #[test]
-    fn streaming_buffer_renders_only_into_the_originating_conversation() {
-        // The UI gate (TUI-4): mid-stream chunks must not paint into a
-        // conversation the user switched to.
-        let mut app = App::new();
-        app.current_conversation = Some(detail("c1"));
-        app.start_streaming("req-1".into(), "c1".into());
-        app.receive_chunk("req-1", "partial");
-        assert!(app.streaming_is_for_current());
-
-        app.load_conversation(detail("c2"));
+        assert_eq!(
+            app.scroll_offset, 7,
+            "scroll is untouched by a backgrounded chunk"
+        );
         assert!(
-            !app.streaming_is_for_current(),
-            "stream belongs to c1, not the open c2"
+            !app.streaming_is_active_for_view(),
+            "and it is not painted into the open chat"
         );
     }
 
     #[test]
-    fn chunks_for_a_backgrounded_stream_do_not_reset_scroll() {
-        // Scroll position belongs to the OPEN conversation; a backgrounded
-        // stream's chunks must not yank it.
-        let mut app = App::new();
-        app.current_conversation = Some(detail("c1"));
-        app.start_streaming("req-1".into(), "c1".into());
-        app.load_conversation(detail("c2"));
-        app.scroll_up(7);
-        app.receive_chunk("req-1", "background chunk");
-        assert_eq!(app.scroll_offset, 7);
-    }
-
-    #[test]
     fn clear_streaming_state_resets_everything_on_disconnect() {
-        // Acceptance (TUI-8): after a disconnect there is no frozen ▌ buffer
-        // and no stale pending id.
+        // Acceptance (TUI-8): after a disconnect there is no frozen ▌ buffer, no
+        // stale pending slot, and the transient assistant-status line is cleared.
         let mut app = App::new();
-        app.current_conversation = Some(detail("c1"));
+        app.load_conversation(detail("c1"));
         app.apply_prompt_ack("task-1".into(), "c1".into());
-        app.receive_chunk("req-1", "now-dead partial");
+        app.apply_core(UiMessage::StreamChunk {
+            request_id: "req-1".into(),
+            chunk: "now-dead partial".into(),
+        });
         app.set_assistant_status("Calling tool…");
 
         app.clear_streaming_state();
 
-        assert_eq!(app.pending_request_id, None);
-        assert_eq!(app.streaming_buffer, "");
-        assert!(app.streaming_conversation_id.is_none());
+        assert!(!app.is_streaming());
+        assert_eq!(app.streaming_buffer(), "");
         assert!(app.assistant_status.is_none());
     }
 
@@ -1794,13 +1793,16 @@ mod tests {
         // Unhappy path (TUI-8): a leftover ack sentinel from before the
         // disconnect must not claim the first post-reconnect stream.
         let mut app = App::new();
-        app.current_conversation = Some(detail("c1"));
+        app.load_conversation(detail("c1"));
         app.apply_prompt_ack("task-1".into(), "c1".into()); // sentinel armed
         app.clear_streaming_state();
 
-        app.receive_chunk("post-reconnect-req", "someone else's chunk");
-        assert_eq!(app.streaming_buffer, "", "chunk must be ignored");
-        assert_eq!(app.pending_request_id, None);
+        app.apply_core(UiMessage::StreamChunk {
+            request_id: "post-reconnect-req".into(),
+            chunk: "someone else's chunk".into(),
+        });
+        assert_eq!(app.streaming_buffer(), "", "chunk must be ignored");
+        assert!(!app.is_streaming());
     }
 
     #[test]
@@ -1819,216 +1821,148 @@ mod tests {
     }
 
     // --- Streaming tests ---
+    //
+    // These cover the TUI's wiring of the shared core's streaming effects. The
+    // happy-path lifecycle (claim → buffer → finalize) is exercised by
+    // `apply_core_finalizes_an_open_streams_reply_into_the_transcript` above; the
+    // reducer's state machine itself is spec'd in client-ui-common.
 
     #[test]
-    fn streaming_lifecycle() {
+    fn streaming_error_surfaces_in_the_status_line() {
+        // apply_core wires StreamError's `SetStatusText` onto App's status line
+        // and `ClearChatStatus` onto the transient assistant-status, and clears
+        // the slot + buffer.
         let mut app = App::new();
-        app.current_conversation = Some(ConversationDetail {
-            id: "c1".into(),
-            title: "Test".into(),
-            messages: vec![],
-            model_selection: None,
-            conversation_personality: None,
+        app.load_conversation(detail("c1"));
+        app.apply_prompt_ack("task-1".into(), "c1".into());
+        app.apply_core(UiMessage::StreamChunk {
+            request_id: "req1".into(),
+            chunk: "half a thought".into(),
+        });
+        app.set_assistant_status("Calling tool…");
+
+        app.apply_core(UiMessage::StreamError {
+            request_id: "req1".into(),
+            error: "LLM timeout".into(),
         });
 
-        app.start_streaming("req1".into(), "c1".into());
-        assert_eq!(app.pending_request_id, Some("req1".to_string()));
-
-        app.receive_chunk("req1", "Hello ");
-        app.receive_chunk("req1", "world!");
-        assert_eq!(app.streaming_buffer, "Hello world!");
-
-        app.complete_streaming("req1", "Hello world!");
-        assert_eq!(app.streaming_buffer, "");
-        assert_eq!(app.pending_request_id, None);
-
-        let msgs = &app.current_conversation.as_ref().unwrap().messages;
-        assert_eq!(msgs.len(), 1);
-        assert_eq!(msgs[0].role, "assistant");
-        assert_eq!(msgs[0].content, "Hello world!");
-    }
-
-    #[test]
-    fn wrong_request_id_ignored() {
-        let mut app = App::new();
-        app.current_conversation = Some(ConversationDetail {
-            id: "c1".into(),
-            title: "Test".into(),
-            messages: vec![],
-            model_selection: None,
-            conversation_personality: None,
-        });
-
-        app.start_streaming("req1".into(), "c1".into());
-        app.receive_chunk("wrong_id", "bad data");
-        assert_eq!(app.streaming_buffer, "");
-
-        app.complete_streaming("wrong_id", "bad");
-        assert!(app.pending_request_id.is_some()); // not cleared
-    }
-
-    #[test]
-    fn streaming_error_sets_status() {
-        let mut app = App::new();
-        app.start_streaming("req1".into(), "c1".into());
-        app.streaming_error("req1", "LLM timeout");
         assert_eq!(app.status_message, "Error: LLM timeout");
-        assert_eq!(app.pending_request_id, None);
-        assert_eq!(app.streaming_buffer, "");
+        assert!(
+            app.assistant_status.is_none(),
+            "the transient status clears"
+        );
+        assert!(!app.is_streaming());
+        assert_eq!(app.streaming_buffer(), "");
     }
 
     // --- Live external-turn rendering (#1) --------------------------------
 
-    /// A `UserMessageAdded` for the open conversation, with no turn in flight,
-    /// is a turn this client did not initiate (voice / another client). It
-    /// renders the user message and adopts the turn so the reply streams live.
     #[test]
-    fn external_user_message_in_open_conversation_renders_and_adopts() {
+    fn external_user_message_renders_and_adopts_into_the_open_conversation() {
+        // A `UserMessageAdded` for the open conversation with nothing in flight
+        // is an external turn (voice / another client): apply_core renders the
+        // user bubble (the `AddUserMessage` effect) and adopts the turn, so a
+        // following chunk for it streams live into the open chat.
         let mut app = app_with_open_conversation("c1");
-        app.user_message_added("c1", "voice-req", "what's the weather?");
+
+        let controller = app.apply_core(UiMessage::UserMessageAdded {
+            conversation_id: "c1".into(),
+            request_id: "voice-req".into(),
+            content: "what's the weather?".into(),
+        });
+        assert!(
+            controller.is_empty(),
+            "rendering the bubble needs no controller effect"
+        );
 
         let msgs = &app.current_conversation.as_ref().unwrap().messages;
         assert_eq!(msgs.len(), 1, "the external user message must be rendered");
         assert_eq!(msgs[0].role, "user");
         assert_eq!(msgs[0].content, "what's the weather?");
-        assert_eq!(
-            app.pending_request_id.as_deref(),
-            Some("voice-req"),
-            "the turn must be adopted so its reply streams live"
-        );
-        assert_eq!(app.streaming_conversation_id.as_deref(), Some("c1"));
-        assert!(
-            app.streaming_is_external,
-            "an adopted turn is external so tui does not also narrate it"
-        );
+
+        // Adopted: its reply now streams live into the open chat.
+        app.apply_core(UiMessage::StreamChunk {
+            request_id: "voice-req".into(),
+            chunk: "Sunny.".into(),
+        });
+        assert_eq!(app.streaming_buffer(), "Sunny.");
+        assert!(app.streaming_is_active_for_view());
     }
 
-    /// This client's own send is echoed back as `UserMessageAdded`. The user
-    /// message was already appended optimistically and the sentinel pinned, so
-    /// the echo renders nothing — it only claims the real request_id.
     #[test]
-    fn own_send_echo_dedupes_and_claims_request_id() {
-        let mut app = app_with_open_conversation("c1");
-        // Mirror the local send: optimistic append + sentinel via the ack.
-        app.current_conversation
-            .as_mut()
-            .unwrap()
-            .messages
-            .push(ChatMessage {
-                id: String::new(),
-                role: "user".to_string(),
-                content: "typed this".to_string(),
-            });
-        app.apply_prompt_ack(String::new(), "c1".to_string());
-
-        app.user_message_added("c1", "real-req", "typed this");
-
-        assert_eq!(
-            app.current_conversation.as_ref().unwrap().messages.len(),
-            1,
-            "our own send's echo must not double-append the user message"
-        );
-        assert_eq!(
-            app.pending_request_id.as_deref(),
-            Some("real-req"),
-            "the echo must claim the real request_id off the sentinel"
-        );
-        assert!(
-            !app.streaming_is_external,
-            "our own turn must NOT be flagged external (tui owns its narration)"
-        );
-    }
-
-    /// An adopted external turn is narrated by its originator — tui must not
-    /// also speak it even when the conversation's gate is open. Verifies the
-    /// flag main.rs captures (`was_external`) to suppress `enqueue_narration`.
-    #[test]
-    fn adopted_external_turn_suppresses_tui_narration() {
+    fn adopted_external_turn_is_not_narrated_by_this_client() {
+        // An adopted external turn is narrated by its originator (the voice
+        // daemon); even with the conversation's gate wide open (Adele=Always),
+        // completing it must emit NO `Speak` controller effect.
         let mut app = app_with_open_conversation("c1");
         app.set_adele_output("c1", AdeleOutput::Always);
         assert!(
             app.narrate_for("c1"),
-            "precondition: the gate alone would narrate (Adele=Always)"
+            "precondition: the gate alone would narrate"
         );
 
-        app.user_message_added("c1", "voice-req", "a question");
-        // main.rs captures this BEFORE complete_streaming resets it, then gates
-        // narration on `!was_external && narrate_for(origin)`.
-        let was_external = app.streaming_is_external;
-        let origin = app.complete_streaming("voice-req", "the spoken answer");
-
-        assert!(was_external, "external turn must suppress tui narration");
-        assert_eq!(origin.as_deref(), Some("c1"));
-        assert!(
-            !app.streaming_is_external,
-            "the external flag must reset at turn completion"
-        );
-    }
-
-    /// A `UserMessageAdded` for a conversation NOT on screen is left to the
-    /// reload-on-switch path — it must not touch the open transcript or the
-    /// in-flight slot.
-    #[test]
-    fn external_turn_for_background_conversation_is_ignored() {
-        let mut app = app_with_open_conversation("c1");
-        app.user_message_added("c2", "bg-req", "background");
-
-        assert!(
-            app.current_conversation
-                .as_ref()
-                .unwrap()
-                .messages
-                .is_empty(),
-            "a background turn must not render into the open transcript"
-        );
-        assert!(
-            app.pending_request_id.is_none(),
-            "a background turn must not be adopted into the in-flight slot"
-        );
-    }
-
-    /// While this client's own turn is in flight, a concurrent external turn is
-    /// NOT adopted — the single in-flight slot stays bound to our turn.
-    #[test]
-    fn external_turn_ignored_while_own_turn_in_flight() {
-        let mut app = app_with_open_conversation("c1");
-        app.start_streaming("mine".to_string(), "c1".to_string());
-
-        app.user_message_added("c1", "other", "concurrent");
-
-        assert_eq!(
-            app.pending_request_id.as_deref(),
-            Some("mine"),
-            "the in-flight turn's slot must be preserved"
-        );
-        assert!(
-            app.current_conversation
-                .as_ref()
-                .unwrap()
-                .messages
-                .is_empty(),
-            "must not append a second user message while a turn is in flight"
-        );
-    }
-
-    #[test]
-    fn assistant_status_set_and_cleared_on_complete() {
-        let mut app = App::new();
-        app.current_conversation = Some(ConversationDetail {
-            id: "c1".into(),
-            title: "Test".into(),
-            messages: vec![],
-            model_selection: None,
-            conversation_personality: None,
+        app.apply_core(UiMessage::UserMessageAdded {
+            conversation_id: "c1".into(),
+            request_id: "voice-req".into(),
+            content: "a question".into(),
         });
-        app.start_streaming("req1".into(), "c1".into());
-        app.set_assistant_status("Searching knowledge base...");
+        let controller = app.apply_core(UiMessage::StreamComplete {
+            request_id: "voice-req".into(),
+            full_response: "the spoken answer".into(),
+        });
+
+        assert!(
+            !controller.iter().any(|e| matches!(e, Effect::Speak(_))),
+            "an external turn must not be narrated here: {controller:?}"
+        );
+    }
+
+    #[test]
+    fn own_narrating_turn_completion_returns_a_speak_effect() {
+        // The flip side: this client's OWN turn, in a narrating conversation
+        // (Adele=Always), must bubble up a `Speak` controller effect on
+        // completion for `main` to enqueue.
+        let mut app = app_with_open_conversation("c1");
+        app.set_adele_output("c1", AdeleOutput::Always);
+        app.apply_prompt_ack("task-1".into(), "c1".into());
+        app.apply_core(UiMessage::StreamChunk {
+            request_id: "req1".into(),
+            chunk: "hi".into(),
+        });
+
+        let controller = app.apply_core(UiMessage::StreamComplete {
+            request_id: "req1".into(),
+            full_response: "the spoken answer".into(),
+        });
+
+        assert!(
+            controller
+                .iter()
+                .any(|e| matches!(e, Effect::Speak(text) if text == "the spoken answer")),
+            "an own narrating turn must bubble up a Speak effect: {controller:?}"
+        );
+    }
+
+    #[test]
+    fn assistant_status_set_and_cleared_through_apply_core() {
+        // A daemon `Status` event paints the transient indicator (SetChatStatus);
+        // completion clears it (ClearChatStatus) — both via apply_core.
+        let mut app = App::new();
+        app.load_conversation(detail("c1"));
+        app.apply_prompt_ack("task-1".into(), "c1".into());
+        app.apply_core(UiMessage::AssistantStatus {
+            request_id: "req1".into(),
+            message: "Searching knowledge base...".into(),
+        });
         assert_eq!(
             app.assistant_status.as_deref(),
             Some("Searching knowledge base...")
         );
 
-        app.complete_streaming("req1", "done");
+        app.apply_core(UiMessage::StreamComplete {
+            request_id: "req1".into(),
+            full_response: "done".into(),
+        });
         assert!(app.assistant_status.is_none());
     }
 
@@ -2049,15 +1983,6 @@ mod tests {
     }
 
     #[test]
-    fn assistant_status_cleared_on_error() {
-        let mut app = App::new();
-        app.start_streaming("req1".into(), "c1".into());
-        app.set_assistant_status("Calling tool...");
-        app.streaming_error("req1", "boom");
-        assert!(app.assistant_status.is_none());
-    }
-
-    #[test]
     fn assistant_status_empty_string_clears() {
         let mut app = App::new();
         app.set_assistant_status("something");
@@ -2065,81 +1990,11 @@ mod tests {
         assert!(app.assistant_status.is_none());
     }
 
-    #[test]
-    fn pending_stream_claims_first_request_id_from_chunk() {
-        let mut app = App::new();
-        app.current_conversation = Some(ConversationDetail {
-            id: "c1".into(),
-            title: "Test".into(),
-            messages: vec![],
-            model_selection: None,
-            conversation_personality: None,
-        });
-
-        app.start_streaming_without_request_id("c1".into());
-        app.receive_chunk("ws-req-1", "Hello ");
-        app.receive_chunk("ws-req-1", "world");
-        app.complete_streaming("ws-req-1", "Hello world");
-
-        assert_eq!(app.pending_request_id, None);
-        let msgs = &app.current_conversation.as_ref().unwrap().messages;
-        assert_eq!(msgs.len(), 1);
-        assert_eq!(msgs[0].content, "Hello world");
-    }
-
-    #[test]
-    fn pending_stream_rejects_unrelated_request_after_claim() {
-        let mut app = App::new();
-        app.start_streaming_without_request_id("c1".into());
-
-        app.receive_chunk("ws-req-1", "good");
-        app.receive_chunk("ws-req-2", "ignored");
-
-        assert_eq!(app.streaming_buffer, "good");
-        assert_eq!(app.pending_request_id, Some("ws-req-1".to_string()));
-    }
-
-    /// Regression test for issue #52.
-    ///
-    /// `WsClient::send_prompt` returns the daemon's `task_id`
-    /// (post-desktop-assistant #114 `SendMessageAck`). That value is
-    /// distinct from the chunk-stream `request_id` embedded in
-    /// `AssistantDelta` events — the latter is server-generated per
-    /// streaming response. Treating the ack value as the stream's
-    /// request_id makes every chunk get filtered out by
-    /// `stream_matches_or_claims_request_id`, so the assistant's
-    /// streaming reply never appears.
-    ///
-    /// After `apply_prompt_ack(task_id)` the next chunk — carrying the
-    /// real, different server request_id — must still be accepted.
-    #[test]
-    fn apply_prompt_ack_accepts_chunks_with_distinct_server_request_id() {
-        let mut app = App::new();
-        app.current_conversation = Some(ConversationDetail {
-            id: "c1".into(),
-            title: "Test".into(),
-            messages: vec![],
-            model_selection: None,
-            conversation_personality: None,
-        });
-
-        // Daemon ack carries a task_id (post-#114 wire protocol).
-        app.apply_prompt_ack("task-abc123".to_string(), "c1".to_string());
-
-        // Streaming chunks then arrive with a *different* server-generated
-        // request_id. They must be accepted, not filtered out.
-        app.receive_chunk("server-req-xyz789", "Hello ");
-        app.receive_chunk("server-req-xyz789", "world!");
-
-        assert_eq!(app.streaming_buffer, "Hello world!");
-
-        app.complete_streaming("server-req-xyz789", "Hello world!");
-        assert_eq!(app.pending_request_id, None);
-        let msgs = &app.current_conversation.as_ref().unwrap().messages;
-        assert_eq!(msgs.len(), 1);
-        assert_eq!(msgs[0].role, "assistant");
-        assert_eq!(msgs[0].content, "Hello world!");
-    }
+    // The pending-sentinel claim, unrelated-request rejection, and the issue #52
+    // distinct-ack-vs-server-request-id regression are all spec'd by
+    // client-ui-common's reducer tests (and exercised end-to-end through the TUI
+    // by `apply_core_finalizes_an_open_streams_reply_into_the_transcript`, which
+    // uses a distinct ack task id and server request id).
 
     // --- Mode transition tests ---
 
@@ -2458,11 +2313,14 @@ mod tests {
     #[test]
     fn receive_chunk_at_bottom_keeps_following() {
         // TUI-10: when the user is at the bottom (offset 0), streaming keeps
-        // auto-following.
+        // auto-following — applying a chunk through the core never moves scroll.
         let mut app = App::new();
-        app.current_conversation = Some(detail("c1"));
-        app.start_streaming("req1".into(), "c1".into());
-        app.receive_chunk("req1", "data");
+        app.load_conversation(detail("c1"));
+        app.apply_prompt_ack("task1".into(), "c1".into());
+        app.apply_core(UiMessage::StreamChunk {
+            request_id: "req1".into(),
+            chunk: "data".into(),
+        });
         assert_eq!(app.scroll_offset, 0);
     }
 
@@ -2471,12 +2329,15 @@ mod tests {
         // Acceptance (TUI-10): the user can read scrollback during a long
         // reply — chunks must not yank the view back to the bottom.
         let mut app = App::new();
-        app.current_conversation = Some(detail("c1"));
-        app.start_streaming("req1".into(), "c1".into());
+        app.load_conversation(detail("c1"));
+        app.apply_prompt_ack("task1".into(), "c1".into());
         app.scroll_up(10);
-        app.receive_chunk("req1", "data");
+        app.apply_core(UiMessage::StreamChunk {
+            request_id: "req1".into(),
+            chunk: "data".into(),
+        });
         assert_eq!(app.scroll_offset, 10);
-        assert_eq!(app.streaming_buffer, "data", "chunk still buffered");
+        assert_eq!(app.streaming_buffer(), "data", "chunk still buffered");
     }
 
     #[test]
@@ -2621,7 +2482,8 @@ mod tests {
 
     fn app_with_open_conversation(id: &str) -> App {
         let mut app = App::new();
-        app.current_conversation = Some(ConversationDetail {
+        // Via `load_conversation` so core's open-conversation id is dual-written.
+        app.load_conversation(ConversationDetail {
             id: id.into(),
             title: "Chat".into(),
             messages: vec![],
@@ -2784,19 +2646,43 @@ mod tests {
     }
 
     #[test]
-    fn narration_gates_on_the_originating_conversation_not_the_open_one() {
-        // TUI-4: a backgrounded turn's reply is narrated per ITS
-        // conversation's settings, not the open conversation's. c1 narrates
-        // (Always), the open c2 is Disabled — the completion still reports c1
-        // and the c1 gate holds.
+    fn backgrounded_turn_completion_is_not_narrated_into_the_open_conversation() {
+        // TUI-4 / GTK-2 convergence: when the originating conversation (c1,
+        // Adele=Always) is backgrounded — the user switched to c2 mid-stream —
+        // its completion touches NOTHING in the open chat and emits no narration.
+        // The reply is persisted daemon-side and re-appears when c1 is reopened.
+        //
+        // This is a deliberate behavior change adopting the shared reducer's
+        // semantics: the pre-migration TUI narrated a backgrounded reply per its
+        // origin's gate even while another conversation was on screen.
         let mut app = app_with_open_conversation("c1");
         app.set_adele_output("c1", AdeleOutput::Always);
         app.apply_prompt_ack("task-1".into(), "c1".into());
-        app.load_conversation(detail("c2"));
+        app.apply_core(UiMessage::StreamChunk {
+            request_id: "req-1".into(),
+            chunk: "partial".into(),
+        });
+        app.load_conversation(detail("c2")); // switch away mid-stream
 
-        let origin = app.complete_streaming("req-1", "spoken reply");
-        assert_eq!(origin.as_deref(), Some("c1"));
-        assert!(app.narrate_for("c1"), "origin's gate holds");
+        let controller = app.apply_core(UiMessage::StreamComplete {
+            request_id: "req-1".into(),
+            full_response: "spoken reply".into(),
+        });
+
+        assert!(
+            !controller.iter().any(|e| matches!(e, Effect::Speak(_))),
+            "a backgrounded turn must not be narrated into the open chat: {controller:?}"
+        );
+        assert!(
+            app.current_conversation
+                .as_ref()
+                .unwrap()
+                .messages
+                .is_empty(),
+            "and it must not append to the open (c2) transcript"
+        );
+        // The gate predicate itself is unchanged and still origin-keyed.
+        assert!(app.narrate_for("c1"), "origin's gate still holds");
         assert!(!app.narrate_for("c2"), "open conversation stays silent");
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -713,6 +713,10 @@ impl App {
     /// `stream_matches_or_claims_request_id`. See issue #52.
     pub fn apply_prompt_ack(&mut self, _task_id: String, conversation_id: String) {
         self.start_streaming_without_request_id(conversation_id);
+        // Immediate feedback in the gap between Enter and the first streamed
+        // token. The daemon's own `Status` events (e.g. "Searching…") overwrite
+        // this, and completion/error clears it (see `set_assistant_status`).
+        self.set_assistant_status("Adele is thinking…");
     }
 
     /// Whether the in-flight stream belongs to the open conversation (TUI-4).
@@ -2002,6 +2006,22 @@ mod tests {
 
         app.complete_streaming("req1", "done");
         assert!(app.assistant_status.is_none());
+    }
+
+    #[test]
+    fn prompt_ack_shows_thinking_status() {
+        // The send was accepted but no token has arrived yet — show an immediate
+        // "thinking" cue so there's no dead air after pressing Enter.
+        let mut app = App::new();
+        app.current_conversation = Some(ConversationDetail {
+            id: "c1".into(),
+            title: "Test".into(),
+            messages: vec![],
+            model_selection: None,
+            conversation_personality: None,
+        });
+        app.apply_prompt_ack("t-1".into(), "c1".into());
+        assert_eq!(app.assistant_status.as_deref(), Some("Adele is thinking…"));
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -7,84 +7,9 @@ use ratatui_textarea::{CursorMove, DataCursor, TextArea};
 
 use crate::tasks::TaskPane;
 
-/// Context-window fill for the current conversation (desktop-assistant#341).
-/// Mirrors the daemon's `SignalEvent::ContextUsage` — token COUNTS only, no
-/// content. Drives the read-only status-bar indicator.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct ContextUsageView {
-    pub used_tokens: u64,
-    pub budget_tokens: u64,
-    pub compaction_active: bool,
-}
-
-/// Colour bucket for the context-fill indicator, decided by the daemon's
-/// proactive-compaction line (0.85 of budget). Green below 0.85, amber from
-/// 0.85 up to budget, red at/over budget (overflow).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ContextFillLevel {
-    Green,
-    Amber,
-    Red,
-}
-
-/// The proactive-compaction ratio the daemon uses (`COMPACTION_TOKEN_RATIO`).
-/// Kept in sync deliberately — this is the colour-threshold contract, not a
-/// recomputation of the budget (the daemon owns the numbers).
-const COMPACTION_RATIO: f64 = 0.85;
-
-impl ContextUsageView {
-    /// Fraction of budget consumed (0.0..). May exceed 1.0 on overflow.
-    /// Returns 0.0 for a zero/unknown budget to avoid a divide-by-zero and
-    /// to render neutrally rather than imply false precision.
-    pub fn fraction(&self) -> f64 {
-        if self.budget_tokens == 0 {
-            0.0
-        } else {
-            self.used_tokens as f64 / self.budget_tokens as f64
-        }
-    }
-
-    pub fn level(&self) -> ContextFillLevel {
-        let f = self.fraction();
-        if f >= 1.0 {
-            ContextFillLevel::Red
-        } else if f >= COMPACTION_RATIO {
-            // Inclusive at exactly 0.85: the daemon's strict-`>` compaction
-            // gate means we are AT the line, the moment to warn (amber).
-            ContextFillLevel::Amber
-        } else {
-            ContextFillLevel::Green
-        }
-    }
-
-    /// Compact human readout, e.g. `12k / 32k (38%)`. A trailing `⟳` marks an
-    /// active compaction/windowing pass. Budgets below 10k show exact counts;
-    /// larger ones are abbreviated to `k` for width.
-    pub fn readout(&self) -> String {
-        let pct = (self.fraction() * 100.0).round() as u64;
-        let mut s = format!(
-            "{} / {} ({pct}%)",
-            abbrev_tokens(self.used_tokens),
-            abbrev_tokens(self.budget_tokens),
-        );
-        if self.compaction_active {
-            s.push_str(" ⟳");
-        }
-        s
-    }
-}
-
-/// Abbreviate a token count for the narrow status bar: `12000 -> "12k"`,
-/// `512 -> "512"`. One decimal under 10k-with-fraction is avoided to keep it
-/// terse; this is a glanceable instrument, not an accounting figure.
-fn abbrev_tokens(n: u64) -> String {
-    if n >= 1_000 {
-        format!("{}k", n / 1_000)
-    } else {
-        n.to_string()
-    }
-}
-
+/// Context-window fill view + colour bucket (#341), shared via client-ui-common;
+/// re-exported so existing crate::app::ContextUsageView paths in ui.rs/main.rs resolve.
+pub use client_ui_common::{ContextFillLevel, ContextUsageView};
 fn new_textarea() -> TextArea<'static> {
     let mut ta = TextArea::default();
     ta.set_cursor_line_style(Style::default());

--- a/src/app.rs
+++ b/src/app.rs
@@ -120,7 +120,6 @@ pub enum InputMode {
 pub use adele_voice_client_common::AdeleOutput;
 
 pub struct App {
-    pub conversations: Vec<ConversationSummary>,
     pub selected_conversation: Option<usize>,
     pub current_conversation: Option<ConversationDetail>,
     pub textarea: TextArea<'static>,
@@ -223,7 +222,6 @@ pub struct App {
 impl App {
     pub fn new() -> Self {
         Self {
-            conversations: Vec::new(),
             selected_conversation: None,
             current_conversation: None,
             textarea: new_textarea(),
@@ -402,7 +400,7 @@ impl App {
         // Move sidebar selection to the linked conversation if it's
         // present in the local list. Loading the detail itself is
         // main's responsibility (it needs the WS client).
-        if let Some(idx) = self.conversations.iter().position(|c| c.id == conv_id) {
+        if let Some(idx) = self.core.conversations.iter().position(|c| c.id == conv_id) {
             self.selected_conversation = Some(idx);
         }
         self.tasks.visible = false;
@@ -464,12 +462,12 @@ impl App {
     // --- Navigation ---
 
     pub fn next_conversation(&mut self) {
-        if self.conversations.is_empty() {
+        if self.core.conversations.is_empty() {
             return;
         }
         self.selected_conversation = Some(match self.selected_conversation {
             Some(i) => {
-                if i >= self.conversations.len() - 1 {
+                if i >= self.core.conversations.len() - 1 {
                     0
                 } else {
                     i + 1
@@ -480,18 +478,18 @@ impl App {
     }
 
     pub fn previous_conversation(&mut self) {
-        if self.conversations.is_empty() {
+        if self.core.conversations.is_empty() {
             return;
         }
         self.selected_conversation = Some(match self.selected_conversation {
             Some(i) => {
                 if i == 0 {
-                    self.conversations.len() - 1
+                    self.core.conversations.len() - 1
                 } else {
                     i - 1
                 }
             }
-            None => self.conversations.len() - 1,
+            None => self.core.conversations.len() - 1,
         });
     }
 
@@ -844,7 +842,7 @@ impl App {
     /// whether it was found (TUI-8: selection is positional, so after a
     /// reconnect's list refresh we reselect by id, not index).
     pub fn select_conversation_by_id(&mut self, id: &str) -> bool {
-        match self.conversations.iter().position(|c| c.id == id) {
+        match self.core.conversations.iter().position(|c| c.id == id) {
             Some(idx) => {
                 self.selected_conversation = Some(idx);
                 true
@@ -855,23 +853,28 @@ impl App {
 
     // --- Conversation management ---
 
+    /// The conversation list, owned by the shared core (CC-3 slice 4): the
+    /// reducer is authoritative for it (its conversation arms read + mutate
+    /// `core.conversations`), and the view reads it back through here. The TUI
+    /// keeps only the *positional* selection (`selected_conversation`) as view
+    /// state.
+    pub fn conversations(&self) -> &[ConversationSummary] {
+        &self.core.conversations
+    }
+
     pub fn set_conversations(&mut self, conversations: Vec<ConversationSummary>) {
-        // Mirror the list into the shared core so it stays authoritative for the
-        // sidebar (CC-3): the reducer's conversation arms read `core.conversations`
-        // (e.g. to decide reconnect reload vs. fresh load). Paths that don't route
+        // The shared core owns the list (CC-3 slice 4): store it there directly.
+        // The reducer's conversation arms read `core.conversations` (e.g. to
+        // decide reconnect reload vs. fresh load), and paths that don't route
         // through `core.apply` (connect-time load, create/delete) funnel here, so
-        // this single dual-write keeps core in sync regardless of the caller.
-        self.core.conversations = conversations.clone();
-        self.conversations = conversations;
+        // this keeps core authoritative regardless of the caller.
+        self.core.conversations = conversations;
         // Fix selection if out of bounds (positional selection is TUI view state).
+        let len = self.core.conversations.len();
         if let Some(sel) = self.selected_conversation
-            && sel >= self.conversations.len()
+            && sel >= len
         {
-            self.selected_conversation = if self.conversations.is_empty() {
-                None
-            } else {
-                Some(self.conversations.len() - 1)
-            };
+            self.selected_conversation = if len == 0 { None } else { Some(len - 1) };
         }
     }
 
@@ -915,7 +918,7 @@ impl App {
 
     pub fn selected_conversation_id(&self) -> Option<&str> {
         let idx = self.selected_conversation?;
-        self.conversations.get(idx).map(|c| c.id.as_str())
+        self.core.conversations.get(idx).map(|c| c.id.as_str())
     }
 
     // --- Rename ---
@@ -926,7 +929,7 @@ impl App {
         let Some(idx) = self.selected_conversation else {
             return;
         };
-        let Some(conv) = self.conversations.get(idx) else {
+        let Some(conv) = self.core.conversations.get(idx) else {
             return;
         };
         let mut ta = new_textarea();
@@ -950,6 +953,7 @@ impl App {
             return None;
         }
         let unchanged = self
+            .core
             .conversations
             .iter()
             .find(|c| c.id == id)
@@ -2112,8 +2116,8 @@ mod tests {
         );
 
         // Sidebar reflects the new list (and core stays authoritative for it)...
-        assert_eq!(app.conversations.len(), 2);
-        assert_eq!(app.conversations[0].title, "First (renamed elsewhere)");
+        assert_eq!(app.conversations().len(), 2);
+        assert_eq!(app.conversations()[0].title, "First (renamed elsewhere)");
         // ...but the open conversation + its transcript are byte-for-byte intact.
         let open = app.current_conversation.as_ref().expect("still open");
         assert_eq!(open.id, "2");
@@ -2146,7 +2150,7 @@ mod tests {
 
         let deleted = app.delete_selected_conversation();
         assert_eq!(deleted, Some("2".to_string()));
-        assert_eq!(app.conversations.len(), 2);
+        assert_eq!(app.conversations().len(), 2);
         assert!(
             app.current_conversation.is_none(),
             "deleting the active conversation clears the open chat"
@@ -2189,7 +2193,7 @@ mod tests {
         app.apply_rename("2", "Renamed Second");
 
         // The sidebar row is updated via the core-owned list...
-        let row = app.conversations.iter().find(|c| c.id == "2").unwrap();
+        let row = app.conversations().iter().find(|c| c.id == "2").unwrap();
         assert_eq!(row.title, "Renamed Second");
         // ...and the open chat's cached title (the header reads it) is refreshed.
         assert_eq!(
@@ -2319,7 +2323,7 @@ mod tests {
             conversation_personality: None,
         });
         app.apply_rename("2", "Renamed");
-        assert_eq!(app.conversations[1].title, "Renamed");
+        assert_eq!(app.conversations()[1].title, "Renamed");
         assert_eq!(app.current_conversation.as_ref().unwrap().title, "Renamed");
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -121,14 +121,14 @@ pub use adele_voice_client_common::AdeleOutput;
 
 pub struct App {
     pub selected_conversation: Option<usize>,
-    pub current_conversation: Option<ConversationDetail>,
     pub textarea: TextArea<'static>,
-    // The in-flight streaming state (buffer, pending request/conversation id,
-    // external-turn flag, ack sentinel, narration gate) now lives in the shared
-    // `core` (CC-3): the reducer owns the state machine and the view reads it
-    // back through `streaming_buffer()` / `streaming_is_active_for_view()` /
-    // `is_streaming()`. `App` keeps only the rendered transcript
-    // (`current_conversation`) and mirrors core's streaming *effects* onto it.
+    // The conversation list, the open conversation's transcript, and the
+    // in-flight streaming state (buffer, pending request/conversation id,
+    // external-turn flag, ack sentinel, narration gate) all now live in the
+    // shared `core` (CC-3): the reducer owns those state machines and the view
+    // reads them back through `conversations()` / `current_conversation()` /
+    // `streaming_buffer()` / `streaming_is_active_for_view()` / `is_streaming()`.
+    // `App` keeps only TUI view state (selection, scroll, mode, status lines).
     pub mode: InputMode,
     pub status_message: String,
     /// Whether the daemon connection is currently live. The run loop projects
@@ -223,7 +223,6 @@ impl App {
     pub fn new() -> Self {
         Self {
             selected_conversation: None,
-            current_conversation: None,
             textarea: new_textarea(),
             mode: InputMode::Normal,
             status_message: "Connected".to_string(),
@@ -277,7 +276,8 @@ impl App {
     /// Whether `You:` is Enabled for the currently-open conversation. `false`
     /// when no conversation is open.
     pub fn current_voice_in(&self) -> bool {
-        self.current_conversation
+        self.core
+            .current_conversation
             .as_ref()
             .is_some_and(|c| self.voice_in_for(&c.id))
     }
@@ -285,7 +285,7 @@ impl App {
     /// Flip `You:` for the currently-open conversation and return the new state
     /// (used by the `Ctrl+V` keybind). `None` when no conversation is open.
     pub fn toggle_current_voice_in(&mut self) -> Option<bool> {
-        let conv_id = self.current_conversation.as_ref()?.id.clone();
+        let conv_id = self.core.current_conversation.as_ref()?.id.clone();
         let next = !self.core.voice_in_for(&conv_id);
         self.set_voice_in(&conv_id, next);
         Some(next)
@@ -310,7 +310,8 @@ impl App {
     /// The `Adele:` level for the currently-open conversation. `Disabled` when
     /// no conversation is open.
     pub fn current_adele_output(&self) -> AdeleOutput {
-        self.current_conversation
+        self.core
+            .current_conversation
             .as_ref()
             .map(|c| self.adele_output_for(&c.id))
             .unwrap_or_default()
@@ -331,7 +332,7 @@ impl App {
     /// (`Disabled → OnDemand → Always → Disabled`) and return the new level
     /// (used by the `Ctrl+S` keybind). `None` when no conversation is open.
     pub fn cycle_current_adele_output(&mut self) -> Option<AdeleOutput> {
-        let conv_id = self.current_conversation.as_ref()?.id.clone();
+        let conv_id = self.core.current_conversation.as_ref()?.id.clone();
         let next = self.core.adele_output_for(&conv_id).next();
         self.set_adele_output(&conv_id, next);
         Some(next)
@@ -359,7 +360,7 @@ impl App {
     /// a stale/other conversation never bleeds into the visible chat. Returns
     /// whether the note was shown.
     pub fn push_speech_disabled_note(&mut self, conversation_id: &str, text: &str) -> bool {
-        let Some(conv) = self.current_conversation.as_mut() else {
+        let Some(conv) = self.core.current_conversation.as_mut() else {
             return false;
         };
         if conv.id != conversation_id {
@@ -427,7 +428,7 @@ impl App {
         &mut self,
         override_selection: desktop_assistant_api_model::SendPromptOverride,
     ) {
-        if let Some(conv) = self.current_conversation.as_mut() {
+        if let Some(conv) = self.core.current_conversation.as_mut() {
             conv.model_selection = Some(
                 desktop_assistant_api_model::ConversationModelSelectionView {
                     connection_id: override_selection.connection_id.clone(),
@@ -551,6 +552,7 @@ impl App {
     /// retyping. The caller sets the status message with the send error.
     pub fn restore_failed_submission(&mut self, conversation_id: &str, prompt: &str) {
         if let Some(conv) = self
+            .core
             .current_conversation
             .as_mut()
             .filter(|c| c.id == conversation_id)
@@ -571,7 +573,7 @@ impl App {
         if content.is_empty() {
             return None;
         }
-        let conv = self.current_conversation.as_mut()?;
+        let conv = self.core.current_conversation.as_mut()?;
         conv.messages.push(ChatMessage {
             // Optimistic local echo of our own send; the daemon assigns the real
             // message id (#1) when it persists the turn. Dedupe of the echoed-back
@@ -702,8 +704,11 @@ impl App {
     ///
     /// View-effects are applied here because the TUI redraws from state every
     /// frame: a streamed chunk is already on screen once it lands in
-    /// `core.streaming_buffer()`, so [`Effect::ReceiveChunk`] is a no-op; only
-    /// the transcript-finalizing and status effects need a write.
+    /// `core.streaming_buffer()`, so [`Effect::ReceiveChunk`] is a no-op — and
+    /// since the reducer now owns the open transcript and the conversation list
+    /// (CC-3 slice 4), the transcript-finalizing and `ClearChat` effects are
+    /// no-ops too. Only the TUI-only view state (status lines, context-usage
+    /// readout, positional selection) still needs a write here.
     pub fn apply_core(&mut self, msg: UiMessage) -> Vec<Effect> {
         let effects = self.core.apply(msg);
         effects
@@ -720,18 +725,13 @@ impl App {
             // so the chunk is already visible — nothing to do. (Scroll follows
             // only at the bottom, TUI-10, which needs no write either.)
             Effect::ReceiveChunk(_) => None,
-            // Finalize the streamed reply into the open conversation. The reducer
-            // only emits this when the originating conversation is the one in view
-            // (TUI-4), so it always targets the right transcript.
-            Effect::CompleteStreaming(full) => {
-                self.append_message("assistant", full);
-                None
-            }
-            // Render the user bubble for an adopted external turn (#1 live sync).
-            Effect::AddUserMessage(content) => {
-                self.append_message("user", content);
-                None
-            }
+            // The reducer now owns the open conversation's transcript
+            // (`core.current_conversation`, CC-3 slice 4) and pushes the finalized
+            // reply / adopted external user bubble into it itself — guarded so it
+            // only ever writes when the originating conversation is the one in view
+            // (TUI-4). The view re-reads that transcript each frame, so these
+            // effects carry no view-level work.
+            Effect::CompleteStreaming(_) | Effect::AddUserMessage(_) => None,
             Effect::SetChatStatus(message) => {
                 self.set_assistant_status(message);
                 None
@@ -760,11 +760,10 @@ impl App {
             // is a no-op here — the auto-load/create that gtk's executor performs
             // is deliberately omitted (CC-3: behavior-preserving).
             Effect::EnsureActiveConversation => None,
-            // Clear the open chat (the active conversation was deleted).
-            Effect::ClearChat => {
-                self.current_conversation = None;
-                None
-            }
+            // The active conversation was deleted. The reducer already cleared
+            // `core.current_conversation` (and its id) before emitting this, so the
+            // view — which reads that field — needs no further write (CC-3 slice 4).
+            Effect::ClearChat => None,
             // The TUI has no side pane (the scratchpad + per-conversation task
             // list live in the gtk/kde clients), so these are inert here.
             Effect::SidePaneSetScratchpad(_)
@@ -774,20 +773,6 @@ impl App {
             // the open-conversation RPC effects) need handles the view doesn't
             // hold; bubble them up to `main`'s executor.
             other => Some(other),
-        }
-    }
-
-    /// Append a finalized message of `role` to the open conversation's transcript
-    /// (no-op when none is open). Mirrors the streaming effects the reducer emits;
-    /// the daemon assigns the authoritative id (#1), re-fetched on the next open,
-    /// so the local copy carries an empty id (streaming dedupe is by request_id).
-    fn append_message(&mut self, role: &str, content: String) {
-        if let Some(conv) = self.current_conversation.as_mut() {
-            conv.messages.push(ChatMessage {
-                id: String::new(),
-                role: role.to_string(),
-                content,
-            });
         }
     }
 
@@ -862,6 +847,16 @@ impl App {
         &self.core.conversations
     }
 
+    /// The open conversation's detail — transcript, title, and model selection —
+    /// owned by the shared core (CC-3 slice 4). The reducer maintains it: it
+    /// finalizes streamed replies into it, adopts external turns, and clears it
+    /// when the active conversation is deleted (`App::load_conversation` seeds it
+    /// on open). The view + controller read it back through here. `None` when no
+    /// conversation is open.
+    pub fn current_conversation(&self) -> Option<&ConversationDetail> {
+        self.core.current_conversation.as_ref()
+    }
+
     pub fn set_conversations(&mut self, conversations: Vec<ConversationSummary>) {
         // The shared core owns the list (CC-3 slice 4): store it there directly.
         // The reducer's conversation arms read `core.conversations` (e.g. to
@@ -879,14 +874,18 @@ impl App {
     }
 
     pub fn load_conversation(&mut self, detail: ConversationDetail) {
-        let switching =
-            self.current_conversation.as_ref().map(|c| c.id.as_str()) != Some(detail.id.as_str());
-        // Dual-write the open-conversation id into the shared core so its
-        // streaming originating-conversation checks (TUI-4 / GTK-2) judge against
-        // the conversation actually in view. `App` still owns the rendered
-        // transcript; only the id `core` needs for routing is mirrored (CC-3).
+        let switching = self
+            .core
+            .current_conversation
+            .as_ref()
+            .map(|c| c.id.as_str())
+            != Some(detail.id.as_str());
+        // Seed the shared core's open conversation (CC-3 slice 4): it owns both the
+        // rendered transcript (the reducer finalizes streamed replies into it) and
+        // the id its streaming originating-conversation checks (TUI-4 / GTK-2)
+        // judge against, so the stream events route to the conversation in view.
         self.core.current_conversation_id = Some(detail.id.clone());
-        self.current_conversation = Some(detail);
+        self.core.current_conversation = Some(detail);
         // Drop a stale context-fill reading when the visible conversation
         // changes; the next turn re-establishes it (#341).
         if switching {
@@ -909,10 +908,24 @@ impl App {
     /// Refresh the open conversation's cached title if it is the one named (the
     /// chat header reads it). No-op when a different conversation is open.
     fn set_open_conversation_title(&mut self, conversation_id: &str, title: &str) {
-        if let Some(current) = self.current_conversation.as_mut()
+        if let Some(current) = self.core.current_conversation.as_mut()
             && current.id == conversation_id
         {
             current.title = title.to_string();
+        }
+    }
+
+    /// Optimistically update the open conversation's per-conversation personality
+    /// after the picker saves it, so the change shows without a re-fetch. The
+    /// picker owns the screen while open, so the open conversation is still the
+    /// one it was launched for; mirrors [`Self::apply_model_override`]. No-op when
+    /// no conversation is open.
+    pub fn set_open_conversation_personality(
+        &mut self,
+        personality: desktop_assistant_api_model::ConversationPersonalityView,
+    ) {
+        if let Some(conv) = self.core.current_conversation.as_mut() {
+            conv.conversation_personality = Some(personality);
         }
     }
 
@@ -1336,7 +1349,7 @@ mod tests {
     #[test]
     fn submit_prompt_sends_unwrapped_text_after_display_wrap() {
         let mut app = App::new();
-        app.current_conversation = Some(ConversationDetail {
+        app.load_conversation(ConversationDetail {
             id: "c1".into(),
             title: "t".into(),
             messages: vec![],
@@ -1375,7 +1388,7 @@ mod tests {
     #[test]
     fn submit_prompt_preserves_explicit_user_newlines() {
         let mut app = App::new();
-        app.current_conversation = Some(ConversationDetail {
+        app.load_conversation(ConversationDetail {
             id: "c1".into(),
             title: "t".into(),
             messages: vec![],
@@ -1418,7 +1431,7 @@ mod tests {
     #[test]
     fn submit_prompt_with_empty_input_returns_none() {
         let mut app = App::new();
-        app.current_conversation = Some(ConversationDetail {
+        app.load_conversation(ConversationDetail {
             id: "1".into(),
             title: "Test".into(),
             messages: vec![],
@@ -1431,7 +1444,7 @@ mod tests {
     #[test]
     fn submit_prompt_appends_user_message_and_clears_input() {
         let mut app = App::new();
-        app.current_conversation = Some(ConversationDetail {
+        app.load_conversation(ConversationDetail {
             id: "conv1".into(),
             title: "Test".into(),
             messages: vec![],
@@ -1447,7 +1460,7 @@ mod tests {
         );
         assert_eq!(app.textarea_content(), "");
 
-        let msgs = &app.current_conversation.as_ref().unwrap().messages;
+        let msgs = &app.current_conversation().unwrap().messages;
         assert_eq!(msgs.len(), 1);
         assert_eq!(msgs[0].role, "user");
         assert_eq!(msgs[0].content, "What is Rust?");
@@ -1478,7 +1491,7 @@ mod tests {
         // Acceptance (TUI-3): a 3-line paste yields ONE submitted prompt with
         // the newlines intact, not three partial prompts.
         let mut app = App::new();
-        app.current_conversation = Some(ConversationDetail {
+        app.load_conversation(ConversationDetail {
             id: "c1".into(),
             title: "Test".into(),
             messages: vec![],
@@ -1492,7 +1505,7 @@ mod tests {
             result,
             Some(("c1".to_string(), "first\nsecond\nthird".to_string()))
         );
-        let msgs = &app.current_conversation.as_ref().unwrap().messages;
+        let msgs = &app.current_conversation().unwrap().messages;
         assert_eq!(msgs.len(), 1, "exactly one user message appended");
     }
 
@@ -1549,11 +1562,7 @@ mod tests {
             "composer text must be preserved"
         );
         assert!(
-            app.current_conversation
-                .as_ref()
-                .unwrap()
-                .messages
-                .is_empty(),
+            app.current_conversation().unwrap().messages.is_empty(),
             "transcript must not gain a user message"
         );
         assert!(
@@ -1581,13 +1590,7 @@ mod tests {
 
         assert!(result.is_none(), "second send must be blocked mid-stream");
         assert_eq!(app.textarea_content(), "second question");
-        assert!(
-            app.current_conversation
-                .as_ref()
-                .unwrap()
-                .messages
-                .is_empty()
-        );
+        assert!(app.current_conversation().unwrap().messages.is_empty());
         assert!(!app.status_message.is_empty());
     }
 
@@ -1609,7 +1612,7 @@ mod tests {
         let result = app.prepare_submission(true);
         assert_eq!(result, Some(("c1".to_string(), "hello".to_string())));
         assert_eq!(app.textarea_content(), "");
-        assert_eq!(app.current_conversation.as_ref().unwrap().messages.len(), 1);
+        assert_eq!(app.current_conversation().unwrap().messages.len(), 1);
     }
 
     #[test]
@@ -1622,11 +1625,7 @@ mod tests {
         app.restore_failed_submission(&conv_id, &prompt);
 
         assert!(
-            app.current_conversation
-                .as_ref()
-                .unwrap()
-                .messages
-                .is_empty(),
+            app.current_conversation().unwrap().messages.is_empty(),
             "optimistic user message must be rolled back"
         );
         assert_eq!(app.textarea_content(), "doomed prompt");
@@ -1656,7 +1655,7 @@ mod tests {
         app.restore_failed_submission(&conv_id, &prompt);
 
         assert_eq!(
-            app.current_conversation.as_ref().unwrap().messages.len(),
+            app.current_conversation().unwrap().messages.len(),
             1,
             "the other conversation's transcript must be untouched"
         );
@@ -1669,19 +1668,13 @@ mod tests {
         // optimistic append; only an exact matching tail is rolled back.
         let mut app = app_ready_to_send("c1", "prompt");
         let (conv_id, prompt) = app.prepare_submission(true).unwrap();
-        app.current_conversation
-            .as_mut()
-            .unwrap()
-            .messages
-            .push(ChatMessage {
-                id: String::new(),
-                role: "assistant".into(),
-                content: "(speech mode disabled) aside".into(),
-            });
+        // A non-matching message lands after the optimistic user append — exactly
+        // how an Adele-disabled `say_this` aside reaches the transcript.
+        app.push_speech_disabled_note("c1", "aside");
 
         app.restore_failed_submission(&conv_id, &prompt);
 
-        let msgs = &app.current_conversation.as_ref().unwrap().messages;
+        let msgs = &app.current_conversation().unwrap().messages;
         assert_eq!(msgs.len(), 2, "non-matching tail must not be popped");
         assert_eq!(app.textarea_content(), "prompt");
     }
@@ -1736,7 +1729,7 @@ mod tests {
 
         assert!(!app.is_streaming(), "the slot clears on completion");
         assert_eq!(app.streaming_buffer(), "", "the live partial is gone");
-        let msgs = &app.current_conversation.as_ref().unwrap().messages;
+        let msgs = &app.current_conversation().unwrap().messages;
         assert_eq!(msgs.len(), 1);
         assert_eq!(msgs[0].role, "assistant");
         assert_eq!(msgs[0].content, "Hello world!");
@@ -1766,11 +1759,7 @@ mod tests {
             "a backgrounded completion emits no controller effect (no narration)"
         );
         assert!(
-            app.current_conversation
-                .as_ref()
-                .unwrap()
-                .messages
-                .is_empty(),
+            app.current_conversation().unwrap().messages.is_empty(),
             "the reply must not bleed into the switched-to conversation"
         );
         assert!(!app.is_streaming(), "the slot still clears");
@@ -1908,7 +1897,7 @@ mod tests {
             "rendering the bubble needs no controller effect"
         );
 
-        let msgs = &app.current_conversation.as_ref().unwrap().messages;
+        let msgs = &app.current_conversation().unwrap().messages;
         assert_eq!(msgs.len(), 1, "the external user message must be rendered");
         assert_eq!(msgs[0].role, "user");
         assert_eq!(msgs[0].content, "what's the weather?");
@@ -2004,7 +1993,7 @@ mod tests {
         // The send was accepted but no token has arrived yet — show an immediate
         // "thinking" cue so there's no dead air after pressing Enter.
         let mut app = App::new();
-        app.current_conversation = Some(ConversationDetail {
+        app.load_conversation(ConversationDetail {
             id: "c1".into(),
             title: "Test".into(),
             messages: vec![],
@@ -2119,7 +2108,7 @@ mod tests {
         assert_eq!(app.conversations().len(), 2);
         assert_eq!(app.conversations()[0].title, "First (renamed elsewhere)");
         // ...but the open conversation + its transcript are byte-for-byte intact.
-        let open = app.current_conversation.as_ref().expect("still open");
+        let open = app.current_conversation().expect("still open");
         assert_eq!(open.id, "2");
         assert_eq!(open.messages.len(), 2);
         assert_eq!(open.messages[1].content, "hi there");
@@ -2152,7 +2141,7 @@ mod tests {
         assert_eq!(deleted, Some("2".to_string()));
         assert_eq!(app.conversations().len(), 2);
         assert!(
-            app.current_conversation.is_none(),
+            app.current_conversation().is_none(),
             "deleting the active conversation clears the open chat"
         );
         assert_eq!(app.selected_conversation, Some(1)); // stays at 1 (now "Third")
@@ -2196,10 +2185,7 @@ mod tests {
         let row = app.conversations().iter().find(|c| c.id == "2").unwrap();
         assert_eq!(row.title, "Renamed Second");
         // ...and the open chat's cached title (the header reads it) is refreshed.
-        assert_eq!(
-            app.current_conversation.as_ref().unwrap().title,
-            "Renamed Second"
-        );
+        assert_eq!(app.current_conversation().unwrap().title, "Renamed Second");
     }
 
     #[test]
@@ -2315,7 +2301,7 @@ mod tests {
     #[test]
     fn apply_rename_updates_sidebar_and_current() {
         let mut app = app_with_conversations();
-        app.current_conversation = Some(ConversationDetail {
+        app.load_conversation(ConversationDetail {
             id: "2".into(),
             title: "Second".into(),
             messages: vec![],
@@ -2324,7 +2310,7 @@ mod tests {
         });
         app.apply_rename("2", "Renamed");
         assert_eq!(app.conversations()[1].title, "Renamed");
-        assert_eq!(app.current_conversation.as_ref().unwrap().title, "Renamed");
+        assert_eq!(app.current_conversation().unwrap().title, "Renamed");
     }
 
     #[test]
@@ -2335,7 +2321,7 @@ mod tests {
     #[test]
     fn apply_model_override_updates_current_conversation_and_stages_pending() {
         let mut app = App::new();
-        app.current_conversation = Some(ConversationDetail {
+        app.load_conversation(ConversationDetail {
             id: "c1".into(),
             title: "Chat".into(),
             messages: vec![],
@@ -2350,8 +2336,7 @@ mod tests {
         app.apply_model_override(ovr.clone());
         assert!(app.pending_model_override.is_some());
         let sel = app
-            .current_conversation
-            .as_ref()
+            .current_conversation()
             .unwrap()
             .model_selection
             .as_ref()
@@ -2430,7 +2415,7 @@ mod tests {
     #[test]
     fn submit_prompt_resets_scroll() {
         let mut app = App::new();
-        app.current_conversation = Some(ConversationDetail {
+        app.load_conversation(ConversationDetail {
             id: "c1".into(),
             title: "Test".into(),
             messages: vec![],
@@ -2761,11 +2746,7 @@ mod tests {
             "a backgrounded turn must not be narrated into the open chat: {controller:?}"
         );
         assert!(
-            app.current_conversation
-                .as_ref()
-                .unwrap()
-                .messages
-                .is_empty(),
+            app.current_conversation().unwrap().messages.is_empty(),
             "and it must not append to the open (c2) transcript"
         );
         // The gate predicate itself is unchanged and still origin-keyed.
@@ -2777,7 +2758,7 @@ mod tests {
     fn push_speech_disabled_note_appends_inline_to_open_conversation() {
         let mut app = app_with_open_conversation("c1");
         assert!(app.push_speech_disabled_note("c1", "the kettle is on"));
-        let msgs = &app.current_conversation.as_ref().unwrap().messages;
+        let msgs = &app.current_conversation().unwrap().messages;
         assert_eq!(msgs.len(), 1);
         assert_eq!(msgs[0].role, "assistant");
         assert_eq!(msgs[0].content, "(speech mode disabled) the kettle is on");
@@ -2789,13 +2770,7 @@ mod tests {
         // must NOT bleed text into the visible transcript.
         let mut app = app_with_open_conversation("c1");
         assert!(!app.push_speech_disabled_note("c2", "wrong conversation"));
-        assert!(
-            app.current_conversation
-                .as_ref()
-                .unwrap()
-                .messages
-                .is_empty()
-        );
+        assert!(app.current_conversation().unwrap().messages.is_empty());
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,11 +1,16 @@
-use std::collections::HashMap;
-
 use desktop_assistant_api_model::TaskId;
 pub use desktop_assistant_client_common::{ChatMessage, ConversationDetail, ConversationSummary};
 use ratatui::style::Style;
 use ratatui_textarea::{CursorMove, DataCursor, TextArea};
 
 use crate::tasks::TaskPane;
+
+// The shared, view-agnostic model+controller (client-ui-common). `App` embeds a
+// `WindowState` as `core` and is migrating its chat-core state onto it slice by
+// slice (CC-3). First slice: per-conversation voice state lives in `core`;
+// `App`'s voice methods are thin wrappers that read core's accessors and route
+// writes through `core.apply(...)`.
+use client_ui_common::{UiMessage, WindowState};
 
 /// Context-window fill view + colour bucket (#341), shared via client-ui-common;
 /// re-exported so existing crate::app::ContextUsageView paths in ui.rs/main.rs resolve.
@@ -199,21 +204,15 @@ pub struct App {
     /// actually closes the loop; this is purely so the status bar can
     /// say "cancelling t-1..." while we wait.
     pub pending_task_cancel: Option<TaskId>,
-    /// Per-conversation `You:` (voice input) state (adele-tui#77, mirroring
-    /// adele-gtk#80). Keyed by conversation id; a conversation absent from the
-    /// map is **Disabled** (type only). When `true` (Enabled), a push-to-talk
-    /// control is available and — combined with `Adele == OnDemand` — gates
-    /// reply narration. Toggled in-app with `Ctrl+V`. Per-conversation, so
-    /// enabling it in one conversation never affects another.
-    voice_in: HashMap<String, bool>,
-    /// Per-conversation `Adele:` (voice output) level (adele-tui#77, mirroring
-    /// adele-gtk#80). Keyed by conversation id; a conversation absent from the
-    /// map is `Disabled` (never speaks). Set by the user (`Ctrl+S` cycles it) or
-    /// the model (`request_voice` → OnDemand, `stop_voice` → Disabled). Decides
-    /// reply narration (with `You`), the `say_this` aside gate, and the send-time
-    /// `system_refinement`. Replaces phase-1/2's `speech_enabled` (read-aloud ==
-    /// Always) and `voice_mode` (== OnDemand) toggles.
-    adele_output: HashMap<String, AdeleOutput>,
+    /// The shared, view-agnostic model+controller (client-ui-common). `App` is
+    /// migrating its chat-core state onto it slice by slice (CC-3). Currently it
+    /// owns the per-conversation voice state (`You:` input enablement and
+    /// `Adele:` output level, adele-tui#77 / adele-gtk#80) — both default to
+    /// Disabled for an absent conversation and never bleed across conversations.
+    /// `App`'s voice methods read core's accessors and route writes through
+    /// `core.apply(...)`. The remaining `core` fields are not yet authoritative
+    /// for the TUI and stay at their defaults until later slices adopt them.
+    core: WindowState,
 }
 
 impl App {
@@ -251,8 +250,7 @@ impl App {
             pending_model_override: None,
             tasks: TaskPane::new(),
             pending_task_cancel: None,
-            voice_in: HashMap::new(),
-            adele_output: HashMap::new(),
+            core: WindowState::default(),
         }
     }
 
@@ -275,7 +273,7 @@ impl App {
     /// Whether `You:` (voice input) is Enabled for `conversation_id`. A
     /// conversation absent from the map is Disabled (the default).
     pub fn voice_in_for(&self, conversation_id: &str) -> bool {
-        self.voice_in.get(conversation_id).copied().unwrap_or(false)
+        self.core.voice_in_for(conversation_id)
     }
 
     /// Whether `You:` is Enabled for the currently-open conversation. `false`
@@ -290,18 +288,25 @@ impl App {
     /// (used by the `Ctrl+V` keybind). `None` when no conversation is open.
     pub fn toggle_current_voice_in(&mut self) -> Option<bool> {
         let conv_id = self.current_conversation.as_ref()?.id.clone();
-        let next = !self.voice_in_for(&conv_id);
-        self.voice_in.insert(conv_id, next);
+        let next = !self.core.voice_in_for(&conv_id);
+        self.set_voice_in(&conv_id, next);
         Some(next)
+    }
+
+    /// Set `You:` (voice input) for an explicit `conversation_id`.
+    /// Per-conversation: only the named conversation is affected. Mirrors
+    /// [`Self::set_adele_output`]; routes the write through `core.apply`.
+    pub fn set_voice_in(&mut self, conversation_id: &str, enabled: bool) {
+        self.core.apply(UiMessage::SetVoiceIn {
+            conversation_id: conversation_id.to_string(),
+            enabled,
+        });
     }
 
     /// The `Adele:` (voice output) level for `conversation_id`. `Disabled` when
     /// the conversation was never set (the default).
     pub fn adele_output_for(&self, conversation_id: &str) -> AdeleOutput {
-        self.adele_output
-            .get(conversation_id)
-            .copied()
-            .unwrap_or_default()
+        self.core.adele_output_for(conversation_id)
     }
 
     /// The `Adele:` level for the currently-open conversation. `Disabled` when
@@ -318,7 +323,10 @@ impl App {
     /// their own conversation). Per-conversation: only the named conversation is
     /// affected.
     pub fn set_adele_output(&mut self, conversation_id: &str, level: AdeleOutput) {
-        self.adele_output.insert(conversation_id.to_string(), level);
+        self.core.apply(UiMessage::SetAdeleOutput {
+            conversation_id: conversation_id.to_string(),
+            level,
+        });
     }
 
     /// Cycle `Adele:` for the currently-open conversation
@@ -326,8 +334,8 @@ impl App {
     /// (used by the `Ctrl+S` keybind). `None` when no conversation is open.
     pub fn cycle_current_adele_output(&mut self) -> Option<AdeleOutput> {
         let conv_id = self.current_conversation.as_ref()?.id.clone();
-        let next = self.adele_output_for(&conv_id).next();
-        self.adele_output.insert(conv_id, next);
+        let next = self.core.adele_output_for(&conv_id).next();
+        self.set_adele_output(&conv_id, next);
         Some(next)
     }
 
@@ -336,8 +344,7 @@ impl App {
     /// `You == Enabled`). `Disabled` never narrates. Delegates to the shared
     /// gate (desktop-assistant#274).
     pub fn narrate_for(&self, conversation_id: &str) -> bool {
-        self.adele_output_for(conversation_id)
-            .narrates_reply(self.voice_in_for(conversation_id))
+        self.core.narrate_for(conversation_id)
     }
 
     /// Whether a `say_this` aside is spoken for `conversation_id` (adele-tui#77):
@@ -345,7 +352,7 @@ impl App {
     /// downgrades the aside to inline text. Delegates to the shared gate
     /// (desktop-assistant#274).
     pub fn say_this_spoken_for(&self, conversation_id: &str) -> bool {
-        self.adele_output_for(conversation_id).speaks_aside()
+        self.core.say_this_spoken_for(conversation_id)
     }
 
     /// Render a `say_this` call whose aside is NOT spoken (Adele == Disabled) as
@@ -2687,7 +2694,7 @@ mod tests {
         // Always reads every reply aloud whether or not You is Enabled.
         for you in [false, true] {
             let mut app = app_with_open_conversation("c1");
-            app.voice_in.insert("c1".to_string(), you);
+            app.set_voice_in("c1", you);
             app.set_adele_output("c1", AdeleOutput::Always);
             assert!(app.narrate_for("c1"), "Always must narrate (You={you})");
             assert!(
@@ -2704,7 +2711,7 @@ mod tests {
         app.set_adele_output("c1", AdeleOutput::OnDemand);
 
         // You Disabled → reply text-only, but say_this aside still spoken.
-        app.voice_in.insert("c1".to_string(), false);
+        app.set_voice_in("c1", false);
         assert!(
             !app.narrate_for("c1"),
             "OnDemand + You=Disabled: no narration"
@@ -2715,7 +2722,7 @@ mod tests {
         );
 
         // You Enabled → reply narrated.
-        app.voice_in.insert("c1".to_string(), true);
+        app.set_voice_in("c1", true);
         assert!(app.narrate_for("c1"), "OnDemand + You=Enabled narrates");
         assert!(app.say_this_spoken_for("c1"));
     }
@@ -2725,7 +2732,7 @@ mod tests {
         let mut app = app_with_open_conversation("c1");
         app.set_adele_output("c1", AdeleOutput::Disabled);
         for you in [false, true] {
-            app.voice_in.insert("c1".to_string(), you);
+            app.set_voice_in("c1", you);
             assert!(
                 !app.narrate_for("c1"),
                 "Disabled never narrates (You={you})"
@@ -2741,7 +2748,7 @@ mod tests {
     fn set_voice_in_targets_an_explicit_conversation() {
         // The model's tools / the streaming path carry their own conversation id.
         let mut app = app_with_open_conversation("c1");
-        app.voice_in.insert("c2".to_string(), true);
+        app.set_voice_in("c2", true);
         assert!(app.voice_in_for("c2"));
         assert!(!app.voice_in_for("c1")); // open conversation untouched
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -762,9 +762,19 @@ impl App {
             // is a no-op here — the auto-load/create that gtk's executor performs
             // is deliberately omitted (CC-3: behavior-preserving).
             Effect::EnsureActiveConversation => None,
-            // Controller-level effects (narration, scratchpad, and — in later
-            // CC-3 slices — the open-conversation RPC effects) need handles the
-            // view doesn't hold; bubble them up to `main`'s executor.
+            // Clear the open chat (the active conversation was deleted).
+            Effect::ClearChat => {
+                self.current_conversation = None;
+                None
+            }
+            // The TUI has no side pane (the scratchpad + per-conversation task
+            // list live in the gtk/kde clients), so these are inert here.
+            Effect::SidePaneSetScratchpad(_)
+            | Effect::RefreshSidePaneTasks
+            | Effect::FetchScratchpad(_) => None,
+            // Controller-level effects (narration, and — in later CC-3 slices —
+            // the open-conversation RPC effects) need handles the view doesn't
+            // hold; bubble them up to `main`'s executor.
             other => Some(other),
         }
     }
@@ -881,12 +891,21 @@ impl App {
         }
     }
 
+    /// Apply a live `TitleChanged` signal: the sidebar list rename flows through
+    /// the shared core (which owns the list and repaints it via `SetConversations`),
+    /// and the open chat's cached title is refreshed locally — the reducer owns
+    /// only the list, but the TUI's chat header reads `current_conversation.title`.
     pub fn update_conversation_title(&mut self, conversation_id: &str, title: &str) {
-        for conv in &mut self.conversations {
-            if conv.id == conversation_id {
-                conv.title = title.to_string();
-            }
-        }
+        let _ = self.apply_core(UiMessage::TitleChanged {
+            conversation_id: conversation_id.to_string(),
+            title: title.to_string(),
+        });
+        self.set_open_conversation_title(conversation_id, title);
+    }
+
+    /// Refresh the open conversation's cached title if it is the one named (the
+    /// chat header reads it). No-op when a different conversation is open.
+    fn set_open_conversation_title(&mut self, conversation_id: &str, title: &str) {
         if let Some(current) = self.current_conversation.as_mut()
             && current.id == conversation_id
         {
@@ -948,38 +967,30 @@ impl App {
         self.mode = InputMode::Normal;
     }
 
-    /// Apply a renamed title locally (call after the daemon confirms).
+    /// Apply a renamed title (call after the daemon confirms). Routes the sidebar
+    /// rename through the shared core and refreshes the open chat's cached title.
     pub fn apply_rename(&mut self, conversation_id: &str, title: &str) {
-        self.update_conversation_title(conversation_id, title);
+        let _ = self.apply_core(UiMessage::ConversationRenamed {
+            id: conversation_id.to_string(),
+            title: title.to_string(),
+        });
+        self.set_open_conversation_title(conversation_id, title);
     }
 
     pub fn delete_selected_conversation(&mut self) -> Option<String> {
-        let idx = self.selected_conversation?;
-        if idx >= self.conversations.len() {
-            return None;
-        }
-        let id = self.conversations[idx].id.clone();
-        self.conversations.remove(idx);
-
-        // Clear current conversation if it was the deleted one (and mirror the
-        // clear into the shared core so its streaming active-checks don't keep
-        // pointing at a gone conversation, CC-3).
-        if self
-            .current_conversation
-            .as_ref()
-            .is_some_and(|c| c.id == id)
-        {
-            self.current_conversation = None;
-            self.core.current_conversation_id = None;
-        }
-
-        // Fix selection
-        if self.conversations.is_empty() {
-            self.selected_conversation = None;
-        } else if idx >= self.conversations.len() {
-            self.selected_conversation = Some(self.conversations.len() - 1);
-        }
-
+        let id = self.selected_conversation_id()?.to_string();
+        // Route the removal through the shared core: the reducer drops the row,
+        // prunes the conversation's per-conversation voice state (GTK-9 — the TUI
+        // previously leaked it, growing the maps unbounded), and clears the open
+        // chat when the deleted conversation was the active one. The emitted
+        // effects are all view-effects (SetConversations re-clamps the positional
+        // selection; ClearChat blanks the chat; the side-pane + EnsureActive
+        // effects are TUI no-ops), so `apply_core` fully handles them.
+        let effects = self.apply_core(UiMessage::ConversationDeleted { id: id.clone() });
+        debug_assert!(
+            effects.is_empty(),
+            "ConversationDeleted must emit only view-effects: {effects:?}"
+        );
         Some(id)
     }
 }
@@ -2123,7 +2134,9 @@ mod tests {
     fn delete_selected_conversation() {
         let mut app = app_with_conversations();
         app.selected_conversation = Some(1);
-        app.current_conversation = Some(ConversationDetail {
+        // `load_conversation` (not a raw field write) so core's open-conversation
+        // id is set — the reducer's delete keys its "clear the open chat" on it.
+        app.load_conversation(ConversationDetail {
             id: "2".into(),
             title: "Second".into(),
             messages: vec![],
@@ -2134,8 +2147,55 @@ mod tests {
         let deleted = app.delete_selected_conversation();
         assert_eq!(deleted, Some("2".to_string()));
         assert_eq!(app.conversations.len(), 2);
-        assert!(app.current_conversation.is_none());
+        assert!(
+            app.current_conversation.is_none(),
+            "deleting the active conversation clears the open chat"
+        );
         assert_eq!(app.selected_conversation, Some(1)); // stays at 1 (now "Third")
+    }
+
+    #[test]
+    fn deleting_a_conversation_prunes_its_per_conversation_voice_state() {
+        // GTK-9 / bug fix: the pre-flip TUI delete left the per-conversation
+        // voice maps untouched, leaking state (and risking a later id-reuse
+        // inheriting a stale setting). Routing delete through the core prunes it.
+        let mut app = app_with_conversations();
+        app.set_adele_output("2", AdeleOutput::Always);
+        app.set_voice_in("2", true);
+        assert!(app.narrate_for("2"), "precondition: voice state is set");
+
+        app.selected_conversation = Some(1); // id "2"
+        app.delete_selected_conversation();
+
+        assert!(
+            !app.narrate_for("2"),
+            "voice state must be pruned on delete"
+        );
+        assert_eq!(app.adele_output_for("2"), AdeleOutput::Disabled);
+        assert!(!app.voice_in_for("2"));
+    }
+
+    #[test]
+    fn rename_routes_through_core_and_refreshes_the_open_title() {
+        let mut app = app_with_conversations();
+        app.load_conversation(ConversationDetail {
+            id: "2".into(),
+            title: "Second".into(),
+            messages: vec![],
+            model_selection: None,
+            conversation_personality: None,
+        });
+
+        app.apply_rename("2", "Renamed Second");
+
+        // The sidebar row is updated via the core-owned list...
+        let row = app.conversations.iter().find(|c| c.id == "2").unwrap();
+        assert_eq!(row.title, "Renamed Second");
+        // ...and the open chat's cached title (the header reads it) is refreshed.
+        assert_eq!(
+            app.current_conversation.as_ref().unwrap().title,
+            "Renamed Second"
+        );
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -139,6 +139,13 @@ pub struct App {
     pub streaming_is_external: bool,
     pub mode: InputMode,
     pub status_message: String,
+    /// Whether the daemon connection is currently live. The run loop projects
+    /// its `ReconnectState` into this each frame (it owns the socket); the view
+    /// reads it to render disconnect chrome — a warn-colored input border plus
+    /// an `offline` tag. Defaults `true`; the loop overwrites it before the
+    /// first draw. (CC-3 moves this into the shared `core` once signals route
+    /// through the reducer.)
+    pub connected: bool,
     pub should_quit: bool,
     /// Whether the `?`/F1 keymap help overlay is shown. Any key closes it.
     pub show_help: bool,
@@ -230,6 +237,7 @@ impl App {
             streaming_is_external: false,
             mode: InputMode::Normal,
             status_message: "Connected".to_string(),
+            connected: true,
             should_quit: false,
             show_help: false,
             scroll_offset: 0,

--- a/src/app.rs
+++ b/src/app.rs
@@ -530,77 +530,20 @@ impl App {
         self.textarea.lines().join("\n")
     }
 
-    /// Gate + mutate for a prompt submission (TUI-2 / TUI-7). Checks the
-    /// preconditions BEFORE touching any state, so a refused submission leaves
-    /// the composer and transcript untouched:
-    ///
-    /// * not connected → refuse with a status message (TUI-2: previously the
-    ///   message was appended to the transcript and the composer cleared, then
-    ///   silently never sent);
-    /// * a reply is still streaming (`pending_request_id` is claimed or the
-    ///   ack sentinel) → refuse with a status message (TUI-7 policy: **block
-    ///   concurrent sends**. The TUI renders a single streaming buffer for the
-    ///   open conversation; interleaving a second stream would cross-wire the
-    ///   request-id claim and drop one reply. Blocking keeps the composer text
-    ///   so nothing is lost — the user sends again once the reply lands).
-    ///
-    /// Only when both gates pass does it delegate to [`App::submit_prompt`].
-    pub fn prepare_submission(&mut self, connected: bool) -> Option<(String, String)> {
-        if !connected {
-            self.status_message =
-                "Not connected — message not sent (your text is preserved)".into();
-            return None;
-        }
-        if self.is_streaming() {
-            self.status_message =
-                "A reply is still streaming — wait for it to finish (your text is preserved)"
-                    .into();
-            return None;
-        }
-        self.submit_prompt()
+    /// Empty the composer (after an accepted send). The submission gate, the
+    /// optimistic user-bubble append, and the streaming block (TUI-2 / TUI-7) all
+    /// live in the shared core now, reached via `UiMessage::SubmitPrompt`; the
+    /// composer is the one piece of pure view state the client still owns.
+    pub fn clear_composer(&mut self) {
+        self.textarea = new_textarea();
     }
 
-    /// Roll back a submission whose send RPC failed (TUI-2): remove the
-    /// optimistically appended user message (only when the originating
-    /// conversation is still open and the tail message matches) and put the
-    /// prompt text back into the composer so the user can retry without
-    /// retyping. The caller sets the status message with the send error.
-    pub fn restore_failed_submission(&mut self, conversation_id: &str, prompt: &str) {
-        if let Some(conv) = self
-            .core
-            .current_conversation
-            .as_mut()
-            .filter(|c| c.id == conversation_id)
-            && conv
-                .messages
-                .last()
-                .is_some_and(|m| m.role == "user" && m.content == prompt)
-        {
-            conv.messages.pop();
-        }
+    /// Refill the composer with `text` (after a failed send, so the user can
+    /// retry without retyping). The matching transcript rollback runs in the core
+    /// via `UiMessage::SendFailed`.
+    pub fn set_composer(&mut self, text: &str) {
         self.textarea = new_textarea();
-        self.textarea.insert_str(prompt);
-    }
-
-    /// Returns (conversation_id, prompt) if valid, None otherwise.
-    pub fn submit_prompt(&mut self) -> Option<(String, String)> {
-        let content = self.textarea_content();
-        if content.is_empty() {
-            return None;
-        }
-        let conv = self.core.current_conversation.as_mut()?;
-        conv.messages.push(ChatMessage {
-            // Optimistic local echo of our own send; the daemon assigns the real
-            // message id (#1) when it persists the turn. Dedupe of the echoed-back
-            // `UserMessageAdded` is by request_id, not message id (see
-            // `user_message_added`), so an empty id here is correct.
-            id: String::new(),
-            role: "user".to_string(),
-            content: content.clone(),
-        });
-        self.textarea = new_textarea();
-        self.scroll_offset = 0;
-        Some((conv.id.clone(), content))
+        self.textarea.insert_str(text);
     }
 
     /// Apply a bracketed paste (TUI-3 / `Event::Paste`) to whichever input is
@@ -1377,10 +1320,13 @@ mod tests {
         // A render frame wraps for display only.
         let _ = app.wrapped_display_textarea(10);
 
-        let (conv_id, payload) = app.submit_prompt().expect("submission");
-        assert_eq!(conv_id, "c1");
-        assert_eq!(payload, typed);
-        assert!(!payload.contains('\n'));
+        // The prompt that reaches the send effect is the logical (unwrapped) text,
+        // not the display-wrapped copy.
+        let prompt = app.textarea_content();
+        let effects = app.apply_core(UiMessage::SubmitPrompt { prompt });
+        let sent = sent_prompt(&effects).expect("an accepted send emits SendPrompt");
+        assert_eq!(sent, typed);
+        assert!(!sent.contains('\n'));
     }
 
     /// Shrinking then regrowing the terminal must not leave wrap newlines
@@ -1415,8 +1361,12 @@ mod tests {
 
         let _ = app.wrapped_display_textarea(8);
 
-        let (_id, payload) = app.submit_prompt().expect("submission");
-        assert_eq!(payload, typed);
+        let prompt = app.textarea_content();
+        let effects = app.apply_core(UiMessage::SubmitPrompt { prompt });
+        assert_eq!(
+            sent_prompt(&effects).expect("an accepted send emits SendPrompt"),
+            typed
+        );
     }
 
     /// CJK (wide) glyphs are measured by display width, not char count, so a
@@ -1435,51 +1385,10 @@ mod tests {
         assert_eq!(app.textarea_content(), "一二三四五");
     }
 
-    #[test]
-    fn submit_prompt_without_conversation_returns_none() {
-        let mut app = App::new();
-        app.textarea.insert_str("hello");
-        assert!(app.submit_prompt().is_none());
-        assert_eq!(app.textarea_content(), "hello"); // input preserved
-    }
-
-    #[test]
-    fn submit_prompt_with_empty_input_returns_none() {
-        let mut app = App::new();
-        app.load_conversation(ConversationDetail {
-            id: "1".into(),
-            title: "Test".into(),
-            messages: vec![],
-            model_selection: None,
-            conversation_personality: None,
-        });
-        assert!(app.submit_prompt().is_none());
-    }
-
-    #[test]
-    fn submit_prompt_appends_user_message_and_clears_input() {
-        let mut app = App::new();
-        app.load_conversation(ConversationDetail {
-            id: "conv1".into(),
-            title: "Test".into(),
-            messages: vec![],
-            model_selection: None,
-            conversation_personality: None,
-        });
-        app.textarea.insert_str("What is Rust?");
-
-        let result = app.submit_prompt();
-        assert_eq!(
-            result,
-            Some(("conv1".to_string(), "What is Rust?".to_string()))
-        );
-        assert_eq!(app.textarea_content(), "");
-
-        let msgs = &app.current_conversation().unwrap().messages;
-        assert_eq!(msgs.len(), 1);
-        assert_eq!(msgs[0].role, "user");
-        assert_eq!(msgs[0].content, "What is Rust?");
-    }
+    // The submit gate, the optimistic user-bubble append, and the empty/
+    // no-conversation rejections moved to the shared core (`UiMessage::SubmitPrompt`,
+    // Phase-2) and are spec'd by client-ui-common's reducer tests. The App tests
+    // below cover only the TUI's own send-path wiring (composer text → effect).
 
     // --- Bracketed paste (TUI-3) ---
 
@@ -1515,10 +1424,11 @@ mod tests {
         });
         app.enter_editing_mode();
         app.apply_paste("first\nsecond\nthird");
-        let result = app.submit_prompt();
+        let prompt = app.textarea_content();
+        let effects = app.apply_core(UiMessage::SubmitPrompt { prompt });
         assert_eq!(
-            result,
-            Some(("c1".to_string(), "first\nsecond\nthird".to_string()))
+            sent_prompt(&effects).expect("an accepted send emits SendPrompt"),
+            "first\nsecond\nthird"
         );
         let msgs = &app.current_conversation().unwrap().messages;
         assert_eq!(msgs.len(), 1, "exactly one user message appended");
@@ -1543,155 +1453,24 @@ mod tests {
         assert_eq!(app.textarea_content(), "");
     }
 
-    // --- Send-path integrity (TUI-2 / TUI-7) ---
+    // --- Send-path wiring (TUI-2 / TUI-7) ---
+    //
+    // The send *decision* (gate, optimistic append, refinement, rollback) now
+    // lives in the shared core (`UiMessage::SubmitPrompt` / `SendFailed`) and is
+    // spec'd by client-ui-common's reducer tests. What stays here is the TUI's
+    // own wiring: the composer text becomes the prompt, and an accepted send
+    // surfaces as a `SendPrompt` effect for `send_prompt_from_input` to run. The
+    // connection gate + the transport RPC live in `main.rs` (not unit-testable
+    // without a daemon), so they're covered by the live smoke test.
 
-    fn app_ready_to_send(conv_id: &str, prompt: &str) -> App {
-        let mut app = App::new();
-        // `load_conversation` (not a raw field write) so the open-conversation id
-        // is dual-written into core — the streaming gate/render checks key off it.
-        app.load_conversation(ConversationDetail {
-            id: conv_id.into(),
-            title: "Test".into(),
-            messages: vec![],
-            model_selection: None,
-            conversation_personality: None,
-        });
-        app.enter_editing_mode();
-        app.textarea.insert_str(prompt);
-        app
-    }
-
-    #[test]
-    fn submit_while_disconnected_preserves_composer_and_appends_nothing() {
-        // Acceptance (TUI-2): disconnected submit → composer text preserved,
-        // status message set, nothing appended to the transcript.
-        let mut app = app_ready_to_send("c1", "important prompt");
-        app.status_message.clear();
-
-        let result = app.prepare_submission(false);
-
-        assert!(result.is_none(), "nothing must be sent while disconnected");
-        assert_eq!(
-            app.textarea_content(),
-            "important prompt",
-            "composer text must be preserved"
-        );
-        assert!(
-            app.current_conversation().unwrap().messages.is_empty(),
-            "transcript must not gain a user message"
-        );
-        assert!(
-            !app.status_message.is_empty(),
-            "the refusal must be surfaced in the status line"
-        );
-    }
-
-    #[test]
-    fn submit_while_streaming_is_blocked_and_composer_preserved() {
-        // Acceptance (TUI-7, chosen policy = block concurrent sends): a second
-        // send while a reply streams is refused with a status message and the
-        // composer keeps its text.
-        let mut app = app_ready_to_send("c1", "second question");
-        // Drive a genuine in-flight stream through the core: ack arms the slot,
-        // the first chunk claims the real request id.
-        app.apply_prompt_ack("task".into(), "c1".into());
-        app.apply_core(UiMessage::StreamChunk {
-            request_id: "req-in-flight".into(),
-            chunk: "partial".into(),
-        });
-        app.status_message.clear();
-
-        let result = app.prepare_submission(true);
-
-        assert!(result.is_none(), "second send must be blocked mid-stream");
-        assert_eq!(app.textarea_content(), "second question");
-        assert!(app.current_conversation().unwrap().messages.is_empty());
-        assert!(!app.status_message.is_empty());
-    }
-
-    #[test]
-    fn submit_while_awaiting_ack_sentinel_is_also_blocked() {
-        // Unhappy path: the window between send and the first chunk uses the
-        // pending sentinel; a send in that window must be blocked too.
-        let mut app = app_ready_to_send("c1", "rapid second send");
-        // Ack received but no chunk yet: the slot holds the pending sentinel.
-        app.apply_prompt_ack("task".into(), "c1".into());
-
-        assert!(app.prepare_submission(true).is_none());
-        assert_eq!(app.textarea_content(), "rapid second send");
-    }
-
-    #[test]
-    fn submit_when_connected_and_idle_goes_through() {
-        let mut app = app_ready_to_send("c1", "hello");
-        let result = app.prepare_submission(true);
-        assert_eq!(result, Some(("c1".to_string(), "hello".to_string())));
-        assert_eq!(app.textarea_content(), "");
-        assert_eq!(app.current_conversation().unwrap().messages.len(), 1);
-    }
-
-    #[test]
-    fn restore_failed_submission_pops_message_and_refills_composer() {
-        // Acceptance (TUI-2): a failed send RPC rolls back the optimistic
-        // transcript append and puts the prompt back in the composer.
-        let mut app = app_ready_to_send("c1", "doomed prompt");
-        let (conv_id, prompt) = app.prepare_submission(true).unwrap();
-
-        app.restore_failed_submission(&conv_id, &prompt);
-
-        assert!(
-            app.current_conversation().unwrap().messages.is_empty(),
-            "optimistic user message must be rolled back"
-        );
-        assert_eq!(app.textarea_content(), "doomed prompt");
-    }
-
-    #[test]
-    fn restore_failed_submission_after_switching_conversations_keeps_other_transcript() {
-        // Unhappy path: the user switched conversations between submit and the
-        // send failure. The other conversation's tail message must NOT be
-        // popped; the composer still gets the text back.
-        let mut app = app_ready_to_send("c1", "prompt for c1");
-        let (conv_id, prompt) = app.prepare_submission(true).unwrap();
-
-        // Switch to a different conversation that already has a user message.
-        app.load_conversation(ConversationDetail {
-            id: "c2".into(),
-            title: "Other".into(),
-            messages: vec![ChatMessage {
-                id: String::new(),
-                role: "user".into(),
-                content: "prompt for c1".into(), // same text, different conv
-            }],
-            model_selection: None,
-            conversation_personality: None,
-        });
-
-        app.restore_failed_submission(&conv_id, &prompt);
-
-        assert_eq!(
-            app.current_conversation().unwrap().messages.len(),
-            1,
-            "the other conversation's transcript must be untouched"
-        );
-        assert_eq!(app.textarea_content(), "prompt for c1");
-    }
-
-    #[test]
-    fn restore_failed_submission_does_not_pop_a_non_matching_tail() {
-        // Unhappy path: something else (e.g. an inline note) landed after the
-        // optimistic append; only an exact matching tail is rolled back.
-        let mut app = app_ready_to_send("c1", "prompt");
-        let (conv_id, prompt) = app.prepare_submission(true).unwrap();
-        // A non-matching message lands after the optimistic user append — exactly
-        // how an Adele-disabled `say_this` aside reaches the transcript.
-        app.push_speech_disabled_note("c1", "aside");
-
-        app.restore_failed_submission(&conv_id, &prompt);
-
-        let msgs = &app.current_conversation().unwrap().messages;
-        assert_eq!(msgs.len(), 2, "non-matching tail must not be popped");
-        assert_eq!(app.textarea_content(), "prompt");
+    /// The prompt carried by the `SendPrompt` effect when a submission was
+    /// accepted (the send path runs this effect as the RPC); `None` when the core
+    /// rejected the submit.
+    fn sent_prompt(effects: &[Effect]) -> Option<String> {
+        effects.iter().find_map(|e| match e {
+            Effect::SendPrompt { prompt, .. } => Some(prompt.clone()),
+            _ => None,
+        })
     }
 
     // --- Conversation-id threading (TUI-4) + disconnect reset (TUI-8) ---
@@ -2454,22 +2233,6 @@ mod tests {
         });
         assert_eq!(app.scroll_offset, 10);
         assert_eq!(app.streaming_buffer(), "data", "chunk still buffered");
-    }
-
-    #[test]
-    fn submit_prompt_resets_scroll() {
-        let mut app = App::new();
-        app.load_conversation(ConversationDetail {
-            id: "c1".into(),
-            title: "Test".into(),
-            messages: vec![],
-            model_selection: None,
-            conversation_personality: None,
-        });
-        app.scroll_up(10);
-        app.textarea.insert_str("hello");
-        app.submit_prompt();
-        assert_eq!(app.scroll_offset, 0);
     }
 
     // --- Tasks pane integration ---

--- a/src/app.rs
+++ b/src/app.rs
@@ -750,9 +750,21 @@ impl App {
                 self.status_message = text;
                 None
             }
+            // Repaint the sidebar list. `set_conversations` re-clamps the
+            // positional selection and keeps core's list in sync.
+            Effect::SetConversations(convs) => {
+                self.set_conversations(convs);
+                None
+            }
+            // The TUI does not auto-open a conversation (unlike gtk): the sidebar
+            // selection is already clamped by `SetConversations`, and the open
+            // conversation is whatever the user last opened. So "ensure active"
+            // is a no-op here — the auto-load/create that gtk's executor performs
+            // is deliberately omitted (CC-3: behavior-preserving).
+            Effect::EnsureActiveConversation => None,
             // Controller-level effects (narration, scratchpad, and — in later
-            // CC-3 slices — the conversation/model/task/RPC effects) need handles
-            // the view doesn't hold; bubble them up to `main`'s executor.
+            // CC-3 slices — the open-conversation RPC effects) need handles the
+            // view doesn't hold; bubble them up to `main`'s executor.
             other => Some(other),
         }
     }
@@ -834,8 +846,14 @@ impl App {
     // --- Conversation management ---
 
     pub fn set_conversations(&mut self, conversations: Vec<ConversationSummary>) {
+        // Mirror the list into the shared core so it stays authoritative for the
+        // sidebar (CC-3): the reducer's conversation arms read `core.conversations`
+        // (e.g. to decide reconnect reload vs. fresh load). Paths that don't route
+        // through `core.apply` (connect-time load, create/delete) funnel here, so
+        // this single dual-write keeps core in sync regardless of the caller.
+        self.core.conversations = conversations.clone();
         self.conversations = conversations;
-        // Fix selection if out of bounds
+        // Fix selection if out of bounds (positional selection is TUI view state).
         if let Some(sel) = self.selected_conversation
             && sel >= self.conversations.len()
         {
@@ -2035,10 +2053,11 @@ mod tests {
 
     #[test]
     fn list_refetch_replaces_sidebar_without_disturbing_open_conversation() {
-        // A `SignalEvent::ConversationListChanged` (#1) refetches the whole
-        // conversation list via `set_conversations`. That must repaint the
-        // sidebar but leave the OPEN conversation and its transcript intact —
-        // even when the change elsewhere renamed and removed rows.
+        // A `ConversationListChanged` / archive refetch (#1) routes through the
+        // reducer's `ConversationListRefetched`: apply_core repaints the sidebar
+        // (SetConversations) and re-syncs selection (EnsureActiveConversation, a
+        // TUI no-op) — emitting only view-effects — while the OPEN conversation
+        // and its transcript stay intact, even when rows were renamed/removed.
         let mut app = app_with_conversations();
         app.selected_conversation = Some(1);
         app.load_conversation(ConversationDetail {
@@ -2060,9 +2079,9 @@ mod tests {
             conversation_personality: None,
         });
 
-        // Simulate the refetched list: "1" was renamed and "3" was deleted
-        // elsewhere; "2" (the open one) survives.
-        app.set_conversations(vec![
+        // Refetched list: "1" was renamed and "3" was deleted elsewhere; "2"
+        // (the open one) survives.
+        let effects = app.apply_core(UiMessage::ConversationListRefetched(vec![
             ConversationSummary {
                 id: "1".into(),
                 title: "First (renamed elsewhere)".into(),
@@ -2075,9 +2094,13 @@ mod tests {
                 message_count: 2,
                 archived: false,
             },
-        ]);
+        ]));
+        assert!(
+            effects.is_empty(),
+            "a list refetch must emit only view-effects: {effects:?}"
+        );
 
-        // Sidebar reflects the new list...
+        // Sidebar reflects the new list (and core stays authoritative for it)...
         assert_eq!(app.conversations.len(), 2);
         assert_eq!(app.conversations[0].title, "First (renamed elsewhere)");
         // ...but the open conversation + its transcript are byte-for-byte intact.

--- a/src/app.rs
+++ b/src/app.rs
@@ -135,6 +135,8 @@ pub struct App {
     pub mode: InputMode,
     pub status_message: String,
     pub should_quit: bool,
+    /// Whether the `?`/F1 keymap help overlay is shown. Any key closes it.
+    pub show_help: bool,
     /// Lines scrolled up from the bottom. 0 = auto-scroll to bottom.
     pub scroll_offset: u16,
     /// Whether to include archived conversations in the list.
@@ -230,6 +232,7 @@ impl App {
             mode: InputMode::Normal,
             status_message: "Connected".to_string(),
             should_quit: false,
+            show_help: false,
             scroll_offset: 0,
             show_archived: false,
             rename_textarea: new_textarea(),
@@ -251,6 +254,12 @@ impl App {
             voice_in: HashMap::new(),
             adele_output: HashMap::new(),
         }
+    }
+
+    /// Toggle the keymap help overlay (`?`/F1). Any key closes it (handled in the
+    /// event loop), so the action only ever opens it.
+    pub fn toggle_help(&mut self) {
+        self.show_help = !self.show_help;
     }
 
     // --- Per-conversation You/Adele voice controls (adele-tui#77) ---

--- a/src/app.rs
+++ b/src/app.rs
@@ -108,6 +108,19 @@ pub enum InputMode {
     Renaming,
 }
 
+/// A modal sub-screen the user has asked the run loop to open. Each maps to one
+/// `*::run` driver invocation in the loop's single dispatch point. Replaces the
+/// old independent `*_requested` bools so the request is mutually exclusive by
+/// construction (CC-3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ScreenRequest {
+    KnowledgeBase,
+    Connections,
+    Purposes,
+    ModelPicker,
+    PersonalityPicker,
+}
+
 /// The `Adele:` voice-output level for a conversation. Decides reply narration
 /// (with `You`), the `say_this` aside gate, and the send-time
 /// `system_refinement`. Defaults to `Disabled`.
@@ -175,19 +188,12 @@ pub struct App {
     /// drains it on the next iteration (once the modal has closed and the
     /// sidebar is visible again) by pushing a conversation-list refetch.
     pub pending_conversation_refresh: bool,
-    /// Set when the user asks to open the knowledge base. The chat loop
-    /// hands the screen to `kb::run` and resets this flag when KB exits.
-    pub kb_requested: bool,
-    /// Set when the user asks to open the LLM-provider connections manager.
-    /// Mirrors `kb_requested`'s screen-handoff pattern.
-    pub connections_requested: bool,
-    /// Set when the user asks to open the purposes manager.
-    pub purposes_requested: bool,
-    /// Set when the user asks to open the per-conversation model picker.
-    pub model_picker_requested: bool,
-    /// Set when the user asks to open the per-conversation personality picker.
-    /// Mirrors `model_picker_requested`'s screen-handoff pattern.
-    pub personality_picker_requested: bool,
+    /// The modal sub-screen the user has asked to open, serviced (and cleared)
+    /// by the run loop on its next iteration. Replaces the old set of independent
+    /// `*_requested` bools (CC-3): only ONE screen can be pending at a time, so a
+    /// fresh request can't silently race a not-yet-serviced one, and the run loop
+    /// dispatches them from a single point instead of five near-identical guards.
+    pub pending_screen: Option<ScreenRequest>,
     /// One-shot override staged by the model picker. Applied to the next
     /// `SendPrompt` and then cleared — the daemon persists it as the
     /// conversation's `last_model_selection`, so subsequent prompts pick
@@ -239,11 +245,7 @@ impl App {
             show_sidebar: true,
             switch_requested: false,
             pending_conversation_refresh: false,
-            kb_requested: false,
-            connections_requested: false,
-            purposes_requested: false,
-            model_picker_requested: false,
-            personality_picker_requested: false,
+            pending_screen: None,
             pending_model_override: None,
             tasks: TaskPane::new(),
             pending_task_cancel: None,
@@ -255,6 +257,19 @@ impl App {
     /// event loop), so the action only ever opens it.
     pub fn toggle_help(&mut self) {
         self.show_help = !self.show_help;
+    }
+
+    /// Ask the run loop to open `screen` as a modal on its next iteration.
+    /// Mutually exclusive: a newer request supersedes any not-yet-serviced one
+    /// (the loop services at most one modal per turn, then redraws).
+    pub fn request_screen(&mut self, screen: ScreenRequest) {
+        self.pending_screen = Some(screen);
+    }
+
+    /// Take (and clear) the pending modal-screen request, if any. The run loop
+    /// calls this once per iteration to drive its single modal-dispatch point.
+    pub fn take_pending_screen(&mut self) -> Option<ScreenRequest> {
+        self.pending_screen.take()
     }
 
     // --- Per-conversation You/Adele voice controls (adele-tui#77) ---
@@ -2316,6 +2331,35 @@ mod tests {
     #[test]
     fn switch_requested_default_false() {
         assert!(!App::new().switch_requested);
+    }
+
+    #[test]
+    fn pending_screen_request_round_trips_and_is_taken_once() {
+        let mut app = App::new();
+        assert_eq!(app.take_pending_screen(), None, "none pending by default");
+
+        app.request_screen(ScreenRequest::KnowledgeBase);
+        assert_eq!(
+            app.take_pending_screen(),
+            Some(ScreenRequest::KnowledgeBase)
+        );
+        assert_eq!(
+            app.take_pending_screen(),
+            None,
+            "taking clears it so the loop services it exactly once"
+        );
+    }
+
+    #[test]
+    fn requesting_a_screen_supersedes_an_unserviced_one() {
+        // The invariant the `ScreenRequest` enum buys over the old set of
+        // independent `*_requested` bools: only ONE screen can be pending, so a
+        // second request can't leave two queued to open in arbitrary order.
+        let mut app = App::new();
+        app.request_screen(ScreenRequest::Connections);
+        app.request_screen(ScreenRequest::Purposes);
+        assert_eq!(app.take_pending_screen(), Some(ScreenRequest::Purposes));
+        assert_eq!(app.take_pending_screen(), None);
     }
 
     #[test]

--- a/src/connections.rs
+++ b/src/connections.rs
@@ -26,7 +26,7 @@
 //! - `y` / `Enter`: confirm
 //! - `f`: force-delete (purposes referencing this connection fall back to
 //!   the `interactive` purpose, per the daemon's contract)
-//! - any other key: cancel
+//! - `n`/`Esc`: cancel (any other key is ignored)
 
 use std::io;
 
@@ -460,7 +460,12 @@ fn handle_delete_key<'a>(
         (KeyCode::Char('f') | KeyCode::Char('F'), _) => {
             do_delete(state, pending, client, true);
         }
-        _ => state.mode = Mode::List,
+        // A destructive confirm is dismissed only by an explicit cancel
+        // (n/Esc); any other key is ignored rather than silently closing it.
+        (KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc, _) => {
+            state.mode = Mode::List;
+        }
+        _ => {}
     }
 }
 
@@ -912,7 +917,7 @@ fn draw_delete_overlay(f: &mut Frame, state: &State, area: Rect) {
             Style::default().fg(Color::White),
         )),
         Line::from(Span::styled(
-            "y/Enter = confirm · f = force (referencing purposes fall back) · any = cancel",
+            "y/Enter = confirm · f = force (referencing purposes fall back) · n/Esc = cancel",
             Style::default().fg(theme().text_dim),
         )),
     ])
@@ -948,7 +953,7 @@ fn draw_hints(f: &mut Frame, state: &State, area: Rect) {
             ("Esc", "back to chat"),
         ],
         Mode::Edit => &[("Tab", "next field"), ("Ctrl+S", "save"), ("Esc", "cancel")],
-        Mode::DeleteConfirm => &[("y/Enter", "confirm"), ("f", "force"), ("any", "cancel")],
+        Mode::DeleteConfirm => &[("y/Enter", "confirm"), ("f", "force"), ("n/Esc", "cancel")],
     };
     let mut spans: Vec<Span> = Vec::new();
     for (idx, (key, desc)) in hints.iter().enumerate() {

--- a/src/connections.rs
+++ b/src/connections.rs
@@ -253,6 +253,20 @@ fn single_line_textarea() -> TextArea<'static> {
     ta
 }
 
+use crate::in_flight::InFlight;
+
+/// Resolved outcome of an off-loop connections RPC (modal-freeze fix). Each
+/// variant carries the daemon result (stringified error); `apply_outcome` may
+/// chain a follow-up `refresh_list` after a successful save/delete.
+enum RpcOutcome {
+    Listed(Result<CommandResult, String>),
+    Saved(Result<CommandResult, String>),
+    Deleted {
+        force: bool,
+        result: Result<CommandResult, String>,
+    },
+}
+
 struct State {
     connections: Vec<ConnectionView>,
     selected: usize,
@@ -270,6 +284,9 @@ struct State {
 struct ConnectionsScreen<'a> {
     state: State,
     client: &'a TransportClient,
+    /// In-flight list/save/delete RPCs, polled off the draw loop by
+    /// `poll_pending` so the screen never freezes during a round-trip.
+    pending: InFlight<'a, RpcOutcome>,
 }
 
 impl Screen for ConnectionsScreen<'_> {
@@ -279,16 +296,32 @@ impl Screen for ConnectionsScreen<'_> {
         draw(frame, &self.state);
     }
 
-    async fn handle_key(&mut self, key: KeyEvent) {
+    fn handle_key(&mut self, key: KeyEvent) -> impl std::future::Future<Output = ()> {
+        // Synchronous: RPC-bearing keys enqueue into `pending` rather than
+        // awaiting here, so the handler never blocks the draw/input loop.
         match self.state.mode {
-            Mode::List => handle_list_key(&mut self.state, key, self.client).await,
-            Mode::Edit => handle_edit_key(&mut self.state, key, self.client).await,
-            Mode::DeleteConfirm => handle_delete_key(&mut self.state, key, self.client).await,
+            Mode::List => handle_list_key(&mut self.state, key, self.client, &mut self.pending),
+            Mode::Edit => handle_edit_key(&mut self.state, key, self.client, &mut self.pending),
+            Mode::DeleteConfirm => {
+                handle_delete_key(&mut self.state, key, self.client, &mut self.pending)
+            }
         }
+        std::future::ready(())
     }
 
     fn take_outcome(&mut self) -> Option<()> {
         self.state.closing.then_some(())
+    }
+
+    fn has_pending(&self) -> bool {
+        !self.pending.is_empty()
+    }
+
+    async fn poll_pending(&mut self) {
+        let resolved = self.pending.next().await;
+        if let Some(outcome) = resolved {
+            apply_outcome(&mut self.state, &mut self.pending, self.client, outcome);
+        }
     }
 }
 
@@ -309,14 +342,22 @@ pub async fn run(
             closing: false,
         },
         client,
+        pending: InFlight::new(),
     };
 
-    refresh_list(&mut screen.state, client).await;
+    // Kick the initial load off-loop so "Loading connections…" shows and the
+    // screen is responsive while it lands.
+    refresh_list(&mut screen.state, &mut screen.pending, client);
 
     crate::screen::run_screen(terminal, &mut screen, signal_rx, sink).await
 }
 
-async fn handle_list_key(state: &mut State, key: KeyEvent, client: &TransportClient) {
+fn handle_list_key<'a>(
+    state: &mut State,
+    key: KeyEvent,
+    client: &'a TransportClient,
+    pending: &mut InFlight<'a, RpcOutcome>,
+) {
     match (key.code, key.modifiers) {
         (KeyCode::Esc | KeyCode::Char('q'), m) if m.is_empty() => state.closing = true,
         (KeyCode::Char('j') | KeyCode::Down, m) if m.is_empty() => advance_selection(state, 1),
@@ -338,16 +379,21 @@ async fn handle_list_key(state: &mut State, key: KeyEvent, client: &TransportCli
         {
             state.mode = Mode::DeleteConfirm;
         }
-        (KeyCode::Char('r'), m) if m.is_empty() => refresh_list(state, client).await,
+        (KeyCode::Char('r'), m) if m.is_empty() => refresh_list(state, pending, client),
         _ => {}
     }
 }
 
-async fn handle_edit_key(state: &mut State, key: KeyEvent, client: &TransportClient) {
+fn handle_edit_key<'a>(
+    state: &mut State,
+    key: KeyEvent,
+    client: &'a TransportClient,
+    pending: &mut InFlight<'a, RpcOutcome>,
+) {
     let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
 
     if ctrl && key.code == KeyCode::Char('s') {
-        save_edit(state, client).await;
+        save_edit(state, pending, client);
         return;
     }
 
@@ -411,19 +457,29 @@ async fn handle_edit_key(state: &mut State, key: KeyEvent, client: &TransportCli
     }
 }
 
-async fn handle_delete_key(state: &mut State, key: KeyEvent, client: &TransportClient) {
+fn handle_delete_key<'a>(
+    state: &mut State,
+    key: KeyEvent,
+    client: &'a TransportClient,
+    pending: &mut InFlight<'a, RpcOutcome>,
+) {
     match (key.code, key.modifiers) {
         (KeyCode::Char('y') | KeyCode::Char('Y') | KeyCode::Enter, _) => {
-            do_delete(state, client, false).await;
+            do_delete(state, pending, client, false);
         }
         (KeyCode::Char('f') | KeyCode::Char('F'), _) => {
-            do_delete(state, client, true).await;
+            do_delete(state, pending, client, true);
         }
         _ => state.mode = Mode::List,
     }
 }
 
-async fn do_delete(state: &mut State, client: &TransportClient, force: bool) {
+fn do_delete<'a>(
+    state: &mut State,
+    pending: &mut InFlight<'a, RpcOutcome>,
+    client: &'a TransportClient,
+    force: bool,
+) {
     let Some(view) = state.connections.get(state.selected).cloned() else {
         state.mode = Mode::List;
         return;
@@ -433,34 +489,15 @@ async fn do_delete(state: &mut State, client: &TransportClient, force: bool) {
     } else {
         "Deleting...".into()
     });
-    match send(
-        client,
-        Command::DeleteConnection {
-            id: view.id.clone(),
+    let id = view.id.clone();
+    pending.push(async move {
+        RpcOutcome::Deleted {
             force,
-        },
-    )
-    .await
-    {
-        Ok(_) => {
-            state.busy = None;
-            state.mode = Mode::List;
-            refresh_list(state, client).await;
+            result: send(client, Command::DeleteConnection { id, force })
+                .await
+                .map_err(|e| e.to_string()),
         }
-        Err(e) => {
-            state.busy = None;
-            // The daemon refuses non-force deletes when purposes still
-            // reference the connection. Surface that and stay in the
-            // confirm overlay so the user can press `f` to force.
-            let msg = e.to_string();
-            if !force && msg.to_lowercase().contains("purpose") {
-                state.error = Some(format!("{msg} — press 'f' to force"));
-            } else {
-                state.error = Some(format!("Delete failed: {msg}"));
-                state.mode = Mode::List;
-            }
-        }
-    }
+    });
 }
 
 fn advance_selection(state: &mut State, delta: i32) {
@@ -478,27 +515,26 @@ fn advance_selection(state: &mut State, delta: i32) {
     state.selected = idx as usize;
 }
 
-async fn refresh_list(state: &mut State, client: &TransportClient) {
+fn refresh_list<'a>(
+    state: &mut State,
+    pending: &mut InFlight<'a, RpcOutcome>,
+    client: &'a TransportClient,
+) {
     state.busy = Some("Loading connections...".into());
-    let result = send(client, Command::ListConnections).await;
-    state.busy = None;
-    match result {
-        Ok(CommandResult::Connections(conns)) => {
-            state.connections = conns;
-            if state.selected >= state.connections.len() {
-                state.selected = state.connections.len().saturating_sub(1);
-            }
-        }
-        Ok(other) => {
-            state.error = Some(format!("Unexpected response: {other:?}"));
-        }
-        Err(e) => {
-            state.error = Some(format!("Failed to load connections: {e}"));
-        }
-    }
+    pending.push(async move {
+        RpcOutcome::Listed(
+            send(client, Command::ListConnections)
+                .await
+                .map_err(|e| e.to_string()),
+        )
+    });
 }
 
-async fn save_edit(state: &mut State, client: &TransportClient) {
+fn save_edit<'a>(
+    state: &mut State,
+    pending: &mut InFlight<'a, RpcOutcome>,
+    client: &'a TransportClient,
+) {
     let (id, config) = match state.form.submit() {
         Ok(parts) => parts,
         Err(e) => {
@@ -517,18 +553,56 @@ async fn save_edit(state: &mut State, client: &TransportClient) {
         Command::CreateConnection { id, config }
     };
 
-    match send(client, cmd).await {
-        Ok(_) => {
-            state.busy = None;
-            state.error = None;
-            state.form = EditForm::empty();
-            state.mode = Mode::List;
-            refresh_list(state, client).await;
-        }
-        Err(e) => {
-            state.busy = None;
-            state.error = Some(format!("Save failed: {e}"));
-        }
+    pending
+        .push(async move { RpcOutcome::Saved(send(client, cmd).await.map_err(|e| e.to_string())) });
+}
+
+/// Apply a resolved connections RPC; chains a `refresh_list` after a successful
+/// save or delete (mirroring the old inline `refresh_list().await`).
+fn apply_outcome<'a>(
+    state: &mut State,
+    pending: &mut InFlight<'a, RpcOutcome>,
+    client: &'a TransportClient,
+    outcome: RpcOutcome,
+) {
+    state.busy = None;
+    match outcome {
+        RpcOutcome::Listed(result) => match result {
+            Ok(CommandResult::Connections(conns)) => {
+                state.connections = conns;
+                if state.selected >= state.connections.len() {
+                    state.selected = state.connections.len().saturating_sub(1);
+                }
+            }
+            Ok(other) => state.error = Some(format!("Unexpected response: {other:?}")),
+            Err(e) => state.error = Some(format!("Failed to load connections: {e}")),
+        },
+        RpcOutcome::Saved(result) => match result {
+            Ok(_) => {
+                state.error = None;
+                state.form = EditForm::empty();
+                state.mode = Mode::List;
+                refresh_list(state, pending, client);
+            }
+            Err(e) => state.error = Some(format!("Save failed: {e}")),
+        },
+        RpcOutcome::Deleted { force, result } => match result {
+            Ok(_) => {
+                state.mode = Mode::List;
+                refresh_list(state, pending, client);
+            }
+            Err(msg) => {
+                // The daemon refuses non-force deletes when purposes still
+                // reference the connection. Surface that and stay in the confirm
+                // overlay so the user can press `f` to force.
+                if !force && msg.to_lowercase().contains("purpose") {
+                    state.error = Some(format!("{msg} — press 'f' to force"));
+                } else {
+                    state.error = Some(format!("Delete failed: {msg}"));
+                    state.mode = Mode::List;
+                }
+            }
+        },
     }
 }
 

--- a/src/connections.rs
+++ b/src/connections.rs
@@ -47,17 +47,7 @@ use ratatui_textarea::{CursorMove, TextArea};
 
 use crate::screen::Screen;
 
-const COLOR_BORDER: Color = Color::Rgb(82, 104, 173);
-const COLOR_BORDER_ACTIVE: Color = Color::Rgb(120, 183, 109);
-const COLOR_TITLE: Color = Color::Rgb(166, 182, 255);
-const COLOR_HINT_KEY: Color = Color::Rgb(216, 223, 236);
-const COLOR_HINT_DESC: Color = Color::Rgb(143, 153, 174);
-const COLOR_HINT_SEP: Color = Color::Rgb(82, 90, 110);
-const COLOR_LIST_HIGHLIGHT: Color = Color::Rgb(72, 102, 180);
-const COLOR_LIST_HIGHLIGHT_FG: Color = Color::Rgb(245, 248, 255);
-const COLOR_ERROR: Color = Color::Rgb(232, 130, 130);
-const COLOR_OK: Color = Color::Rgb(132, 218, 193);
-const COLOR_DELETE_BORDER: Color = Color::Rgb(232, 130, 130);
+use crate::theme::theme;
 
 /// Connector kinds the TUI can build forms for. Mirrors
 /// `ConnectionConfigView` variants.
@@ -655,12 +645,12 @@ fn draw_header(f: &mut Frame, area: Rect) {
         Span::styled(
             "LLM provider connections",
             Style::default()
-                .fg(COLOR_TITLE)
+                .fg(theme().title)
                 .add_modifier(Modifier::BOLD),
         ),
         Span::styled(
             "  —  Esc to return to chat",
-            Style::default().fg(COLOR_HINT_DESC),
+            Style::default().fg(theme().text_dim),
         ),
     ]);
     f.render_widget(Paragraph::new(line), area);
@@ -670,7 +660,7 @@ fn draw_list(f: &mut Frame, state: &State, area: Rect) {
     let items: Vec<ListItem> = if state.connections.is_empty() {
         vec![ListItem::new(Line::from(Span::styled(
             "(no connections — press 'a' to add one)",
-            Style::default().fg(COLOR_HINT_DESC),
+            Style::default().fg(theme().text_dim),
         )))]
     } else {
         state
@@ -678,9 +668,11 @@ fn draw_list(f: &mut Frame, state: &State, area: Rect) {
             .iter()
             .map(|c| {
                 let availability_text = match &c.availability {
-                    ConnectionAvailability::Ok => Span::styled("●", Style::default().fg(COLOR_OK)),
+                    ConnectionAvailability::Ok => {
+                        Span::styled("●", Style::default().fg(theme().ok))
+                    }
                     ConnectionAvailability::Unavailable { .. } => {
-                        Span::styled("●", Style::default().fg(COLOR_ERROR))
+                        Span::styled("●", Style::default().fg(theme().error))
                     }
                 };
                 let unavail_reason = match &c.availability {
@@ -693,20 +685,20 @@ fn draw_list(f: &mut Frame, state: &State, area: Rect) {
                     Span::styled(c.id.clone(), Style::default().add_modifier(Modifier::BOLD)),
                     Span::styled(
                         format!(" [{}]", c.connector_type),
-                        Style::default().fg(COLOR_HINT_DESC),
+                        Style::default().fg(theme().text_dim),
                     ),
                 ];
                 if c.display_label != format!("{} ({})", c.id, c.connector_type) {
                     spans.push(Span::styled(
                         format!("  ·  {}", c.display_label),
-                        Style::default().fg(COLOR_HINT_DESC),
+                        Style::default().fg(theme().text_dim),
                     ));
                 }
                 if let Some(reason) = unavail_reason {
                     spans.push(Span::styled(
                         format!("  ·  {reason}"),
                         Style::default()
-                            .fg(COLOR_ERROR)
+                            .fg(theme().error)
                             .add_modifier(Modifier::ITALIC),
                     ));
                 }
@@ -725,18 +717,18 @@ fn draw_list(f: &mut Frame, state: &State, area: Rect) {
         .block(
             Block::default()
                 .borders(Borders::ALL)
-                .border_style(Style::default().fg(COLOR_BORDER))
+                .border_style(Style::default().fg(theme().border))
                 .title(Line::from(Span::styled(
                     title,
                     Style::default()
-                        .fg(COLOR_TITLE)
+                        .fg(theme().title)
                         .add_modifier(Modifier::BOLD),
                 ))),
         )
         .highlight_style(
             Style::default()
-                .bg(COLOR_LIST_HIGHLIGHT)
-                .fg(COLOR_LIST_HIGHLIGHT_FG)
+                .bg(theme().list_highlight)
+                .fg(theme().list_highlight_fg)
                 .add_modifier(Modifier::BOLD),
         )
         .highlight_symbol("▸ ");
@@ -751,7 +743,7 @@ fn draw_list(f: &mut Frame, state: &State, area: Rect) {
 fn draw_edit_form(f: &mut Frame, state: &State, area: Rect) {
     let block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(COLOR_BORDER))
+        .border_style(Style::default().fg(theme().border))
         .title(Line::from(Span::styled(
             if state.form.editing_id.is_some() {
                 "Edit connection"
@@ -759,7 +751,7 @@ fn draw_edit_form(f: &mut Frame, state: &State, area: Rect) {
                 "New connection"
             },
             Style::default()
-                .fg(COLOR_TITLE)
+                .fg(theme().title)
                 .add_modifier(Modifier::BOLD),
         )));
     let inner = block.inner(area);
@@ -829,9 +821,9 @@ fn draw_edit_form(f: &mut Frame, state: &State, area: Rect) {
 
 fn draw_type_toggle(f: &mut Frame, area: Rect, state: &State, focused: bool) {
     let border_color = if focused {
-        COLOR_BORDER_ACTIVE
+        theme().border_active
     } else {
-        COLOR_BORDER
+        theme().border
     };
     let block = Block::default()
         .borders(Borders::ALL)
@@ -844,10 +836,10 @@ fn draw_type_toggle(f: &mut Frame, area: Rect, state: &State, focused: bool) {
         let style = if active {
             Style::default()
                 .fg(Color::Black)
-                .bg(COLOR_BORDER_ACTIVE)
+                .bg(theme().border_active)
                 .add_modifier(Modifier::BOLD)
         } else {
-            Style::default().fg(COLOR_HINT_DESC)
+            Style::default().fg(theme().text_dim)
         };
         Span::styled(format!(" {} ", kind.label()), style)
     };
@@ -865,10 +857,10 @@ fn draw_type_toggle(f: &mut Frame, area: Rect, state: &State, focused: bool) {
 fn draw_field_label(f: &mut Frame, area: Rect, label: &str, focused: bool) {
     let style = if focused {
         Style::default()
-            .fg(COLOR_BORDER_ACTIVE)
+            .fg(theme().border_active)
             .add_modifier(Modifier::BOLD)
     } else {
-        Style::default().fg(COLOR_HINT_DESC)
+        Style::default().fg(theme().text_dim)
     };
     f.render_widget(Paragraph::new(Span::styled(label.to_string(), style)), area);
 }
@@ -876,9 +868,9 @@ fn draw_field_label(f: &mut Frame, area: Rect, label: &str, focused: bool) {
 fn draw_text_field(f: &mut Frame, area: Rect, textarea: &TextArea<'static>, focused: bool) {
     let mut ta = textarea.clone();
     let border_color = if focused {
-        COLOR_BORDER_ACTIVE
+        theme().border_active
     } else {
-        COLOR_BORDER
+        theme().border
     };
     ta.set_block(
         Block::default()
@@ -905,11 +897,11 @@ fn draw_delete_overlay(f: &mut Frame, state: &State, area: Rect) {
     f.render_widget(Clear, popup);
     let block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(COLOR_DELETE_BORDER))
+        .border_style(Style::default().fg(theme().error))
         .title(Line::from(Span::styled(
             "Delete connection",
             Style::default()
-                .fg(Color::Rgb(255, 200, 200))
+                .fg(theme().error_text)
                 .add_modifier(Modifier::BOLD),
         )));
     let inner = block.inner(popup);
@@ -921,7 +913,7 @@ fn draw_delete_overlay(f: &mut Frame, state: &State, area: Rect) {
         )),
         Line::from(Span::styled(
             "y/Enter = confirm · f = force (referencing purposes fall back) · any = cancel",
-            Style::default().fg(COLOR_HINT_DESC),
+            Style::default().fg(theme().text_dim),
         )),
     ])
     .wrap(Wrap { trim: true });
@@ -931,14 +923,14 @@ fn draw_delete_overlay(f: &mut Frame, state: &State, area: Rect) {
 fn draw_status(f: &mut Frame, state: &State, area: Rect) {
     if let Some(busy) = &state.busy {
         let style = Style::default()
-            .fg(Color::Rgb(178, 220, 245))
+            .fg(theme().assistant_indicator)
             .add_modifier(Modifier::ITALIC);
         f.render_widget(
             Paragraph::new(Span::styled(format!(" ● {busy}"), style)),
             area,
         );
     } else if let Some(err) = &state.error {
-        let style = Style::default().fg(COLOR_ERROR);
+        let style = Style::default().fg(theme().error);
         f.render_widget(
             Paragraph::new(Span::styled(format!(" • {err}"), style)),
             area,
@@ -961,18 +953,18 @@ fn draw_hints(f: &mut Frame, state: &State, area: Rect) {
     let mut spans: Vec<Span> = Vec::new();
     for (idx, (key, desc)) in hints.iter().enumerate() {
         if idx > 0 {
-            spans.push(Span::styled("  ·  ", Style::default().fg(COLOR_HINT_SEP)));
+            spans.push(Span::styled("  ·  ", Style::default().fg(theme().hint_sep)));
         }
         spans.push(Span::styled(
             (*key).to_string(),
             Style::default()
-                .fg(COLOR_HINT_KEY)
+                .fg(theme().hint_key)
                 .add_modifier(Modifier::BOLD),
         ));
         spans.push(Span::raw(" "));
         spans.push(Span::styled(
             (*desc).to_string(),
-            Style::default().fg(COLOR_HINT_DESC),
+            Style::default().fg(theme().text_dim),
         ));
     }
     f.render_widget(Paragraph::new(Line::from(spans)), area);

--- a/src/kb.rs
+++ b/src/kb.rs
@@ -27,7 +27,7 @@
 //!
 //! Delete-confirm overlay:
 //! - `y/Enter`: confirm
-//! - any other key: cancel
+//! - `n`/`Esc`: cancel (any other key is ignored)
 
 use std::{io, time::Duration};
 
@@ -444,7 +444,12 @@ fn handle_delete_key<'a>(
             }
             state.mode = state.return_mode;
         }
-        _ => state.mode = Mode::List,
+        // A destructive confirm is dismissed only by an explicit cancel
+        // (n/Esc); any other key is ignored rather than silently closing it.
+        (KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc, _) => {
+            state.mode = Mode::List;
+        }
+        _ => {}
     }
 }
 
@@ -860,7 +865,7 @@ fn draw_hints(f: &mut Frame, state: &State, area: Rect) {
         ],
         Mode::Search => &[("Enter", "search"), ("Esc", "clear & back")],
         Mode::Edit => &[("Tab", "next field"), ("Ctrl+S", "save"), ("Esc", "cancel")],
-        Mode::DeleteConfirm => &[("y/Enter", "confirm"), ("any", "cancel")],
+        Mode::DeleteConfirm => &[("y/Enter", "confirm"), ("n/Esc", "cancel")],
     };
 
     let mut spans: Vec<Span> = Vec::with_capacity(hints.len() * 4);
@@ -924,7 +929,7 @@ fn draw_delete_overlay(f: &mut Frame, state: &State, area: Rect) {
             Style::default().fg(Color::White),
         )),
         Line::from(Span::styled(
-            "y/Enter = confirm · any other key = cancel",
+            "y/Enter = confirm · n/Esc = cancel",
             Style::default().fg(theme().text_dim),
         )),
     ])

--- a/src/kb.rs
+++ b/src/kb.rs
@@ -51,17 +51,7 @@ const LIST_LIMIT: u32 = 100;
 const SEARCH_LIMIT: u32 = 50;
 const SEARCH_DEBOUNCE: Duration = Duration::from_millis(250);
 
-const COLOR_BORDER: Color = Color::Rgb(82, 104, 173);
-const COLOR_BORDER_ACTIVE: Color = Color::Rgb(120, 183, 109);
-const COLOR_TITLE: Color = Color::Rgb(166, 182, 255);
-const COLOR_HINT_KEY: Color = Color::Rgb(216, 223, 236);
-const COLOR_HINT_DESC: Color = Color::Rgb(143, 153, 174);
-const COLOR_HINT_SEP: Color = Color::Rgb(82, 90, 110);
-const COLOR_LIST_HIGHLIGHT: Color = Color::Rgb(72, 102, 180);
-const COLOR_LIST_HIGHLIGHT_FG: Color = Color::Rgb(245, 248, 255);
-const COLOR_ERROR: Color = Color::Rgb(232, 130, 130);
-const COLOR_DELETE_BORDER: Color = Color::Rgb(232, 130, 130);
-const COLOR_TIMESTAMP: Color = Color::Rgb(140, 156, 196);
+use crate::theme::theme;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Mode {
@@ -618,12 +608,12 @@ fn draw_header(f: &mut Frame, area: Rect) {
         Span::styled(
             "Knowledge base",
             Style::default()
-                .fg(COLOR_TITLE)
+                .fg(theme().title)
                 .add_modifier(Modifier::BOLD),
         ),
         Span::styled(
             "  —  Esc to return to chat",
-            Style::default().fg(COLOR_HINT_DESC),
+            Style::default().fg(theme().text_dim),
         ),
     ]);
     f.render_widget(Paragraph::new(line), area);
@@ -633,9 +623,9 @@ fn draw_search_bar(f: &mut Frame, state: &State, area: Rect) {
     let focused = matches!(state.mode, Mode::Search);
     let mut ta = state.search.clone();
     let border_color = if focused {
-        COLOR_BORDER_ACTIVE
+        theme().border_active
     } else {
-        COLOR_BORDER
+        theme().border
     };
     ta.set_block(
         Block::default()
@@ -647,7 +637,7 @@ fn draw_search_bar(f: &mut Frame, state: &State, area: Rect) {
                 } else {
                     "Search (press / to focus)"
                 },
-                Style::default().fg(COLOR_TITLE),
+                Style::default().fg(theme().title),
             ))),
     );
     f.render_widget(&ta, area);
@@ -657,7 +647,7 @@ fn draw_list(f: &mut Frame, state: &State, area: Rect) {
     let items: Vec<ListItem> = if state.entries.is_empty() {
         vec![ListItem::new(Line::from(Span::styled(
             "(no entries — press 'n' to create one)",
-            Style::default().fg(COLOR_HINT_DESC),
+            Style::default().fg(theme().text_dim),
         )))]
     } else {
         state
@@ -677,7 +667,7 @@ fn draw_list(f: &mut Frame, state: &State, area: Rect) {
                 if !entry.tags.is_empty() {
                     spans.push(Span::styled(
                         format!("  [{}]", entry.tags.join(", ")),
-                        Style::default().fg(COLOR_HINT_DESC),
+                        Style::default().fg(theme().text_dim),
                     ));
                 }
                 ListItem::new(Line::from(spans))
@@ -695,18 +685,18 @@ fn draw_list(f: &mut Frame, state: &State, area: Rect) {
         .block(
             Block::default()
                 .borders(Borders::ALL)
-                .border_style(Style::default().fg(COLOR_BORDER))
+                .border_style(Style::default().fg(theme().border))
                 .title(Line::from(Span::styled(
                     title,
                     Style::default()
-                        .fg(COLOR_TITLE)
+                        .fg(theme().title)
                         .add_modifier(Modifier::BOLD),
                 ))),
         )
         .highlight_style(
             Style::default()
-                .bg(COLOR_LIST_HIGHLIGHT)
-                .fg(COLOR_LIST_HIGHLIGHT_FG)
+                .bg(theme().list_highlight)
+                .fg(theme().list_highlight_fg)
                 .add_modifier(Modifier::BOLD),
         )
         .highlight_symbol("▸ ");
@@ -721,7 +711,7 @@ fn draw_list(f: &mut Frame, state: &State, area: Rect) {
 fn draw_edit_form(f: &mut Frame, state: &State, area: Rect) {
     let block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(COLOR_BORDER))
+        .border_style(Style::default().fg(theme().border))
         .title(Line::from(Span::styled(
             if state.edit.editing_id.is_some() {
                 "Edit entry"
@@ -729,7 +719,7 @@ fn draw_edit_form(f: &mut Frame, state: &State, area: Rect) {
                 "New entry"
             },
             Style::default()
-                .fg(COLOR_TITLE)
+                .fg(theme().title)
                 .add_modifier(Modifier::BOLD),
         )));
     let inner = block.inner(area);
@@ -760,7 +750,7 @@ fn draw_edit_form(f: &mut Frame, state: &State, area: Rect) {
     f.render_widget(
         Paragraph::new(Span::styled(
             header_text,
-            Style::default().fg(COLOR_TIMESTAMP),
+            Style::default().fg(theme().debug_system),
         )),
         rows[0],
     );
@@ -798,9 +788,9 @@ fn draw_text_field_with_label(
 ) {
     let mut ta = textarea.clone();
     let border_color = if focused {
-        COLOR_BORDER_ACTIVE
+        theme().border_active
     } else {
-        COLOR_BORDER
+        theme().border
     };
     ta.set_block(
         Block::default()
@@ -808,7 +798,7 @@ fn draw_text_field_with_label(
             .border_style(Style::default().fg(border_color))
             .title(Line::from(Span::styled(
                 title.to_string(),
-                Style::default().fg(COLOR_TITLE),
+                Style::default().fg(theme().title),
             ))),
     );
     f.render_widget(&ta, area);
@@ -817,10 +807,10 @@ fn draw_text_field_with_label(
 fn draw_field_label(f: &mut Frame, area: Rect, label: &str, focused: bool) {
     let style = if focused {
         Style::default()
-            .fg(COLOR_BORDER_ACTIVE)
+            .fg(theme().border_active)
             .add_modifier(Modifier::BOLD)
     } else {
-        Style::default().fg(COLOR_HINT_DESC)
+        Style::default().fg(theme().text_dim)
     };
     f.render_widget(Paragraph::new(Span::styled(label.to_string(), style)), area);
 }
@@ -828,9 +818,9 @@ fn draw_field_label(f: &mut Frame, area: Rect, label: &str, focused: bool) {
 fn draw_text_field(f: &mut Frame, area: Rect, textarea: &TextArea<'static>, focused: bool) {
     let mut ta = textarea.clone();
     let border_color = if focused {
-        COLOR_BORDER_ACTIVE
+        theme().border_active
     } else {
-        COLOR_BORDER
+        theme().border
     };
     ta.set_block(
         Block::default()
@@ -843,14 +833,14 @@ fn draw_text_field(f: &mut Frame, area: Rect, textarea: &TextArea<'static>, focu
 fn draw_status(f: &mut Frame, state: &State, area: Rect) {
     if let Some(busy) = &state.busy {
         let style = Style::default()
-            .fg(Color::Rgb(178, 220, 245))
+            .fg(theme().assistant_indicator)
             .add_modifier(Modifier::ITALIC);
         f.render_widget(
             Paragraph::new(Span::styled(format!(" ● {busy}"), style)),
             area,
         );
     } else if let Some(err) = &state.error {
-        let style = Style::default().fg(COLOR_ERROR);
+        let style = Style::default().fg(theme().error);
         f.render_widget(
             Paragraph::new(Span::styled(format!(" • {err}"), style)),
             area,
@@ -876,18 +866,18 @@ fn draw_hints(f: &mut Frame, state: &State, area: Rect) {
     let mut spans: Vec<Span> = Vec::with_capacity(hints.len() * 4);
     for (idx, (key, desc)) in hints.iter().enumerate() {
         if idx > 0 {
-            spans.push(Span::styled("  ·  ", Style::default().fg(COLOR_HINT_SEP)));
+            spans.push(Span::styled("  ·  ", Style::default().fg(theme().hint_sep)));
         }
         spans.push(Span::styled(
             (*key).to_string(),
             Style::default()
-                .fg(COLOR_HINT_KEY)
+                .fg(theme().hint_key)
                 .add_modifier(Modifier::BOLD),
         ));
         spans.push(Span::raw(" "));
         spans.push(Span::styled(
             (*desc).to_string(),
-            Style::default().fg(COLOR_HINT_DESC),
+            Style::default().fg(theme().text_dim),
         ));
     }
     f.render_widget(Paragraph::new(Line::from(spans)), area);
@@ -919,11 +909,11 @@ fn draw_delete_overlay(f: &mut Frame, state: &State, area: Rect) {
     f.render_widget(Clear, popup);
     let block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(COLOR_DELETE_BORDER))
+        .border_style(Style::default().fg(theme().error))
         .title(Line::from(Span::styled(
             "Delete entry",
             Style::default()
-                .fg(Color::Rgb(255, 200, 200))
+                .fg(theme().error_text)
                 .add_modifier(Modifier::BOLD),
         )));
     let inner = block.inner(popup);
@@ -935,7 +925,7 @@ fn draw_delete_overlay(f: &mut Frame, state: &State, area: Rect) {
         )),
         Line::from(Span::styled(
             "y/Enter = confirm · any other key = cancel",
-            Style::default().fg(COLOR_HINT_DESC),
+            Style::default().fg(theme().text_dim),
         )),
     ])
     .wrap(Wrap { trim: true });

--- a/src/kb.rs
+++ b/src/kb.rs
@@ -222,6 +222,19 @@ struct State {
     closing: bool,
 }
 
+use crate::in_flight::InFlight;
+
+/// Resolved outcome of an off-loop KB RPC (modal-freeze fix). `Entries` covers
+/// both the list and search RPCs (both return entry vecs).
+enum RpcOutcome {
+    Entries(Result<Vec<KnowledgeEntryView>, String>),
+    Saved(Result<KnowledgeEntryView, String>),
+    Deleted {
+        id: String,
+        result: Result<(), String>,
+    },
+}
+
 /// The KB browser as a [`Screen`]: its mutable [`State`] plus the borrowed
 /// transport client the key/timer handlers need. The shared driver supplies the
 /// event loop and — the reason it's shared — drains daemon signals while this
@@ -229,6 +242,9 @@ struct State {
 struct KbScreen<'a> {
     state: State,
     client: &'a TransportClient,
+    /// In-flight list/search/save/delete RPCs, polled off the draw loop by
+    /// `poll_pending` so the browser never freezes during a round-trip.
+    pending: InFlight<'a, RpcOutcome>,
 }
 
 impl Screen for KbScreen<'_> {
@@ -238,8 +254,9 @@ impl Screen for KbScreen<'_> {
         draw(frame, &self.state);
     }
 
-    async fn handle_key(&mut self, key: KeyEvent) {
-        handle_key(&mut self.state, key, self.client).await;
+    fn handle_key(&mut self, key: KeyEvent) -> impl std::future::Future<Output = ()> {
+        handle_key(&mut self.state, key, self.client, &mut self.pending);
+        std::future::ready(())
     }
 
     fn take_outcome(&mut self) -> Option<()> {
@@ -250,10 +267,24 @@ impl Screen for KbScreen<'_> {
         self.state.search_deadline
     }
 
-    async fn on_timer(&mut self) {
+    fn on_timer(&mut self) -> impl std::future::Future<Output = ()> {
+        // Debounced search: enqueue it off-loop instead of awaiting here, so the
+        // browser keeps drawing/handling input while the search runs.
         self.state.search_deadline = None;
         let query = self.state.search.lines().join(" ").trim().to_string();
-        run_search(&mut self.state, self.client, query).await;
+        run_search(&mut self.state, &mut self.pending, self.client, query);
+        std::future::ready(())
+    }
+
+    fn has_pending(&self) -> bool {
+        !self.pending.is_empty()
+    }
+
+    async fn poll_pending(&mut self) {
+        let resolved = self.pending.next().await;
+        if let Some(outcome) = resolved {
+            apply_outcome(&mut self.state, outcome);
+        }
     }
 }
 
@@ -282,24 +313,35 @@ pub async fn run(
             closing: false,
         },
         client,
+        pending: InFlight::new(),
     };
 
-    // Initial fetch.
-    refresh_list(&mut screen.state, client).await;
+    // Initial fetch (off-loop).
+    refresh_list(&mut screen.state, &mut screen.pending, client);
 
     crate::screen::run_screen(terminal, &mut screen, signal_rx, sink).await
 }
 
-async fn handle_key(state: &mut State, key: KeyEvent, client: &TransportClient) {
+fn handle_key<'a>(
+    state: &mut State,
+    key: KeyEvent,
+    client: &'a TransportClient,
+    pending: &mut InFlight<'a, RpcOutcome>,
+) {
     match state.mode {
-        Mode::List => handle_list_key(state, key, client).await,
+        Mode::List => handle_list_key(state, key, client, pending),
         Mode::Search => handle_search_key(state, key),
-        Mode::Edit => handle_edit_key(state, key, client).await,
-        Mode::DeleteConfirm => handle_delete_key(state, key, client).await,
+        Mode::Edit => handle_edit_key(state, key, client, pending),
+        Mode::DeleteConfirm => handle_delete_key(state, key, client, pending),
     }
 }
 
-async fn handle_list_key(state: &mut State, key: KeyEvent, client: &TransportClient) {
+fn handle_list_key<'a>(
+    state: &mut State,
+    key: KeyEvent,
+    client: &'a TransportClient,
+    pending: &mut InFlight<'a, RpcOutcome>,
+) {
     match (key.code, key.modifiers) {
         (KeyCode::Esc | KeyCode::Char('q'), m) if m.is_empty() => {
             state.closing = true;
@@ -324,9 +366,7 @@ async fn handle_list_key(state: &mut State, key: KeyEvent, client: &TransportCli
         (KeyCode::Char('/'), m) if m.is_empty() => {
             state.mode = Mode::Search;
         }
-        (KeyCode::Char('r'), m) if m.is_empty() => {
-            refresh_list(state, client).await;
-        }
+        (KeyCode::Char('r'), m) if m.is_empty() => refresh_list(state, pending, client),
         _ => {}
     }
 }
@@ -352,11 +392,16 @@ fn handle_search_key(state: &mut State, key: KeyEvent) {
     }
 }
 
-async fn handle_edit_key(state: &mut State, key: KeyEvent, client: &TransportClient) {
+fn handle_edit_key<'a>(
+    state: &mut State,
+    key: KeyEvent,
+    client: &'a TransportClient,
+    pending: &mut InFlight<'a, RpcOutcome>,
+) {
     let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
 
     if ctrl && key.code == KeyCode::Char('s') {
-        save_edit(state, client).await;
+        save_edit(state, pending, client);
         return;
     }
 
@@ -386,24 +431,26 @@ async fn handle_edit_key(state: &mut State, key: KeyEvent, client: &TransportCli
     }
 }
 
-async fn handle_delete_key(state: &mut State, key: KeyEvent, client: &TransportClient) {
+fn handle_delete_key<'a>(
+    state: &mut State,
+    key: KeyEvent,
+    client: &'a TransportClient,
+    pending: &mut InFlight<'a, RpcOutcome>,
+) {
     match (key.code, key.modifiers) {
         (KeyCode::Char('y') | KeyCode::Char('Y') | KeyCode::Enter, _) => {
             if let Some(entry) = state.entries.get(state.selected).cloned() {
                 state.busy = Some("Deleting entry...".into());
-                match client.delete_knowledge_entry(&entry.id).await {
-                    Ok(()) => {
-                        state.entries.remove(state.selected);
-                        if state.selected >= state.entries.len() {
-                            state.selected = state.entries.len().saturating_sub(1);
-                        }
-                        state.busy = None;
+                let id = entry.id.clone();
+                pending.push(async move {
+                    RpcOutcome::Deleted {
+                        result: client
+                            .delete_knowledge_entry(&id)
+                            .await
+                            .map_err(|e| format!("Delete failed: {e}")),
+                        id,
                     }
-                    Err(e) => {
-                        state.busy = None;
-                        state.error = Some(format!("Delete failed: {e}"));
-                    }
-                }
+                });
             }
             state.mode = state.return_mode;
         }
@@ -426,47 +473,48 @@ fn advance_selection(state: &mut State, delta: i32) {
     state.selected = idx as usize;
 }
 
-async fn refresh_list(state: &mut State, client: &TransportClient) {
+fn refresh_list<'a>(
+    state: &mut State,
+    pending: &mut InFlight<'a, RpcOutcome>,
+    client: &'a TransportClient,
+) {
     state.busy = Some("Loading entries...".into());
-    let result = client.list_knowledge_entries(LIST_LIMIT, 0, None).await;
-    state.busy = None;
-    match result {
-        Ok(entries) => {
-            state.entries = entries;
-            if state.selected >= state.entries.len() {
-                state.selected = state.entries.len().saturating_sub(1);
-            }
-        }
-        Err(e) => {
-            state.error = Some(format!("Failed to load entries: {e}"));
-        }
-    }
+    pending.push(async move {
+        RpcOutcome::Entries(
+            client
+                .list_knowledge_entries(LIST_LIMIT, 0, None)
+                .await
+                .map_err(|e| format!("Failed to load entries: {e}")),
+        )
+    });
 }
 
-async fn run_search(state: &mut State, client: &TransportClient, query: String) {
+fn run_search<'a>(
+    state: &mut State,
+    pending: &mut InFlight<'a, RpcOutcome>,
+    client: &'a TransportClient,
+    query: String,
+) {
     if query.is_empty() {
-        refresh_list(state, client).await;
+        refresh_list(state, pending, client);
         return;
     }
     state.busy = Some("Searching...".into());
-    let result = client
-        .search_knowledge_entries(&query, None, SEARCH_LIMIT)
-        .await;
-    state.busy = None;
-    match result {
-        Ok(entries) => {
-            state.entries = entries;
-            if state.selected >= state.entries.len() {
-                state.selected = state.entries.len().saturating_sub(1);
-            }
-        }
-        Err(e) => {
-            state.error = Some(format!("Search failed: {e}"));
-        }
-    }
+    pending.push(async move {
+        RpcOutcome::Entries(
+            client
+                .search_knowledge_entries(&query, None, SEARCH_LIMIT)
+                .await
+                .map_err(|e| format!("Search failed: {e}")),
+        )
+    });
 }
 
-async fn save_edit(state: &mut State, client: &TransportClient) {
+fn save_edit<'a>(
+    state: &mut State,
+    pending: &mut InFlight<'a, RpcOutcome>,
+    client: &'a TransportClient,
+) {
     let (content, tags, metadata) = match state.edit.submit() {
         Ok(parts) => parts,
         Err(e) => {
@@ -476,19 +524,34 @@ async fn save_edit(state: &mut State, client: &TransportClient) {
     };
 
     state.busy = Some("Saving...".into());
-    let result = if let Some(id) = state.edit.editing_id.clone() {
-        client
-            .update_knowledge_entry(&id, &content, tags, metadata)
-            .await
-    } else {
-        client
-            .create_knowledge_entry(&content, tags, metadata)
-            .await
-    };
-    state.busy = None;
+    let editing_id = state.edit.editing_id.clone();
+    pending.push(async move {
+        let result = if let Some(id) = editing_id {
+            client
+                .update_knowledge_entry(&id, &content, tags, metadata)
+                .await
+        } else {
+            client
+                .create_knowledge_entry(&content, tags, metadata)
+                .await
+        };
+        RpcOutcome::Saved(result.map_err(|e| format!("Save failed: {e}")))
+    });
+}
 
-    match result {
-        Ok(saved) => {
+/// Apply a resolved KB RPC. `Saved`/`Deleted` patch the list in place (no
+/// refetch); `Entries` replaces it (used by both the list and search RPCs).
+fn apply_outcome(state: &mut State, outcome: RpcOutcome) {
+    state.busy = None;
+    match outcome {
+        RpcOutcome::Entries(Ok(entries)) => {
+            state.entries = entries;
+            if state.selected >= state.entries.len() {
+                state.selected = state.entries.len().saturating_sub(1);
+            }
+        }
+        RpcOutcome::Entries(Err(e)) => state.error = Some(e),
+        RpcOutcome::Saved(Ok(saved)) => {
             // Replace or insert the saved entry in the list.
             if let Some(existing) = state.entries.iter_mut().find(|e| e.id == saved.id) {
                 *existing = saved.clone();
@@ -504,9 +567,18 @@ async fn save_edit(state: &mut State, client: &TransportClient) {
             state.edit = EditForm::empty();
             state.mode = Mode::List;
         }
-        Err(e) => {
-            state.error = Some(format!("Save failed: {e}"));
-        }
+        RpcOutcome::Saved(Err(e)) => state.error = Some(e),
+        RpcOutcome::Deleted { id, result } => match result {
+            Ok(()) => {
+                if let Some(pos) = state.entries.iter().position(|e| e.id == id) {
+                    state.entries.remove(pos);
+                    if state.selected >= state.entries.len() {
+                        state.selected = state.entries.len().saturating_sub(1);
+                    }
+                }
+            }
+            Err(e) => state.error = Some(e),
+        },
     }
 }
 

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -70,6 +70,8 @@ pub enum Action {
     /// `Adele == On Demand` — reply narration is on. Defaults `Disabled` (type
     /// only); text input is always available.
     ToggleVoiceIn,
+    /// Toggle the keymap help overlay (`?` in Normal mode, or `F1` from anywhere).
+    ToggleHelp,
 }
 
 /// Handle key events that we intercept before passing to textarea.
@@ -99,6 +101,12 @@ pub fn handle_key_event(
     // F4 opens the purposes manager.
     if key.code == KeyCode::F(4) && key.modifiers.is_empty() {
         return Some(Action::OpenPurposes);
+    }
+    // F1 toggles the keymap help overlay from any mode (`?` also opens it in
+    // Normal mode; F1 is offered too since `?` is a literal character in the
+    // composer).
+    if key.code == KeyCode::F(1) && key.modifiers.is_empty() {
+        return Some(Action::ToggleHelp);
     }
 
     // Ctrl combos. Most apply across modes, but in Renaming we forward
@@ -185,6 +193,7 @@ pub fn handle_key_event(
                 KeyCode::Char('A') => Some(Action::ArchiveConversation),
                 KeyCode::Char('r') => Some(Action::BeginRename),
                 KeyCode::Char('i') => Some(Action::EnterEditMode),
+                KeyCode::Char('?') => Some(Action::ToggleHelp),
                 KeyCode::PageUp => Some(Action::ScrollUp),
                 KeyCode::PageDown => Some(Action::ScrollDown),
                 KeyCode::End => Some(Action::ScrollToBottom),
@@ -224,6 +233,79 @@ pub fn handle_key_event(
             }
         }
     }
+}
+
+/// The keymap shown in the `?`/F1 help overlay (rendered by `ui::draw_help_overlay`).
+/// Lives next to `handle_key_event` so the help stays the single source of truth
+/// for the bindings.
+pub fn help_sections() -> &'static [(&'static str, &'static [(&'static str, &'static str)])] {
+    &[
+        (
+            "Conversations (Normal mode)",
+            &[
+                ("j / k   ↑ / ↓", "move selection"),
+                ("Enter", "open conversation"),
+                ("i", "compose / edit"),
+                ("n", "new conversation"),
+                ("r", "rename"),
+                ("d", "delete"),
+                ("A", "archive"),
+                ("a", "show / hide archived"),
+                ("q", "quit"),
+            ],
+        ),
+        (
+            "Composing (edit mode)",
+            &[
+                ("Enter", "send"),
+                ("Shift+Enter / Ctrl+J", "insert newline"),
+                ("Esc", "leave edit mode"),
+            ],
+        ),
+        (
+            "Scroll",
+            &[
+                ("Ctrl+U / Ctrl+D", "page up / down"),
+                ("Ctrl+E", "jump to bottom"),
+            ],
+        ),
+        (
+            "View",
+            &[
+                ("Ctrl+B", "toggle sidebar"),
+                ("Ctrl+T", "toggle debug messages"),
+                ("Ctrl+P", "tasks pane"),
+            ],
+        ),
+        (
+            "Open",
+            &[
+                ("F2", "switch connection"),
+                ("F3", "connections manager"),
+                ("F4", "purposes"),
+                ("Ctrl+K", "knowledge base"),
+                ("Ctrl+M", "model picker"),
+                ("Ctrl+R", "personality"),
+            ],
+        ),
+        (
+            "Voice",
+            &[
+                ("Ctrl+G", "push-to-talk dictation"),
+                ("Ctrl+S", "cycle Adele voice output"),
+                ("Ctrl+V", "toggle You (voice input)"),
+            ],
+        ),
+        (
+            "Tasks pane (when open)",
+            &[
+                ("j / k", "move selection"),
+                ("c", "cancel task"),
+                ("Enter", "open task's conversation"),
+                ("Esc", "close pane"),
+            ],
+        ),
+    ]
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub mod purposes;
 pub mod screen;
 pub mod settings;
 pub mod tasks;
+pub mod theme;
 pub mod toolbar;
 pub mod ui;
 pub mod voice;

--- a/src/main.rs
+++ b/src/main.rs
@@ -144,6 +144,9 @@ impl From<CliArgs> for ConnectionConfig {
             ws_login_password: None,
             ws_subject,
             socket_path,
+            // Mint the socket-handshake JWT locally (#101/#316), not over the
+            // deprecated D-Bus path (see `Profile::to_connection_config`).
+            minter_socket: desktop_assistant_client_common::minter::default_minter_socket_path(),
             ..Default::default()
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ use tokio::{
 // `personality_selector` + `voice_client` from `lib.rs`). Only the orchestration
 // wiring them together (the `run` event loop, its RPC/signal helpers, the voice
 // plumbing types) lives in this file.
-use adele::app::{AdeleOutput, App, InputMode};
+use adele::app::{AdeleOutput, App, InputMode, ScreenRequest};
 use adele::in_flight::InFlight;
 use adele::keys::{Action, handle_key_event};
 use adele::picker::PickerOutcome;
@@ -453,27 +453,149 @@ async fn run(
             ReconnectState::Connected => None,
         };
 
-        // Sub-screens (TUI-12): each modal screen now runs over the shared
-        // `screen::run_screen` driver, which drains the daemon signal stream via
-        // `handle_signal` while the screen is open so a turn parked on the TUI's
-        // `say_this` client tool is answered immediately instead of stalling
-        // until the screen closes. A `Disconnected` that arrives mid-screen is
-        // recorded by the drain callback and actioned right after the screen
-        // returns (the teardown touches loop-local state the callback can't own).
-        if app.kb_requested {
-            app.kb_requested = false;
+        // Sub-screens: each modal runs over the shared `screen::run_screen`
+        // driver, which drains the daemon signal stream while the screen is open
+        // (TUI-12) so a turn parked on the TUI's `say_this` client tool is
+        // answered immediately instead of stalling until the screen closes.
+        //
+        // A single dispatch point (CC-3): the user's request is mutually exclusive
+        // (`ScreenRequest`), so the loop opens at most one modal per turn. Every
+        // screen shares the same disconnect handling — a `Disconnected` drained
+        // mid-screen is recorded into `disconnect` and actioned once the screen
+        // returns, since the teardown touches loop-local state the sink can't own
+        // — so that skeleton is hoisted around the per-screen `match`.
+        if let Some(screen) = app.take_pending_screen() {
             let mut disconnect: Option<String> = None;
-            if let Some(conn) = connector.clone() {
-                let mut sink = SubScreenSink {
-                    app: &mut app,
-                    connector: &connector,
-                    voice_daemon: &voice_daemon,
-                    voice_session: &voice_session,
-                    narration_tx: &narration_tx,
-                    disconnect: &mut disconnect,
-                };
-                if let Err(e) = kb::run(terminal, conn.client(), &mut signal_rx, &mut sink).await {
-                    sink.app.status_message = format!("KB error: {e}");
+            match screen {
+                ScreenRequest::KnowledgeBase => {
+                    if let Some(conn) = connector.clone() {
+                        let mut sink = SubScreenSink {
+                            app: &mut app,
+                            connector: &connector,
+                            voice_daemon: &voice_daemon,
+                            voice_session: &voice_session,
+                            narration_tx: &narration_tx,
+                            disconnect: &mut disconnect,
+                        };
+                        if let Err(e) =
+                            kb::run(terminal, conn.client(), &mut signal_rx, &mut sink).await
+                        {
+                            sink.app.status_message = format!("KB error: {e}");
+                        }
+                    }
+                }
+                ScreenRequest::Connections => {
+                    if let Some(conn) = connector.clone() {
+                        let mut sink = SubScreenSink {
+                            app: &mut app,
+                            connector: &connector,
+                            voice_daemon: &voice_daemon,
+                            voice_session: &voice_session,
+                            narration_tx: &narration_tx,
+                            disconnect: &mut disconnect,
+                        };
+                        if let Err(e) =
+                            connections::run(terminal, conn.client(), &mut signal_rx, &mut sink)
+                                .await
+                        {
+                            sink.app.status_message = format!("Connections error: {e}");
+                        }
+                    }
+                }
+                ScreenRequest::Purposes => {
+                    if let Some(conn) = connector.clone() {
+                        let mut sink = SubScreenSink {
+                            app: &mut app,
+                            connector: &connector,
+                            voice_daemon: &voice_daemon,
+                            voice_session: &voice_session,
+                            narration_tx: &narration_tx,
+                            disconnect: &mut disconnect,
+                        };
+                        if let Err(e) =
+                            purposes::run(terminal, conn.client(), &mut signal_rx, &mut sink).await
+                        {
+                            sink.app.status_message = format!("Purposes error: {e}");
+                        }
+                    }
+                }
+                ScreenRequest::ModelPicker => {
+                    let mut picked_outcome = None;
+                    if let Some(conn) = connector.clone() {
+                        let current = app
+                            .current_conversation()
+                            .and_then(|c| c.model_selection.clone());
+                        let mut sink = SubScreenSink {
+                            app: &mut app,
+                            connector: &connector,
+                            voice_daemon: &voice_daemon,
+                            voice_session: &voice_session,
+                            narration_tx: &narration_tx,
+                            disconnect: &mut disconnect,
+                        };
+                        match model_selector::run(
+                            terminal,
+                            conn.client(),
+                            current,
+                            &mut signal_rx,
+                            &mut sink,
+                        )
+                        .await
+                        {
+                            Ok(outcome) => picked_outcome = Some(outcome),
+                            Err(e) => sink.app.status_message = format!("Model picker error: {e}"),
+                        }
+                    }
+                    // Apply the selection AFTER the sink's borrow of `app` ends.
+                    if let Some(model_selector::Outcome::Selected(picked)) = picked_outcome {
+                        let label = format!("{} · {}", picked.connection_id, picked.model_id);
+                        app.apply_model_override(picked);
+                        app.status_message = format!("Model: {label} (applies to next message)");
+                    }
+                }
+                ScreenRequest::PersonalityPicker => {
+                    let mut saved_outcome = None;
+                    // Only reachable with a loaded conversation (handle_action gates
+                    // on `current_conversation`), but re-check so the borrow stays
+                    // clean.
+                    let conv_info = app
+                        .current_conversation()
+                        .map(|conv| (conv.id.clone(), conv.conversation_personality));
+                    if let (Some(conn), Some((conv_id, current))) = (connector.clone(), conv_info) {
+                        let mut sink = SubScreenSink {
+                            app: &mut app,
+                            connector: &connector,
+                            voice_daemon: &voice_daemon,
+                            voice_session: &voice_session,
+                            narration_tx: &narration_tx,
+                            disconnect: &mut disconnect,
+                        };
+                        match personality_selector::run(
+                            terminal,
+                            conn.client(),
+                            conv_id,
+                            current,
+                            &mut signal_rx,
+                            &mut sink,
+                        )
+                        .await
+                        {
+                            Ok(outcome) => saved_outcome = Some(outcome),
+                            Err(e) => {
+                                sink.app.status_message = format!("Personality picker error: {e}")
+                            }
+                        }
+                    }
+                    // Apply the result AFTER the sink's borrow of `app` ends.
+                    if let Some(personality_selector::Outcome::Saved(stored)) = saved_outcome {
+                        let cleared = stored == Default::default();
+                        app.set_open_conversation_personality(stored);
+                        app.status_message = if cleared {
+                            "Personality cleared (using global)".into()
+                        } else {
+                            "Personality saved for this conversation".into()
+                        };
+                    }
                 }
             }
             apply_sub_screen_disconnect(
@@ -485,159 +607,6 @@ async fn run(
             );
             // Force a redraw on the next iteration so the chat reappears
             // immediately instead of waiting for the next event.
-            continue;
-        }
-
-        if app.connections_requested {
-            app.connections_requested = false;
-            let mut disconnect: Option<String> = None;
-            if let Some(conn) = connector.clone() {
-                let mut sink = SubScreenSink {
-                    app: &mut app,
-                    connector: &connector,
-                    voice_daemon: &voice_daemon,
-                    voice_session: &voice_session,
-                    narration_tx: &narration_tx,
-                    disconnect: &mut disconnect,
-                };
-                if let Err(e) =
-                    connections::run(terminal, conn.client(), &mut signal_rx, &mut sink).await
-                {
-                    sink.app.status_message = format!("Connections error: {e}");
-                }
-            }
-            apply_sub_screen_disconnect(
-                &mut app,
-                &mut connector,
-                &mut signal_rx,
-                &mut reconnect,
-                disconnect,
-            );
-            continue;
-        }
-
-        if app.purposes_requested {
-            app.purposes_requested = false;
-            let mut disconnect: Option<String> = None;
-            if let Some(conn) = connector.clone() {
-                let mut sink = SubScreenSink {
-                    app: &mut app,
-                    connector: &connector,
-                    voice_daemon: &voice_daemon,
-                    voice_session: &voice_session,
-                    narration_tx: &narration_tx,
-                    disconnect: &mut disconnect,
-                };
-                if let Err(e) =
-                    purposes::run(terminal, conn.client(), &mut signal_rx, &mut sink).await
-                {
-                    sink.app.status_message = format!("Purposes error: {e}");
-                }
-            }
-            apply_sub_screen_disconnect(
-                &mut app,
-                &mut connector,
-                &mut signal_rx,
-                &mut reconnect,
-                disconnect,
-            );
-            continue;
-        }
-
-        if app.model_picker_requested {
-            app.model_picker_requested = false;
-            let mut disconnect: Option<String> = None;
-            let mut picked_outcome = None;
-            if let Some(conn) = connector.clone() {
-                let current = app
-                    .current_conversation()
-                    .and_then(|c| c.model_selection.clone());
-                let mut sink = SubScreenSink {
-                    app: &mut app,
-                    connector: &connector,
-                    voice_daemon: &voice_daemon,
-                    voice_session: &voice_session,
-                    narration_tx: &narration_tx,
-                    disconnect: &mut disconnect,
-                };
-                match model_selector::run(
-                    terminal,
-                    conn.client(),
-                    current,
-                    &mut signal_rx,
-                    &mut sink,
-                )
-                .await
-                {
-                    Ok(outcome) => picked_outcome = Some(outcome),
-                    Err(e) => sink.app.status_message = format!("Model picker error: {e}"),
-                }
-            }
-            // Apply the selection AFTER the sink's borrow of `app` ends.
-            if let Some(model_selector::Outcome::Selected(picked)) = picked_outcome {
-                let label = format!("{} · {}", picked.connection_id, picked.model_id);
-                app.apply_model_override(picked);
-                app.status_message = format!("Model: {label} (applies to next message)");
-            }
-            apply_sub_screen_disconnect(
-                &mut app,
-                &mut connector,
-                &mut signal_rx,
-                &mut reconnect,
-                disconnect,
-            );
-            continue;
-        }
-
-        if app.personality_picker_requested {
-            app.personality_picker_requested = false;
-            let mut disconnect: Option<String> = None;
-            let mut saved_outcome = None;
-            // Only reachable with a loaded conversation (handle_action gates on
-            // `current_conversation`), but re-check so the borrow stays clean.
-            let conv_info = app
-                .current_conversation()
-                .map(|conv| (conv.id.clone(), conv.conversation_personality));
-            if let (Some(conn), Some((conv_id, current))) = (connector.clone(), conv_info) {
-                let mut sink = SubScreenSink {
-                    app: &mut app,
-                    connector: &connector,
-                    voice_daemon: &voice_daemon,
-                    voice_session: &voice_session,
-                    narration_tx: &narration_tx,
-                    disconnect: &mut disconnect,
-                };
-                match personality_selector::run(
-                    terminal,
-                    conn.client(),
-                    conv_id,
-                    current,
-                    &mut signal_rx,
-                    &mut sink,
-                )
-                .await
-                {
-                    Ok(outcome) => saved_outcome = Some(outcome),
-                    Err(e) => sink.app.status_message = format!("Personality picker error: {e}"),
-                }
-            }
-            // Apply the result AFTER the sink's borrow of `app` ends.
-            if let Some(personality_selector::Outcome::Saved(stored)) = saved_outcome {
-                let cleared = stored == Default::default();
-                app.set_open_conversation_personality(stored);
-                app.status_message = if cleared {
-                    "Personality cleared (using global)".into()
-                } else {
-                    "Personality saved for this conversation".into()
-                };
-            }
-            apply_sub_screen_disconnect(
-                &mut app,
-                &mut connector,
-                &mut signal_rx,
-                &mut reconnect,
-                disconnect,
-            );
             continue;
         }
 
@@ -1606,28 +1575,28 @@ async fn handle_action(
         }
         Action::OpenKnowledgeBase => {
             if client.is_some() {
-                app.kb_requested = true;
+                app.request_screen(ScreenRequest::KnowledgeBase);
             } else {
                 app.status_message = "Not connected — knowledge base unavailable".into();
             }
         }
         Action::OpenConnections => {
             if client.is_some() {
-                app.connections_requested = true;
+                app.request_screen(ScreenRequest::Connections);
             } else {
                 app.status_message = "Not connected — connections manager unavailable".into();
             }
         }
         Action::OpenPurposes => {
             if client.is_some() {
-                app.purposes_requested = true;
+                app.request_screen(ScreenRequest::Purposes);
             } else {
                 app.status_message = "Not connected — purposes manager unavailable".into();
             }
         }
         Action::OpenModelPicker => {
             if client.is_some() {
-                app.model_picker_requested = true;
+                app.request_screen(ScreenRequest::ModelPicker);
             } else {
                 app.status_message = "Not connected — model picker unavailable".into();
             }
@@ -1639,7 +1608,7 @@ async fn handle_action(
                 app.status_message =
                     "Open a conversation first (Enter) — personality is per-conversation".into();
             } else {
-                app.personality_picker_requested = true;
+                app.request_screen(ScreenRequest::PersonalityPicker);
             }
         }
         Action::ToggleTasksPane => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -422,6 +422,12 @@ async fn run(
     }
 
     loop {
+        // Project the run loop's connection state into the model so the view
+        // can render disconnect chrome — the loop owns the socket; the draw
+        // path only sees `app`. Mirror the exact predicate that gates sending
+        // (`connector.is_some()`) so the `offline` cue shows precisely when a
+        // send would be refused.
+        app.connected = connector.is_some();
         terminal.draw(|f| ui::draw(f, &mut app))?;
 
         if app.should_quit {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1523,7 +1523,7 @@ async fn handle_action(
                 let id = id.to_string();
                 // Determine if conversation is currently archived
                 let is_archived = app
-                    .conversations
+                    .conversations()
                     .get(app.selected_conversation.unwrap_or(0))
                     .is_some_and(|c| c.archived);
                 let show_archived = app.show_archived;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1058,31 +1058,26 @@ enum SignalAction {
 }
 
 /// Run the controller-level effects [`App::apply_core`] bubbled up from a
-/// streaming signal — the ones the view can't perform itself. The streaming arms
-/// emit only [`Effect::Speak`] (reply narration, already gated by core's
-/// `StreamComplete`) and [`Effect::FetchScratchpad`] (a no-op here: the TUI has
-/// no scratchpad pane). The view-level effects were already applied inside
-/// `apply_core`, so they never reach this point; later CC-3 slices (conversation
-/// management) add the conversation/model/task effects and handle them here.
+/// streaming signal — the ones the view can't perform itself. Today the streaming
+/// arms bubble up only [`Effect::Speak`] (reply narration, already gated by
+/// core's `StreamComplete`); the view-level effects (including the side-pane
+/// no-ops) were already absorbed inside `apply_core`. Later CC-3 slices route the
+/// open-conversation RPC effects and handle them here.
 fn run_stream_controller_effects(
     effects: Vec<Effect>,
     voice_daemon: &VoiceController,
     voice_session: &Option<VoiceSession>,
     narration_tx: &UnboundedSender<NarrationRequest>,
 ) {
+    // Today the streaming arms bubble up only `Speak`; any other effect is
+    // ignored here (later CC-3 slices route the open-conversation RPC effects).
+    // Reaching the body means core's narration gate passed; skip an empty reply
+    // so we don't enqueue silence.
     for effect in effects {
-        match effect {
-            Effect::Speak(text) => {
-                // Reaching here means core's narration gate passed; skip an empty
-                // reply so we don't enqueue silence.
-                if !text.trim().is_empty() {
-                    enqueue_narration(narration_tx, voice_daemon, voice_session, text);
-                }
-            }
-            // The TUI has no scratchpad pane (GTK/KDE only).
-            Effect::FetchScratchpad(_) => {}
-            // No other effect is produced by the streaming arms yet.
-            _ => {}
+        if let Effect::Speak(text) = effect
+            && !text.trim().is_empty()
+        {
+            enqueue_narration(narration_tx, voice_daemon, voice_session, text);
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,7 @@ use adele::{
     client_tools, connections, credentials, kb, model_selector, personality_selector, picker,
     purposes, screen, ui, voice,
 };
+use client_ui_common::{Effect, UiMessage};
 
 const DEFAULT_WS_URL: &str = desktop_assistant_client_common::config::DEFAULT_WS_URL;
 const DEFAULT_WS_SUBJECT: &str = desktop_assistant_client_common::config::DEFAULT_WS_SUBJECT;
@@ -1044,6 +1045,36 @@ enum SignalAction {
     RefreshConversations,
 }
 
+/// Run the controller-level effects [`App::apply_core`] bubbled up from a
+/// streaming signal — the ones the view can't perform itself. The streaming arms
+/// emit only [`Effect::Speak`] (reply narration, already gated by core's
+/// `StreamComplete`) and [`Effect::FetchScratchpad`] (a no-op here: the TUI has
+/// no scratchpad pane). The view-level effects were already applied inside
+/// `apply_core`, so they never reach this point; later CC-3 slices (conversation
+/// management) add the conversation/model/task effects and handle them here.
+fn run_stream_controller_effects(
+    effects: Vec<Effect>,
+    voice_daemon: &VoiceController,
+    voice_session: &Option<VoiceSession>,
+    narration_tx: &UnboundedSender<NarrationRequest>,
+) {
+    for effect in effects {
+        match effect {
+            Effect::Speak(text) => {
+                // Reaching here means core's narration gate passed; skip an empty
+                // reply so we don't enqueue silence.
+                if !text.trim().is_empty() {
+                    enqueue_narration(narration_tx, voice_daemon, voice_session, text);
+                }
+            }
+            // The TUI has no scratchpad pane (GTK/KDE only).
+            Effect::FetchScratchpad(_) => {}
+            // No other effect is produced by the streaming arms yet.
+            _ => {}
+        }
+    }
+}
+
 /// Apply one daemon [`SignalEvent`] to `App` (+ voice). Extracted from the main
 /// `select!` so it can be reused by the sub-screen driver (TUI-12): while a modal
 /// screen is open, [`screen::run_screen`] drains the signal stream through this
@@ -1063,63 +1094,75 @@ async fn handle_signal(
     signal: SignalEvent,
 ) -> SignalAction {
     match signal {
-        // A user message was committed and a turn started (#1). For our own send
-        // this dedupes (the bubble was drawn optimistically); for a turn started
-        // elsewhere (a voice turn) in the open conversation it renders the user
-        // bubble and adopts the turn so its reply streams live. All streaming
-        // events now carry `conversation_id` too, but the in-flight slot routes
-        // them by `request_id`, so it is dropped on those arms.
+        // The streaming events (#1) route through the shared core
+        // (`App::apply_core`): the reducer owns the in-flight state machine —
+        // request-id claiming, originating-conversation targeting (TUI-4), and
+        // the reply-narration gate — and emits effects. `apply_core` applies the
+        // view-level effects (transcript, chat status, context fill) onto `App`
+        // in place and returns the controller-level ones (narration) for
+        // `run_stream_controller_effects` to run. The events carry
+        // `conversation_id` too, but the in-flight slot routes the stream arms by
+        // `request_id`, so the reducer drops it there.
         SignalEvent::UserMessageAdded {
             conversation_id,
             request_id,
             content,
         } => {
-            app.user_message_added(&conversation_id, &request_id, &content);
+            let effects = app.apply_core(UiMessage::UserMessageAdded {
+                conversation_id,
+                request_id,
+                content,
+            });
+            run_stream_controller_effects(effects, voice_daemon, voice_session, narration_tx);
         }
         SignalEvent::Chunk {
             request_id, chunk, ..
         } => {
-            app.receive_chunk(&request_id, &chunk);
+            let effects = app.apply_core(UiMessage::StreamChunk { request_id, chunk });
+            run_stream_controller_effects(effects, voice_daemon, voice_session, narration_tx);
         }
         SignalEvent::Complete {
             request_id,
             full_response,
             ..
         } => {
-            // `complete_streaming` reports the ORIGINATING conversation (TUI-4) —
-            // the one the prompt was sent to, not whichever is open now — and the
-            // narration gate (adele-tui#77: `Adele == Always` OR `Adele ==
-            // OnDemand` AND `You == Enabled`) is evaluated against THAT
-            // conversation's settings. Routed daemon-first + chunked through the
-            // single narration queue (TUI-11) so it can't interleave with a
-            // `say_this` aside; the queue task speaks it so synth never blocks the
-            // UI. Gated entirely here so the cut-off holds: when the gate is false
-            // nothing is spoken on any path.
-            // An adopted external turn (a voice turn, or another client) is
-            // narrated by its originator — tui must not also speak it. Capture
-            // the flag before `complete_streaming` resets it.
-            let was_external = app.streaming_is_external;
-            let origin = app.complete_streaming(&request_id, &full_response);
-            if let Some(origin) = origin
-                && !was_external
-                && app.narrate_for(&origin)
-                && !full_response.trim().is_empty()
-            {
-                enqueue_narration(narration_tx, voice_daemon, voice_session, full_response);
-            }
+            // The whole narration gate — TUI-4 originating-conversation
+            // targeting, the adele-tui#77 `Adele`-level gate (`Always` OR
+            // `OnDemand` AND `You == Enabled`), external-turn suppression, and the
+            // `say_this` dedupe — now lives in core's `StreamComplete`, which
+            // emits a `Speak` effect when (and only when) the reply should be
+            // spoken. `run_stream_controller_effects` routes that through the
+            // single narration queue (TUI-11) so synth never blocks the UI and a
+            // `say_this` aside can't interleave.
+            let effects = app.apply_core(UiMessage::StreamComplete {
+                request_id,
+                full_response,
+            });
+            run_stream_controller_effects(effects, voice_daemon, voice_session, narration_tx);
         }
         SignalEvent::Error {
             request_id, error, ..
         } => {
-            app.streaming_error(&request_id, &error);
+            let effects = app.apply_core(UiMessage::StreamError {
+                request_id,
+                error: error.clone(),
+            });
+            run_stream_controller_effects(effects, voice_daemon, voice_session, narration_tx);
+            // The reducer surfaces "Error: …" in the status line only for the
+            // matching in-flight stream; set it unconditionally too so an error
+            // for an already-resolved request still reaches the user.
             app.status_message = format!("Error: {error}");
         }
         SignalEvent::Status {
-            request_id: _,
+            request_id,
             message,
             ..
         } => {
-            app.set_assistant_status(message);
+            let effects = app.apply_core(UiMessage::AssistantStatus {
+                request_id,
+                message,
+            });
+            run_stream_controller_effects(effects, voice_daemon, voice_session, narration_tx);
         }
         SignalEvent::ContextUsage {
             conversation_id,
@@ -1128,14 +1171,13 @@ async fn handle_signal(
             budget_tokens,
             compaction_active,
         } => {
-            app.set_context_usage(
-                &conversation_id,
-                adele::app::ContextUsageView {
-                    used_tokens,
-                    budget_tokens,
-                    compaction_active,
-                },
-            );
+            let effects = app.apply_core(UiMessage::ContextUsage {
+                conversation_id,
+                used_tokens,
+                budget_tokens,
+                compaction_active,
+            });
+            run_stream_controller_effects(effects, voice_daemon, voice_session, narration_tx);
         }
         SignalEvent::TitleChanged {
             conversation_id,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1003,7 +1003,19 @@ fn apply_rpc_outcome(app: &mut App, outcome: RpcOutcome) -> bool {
         },
         RpcOutcome::ConversationsRefreshed { list, on_success } => match list {
             Ok(convs) => {
-                app.set_conversations(convs);
+                // The list-only refresh (a show-archived/(un)archive toggle, or a
+                // `ConversationListChanged` refetch) flows through the reducer's
+                // `ConversationListRefetched`, which repaints the sidebar
+                // (`SetConversations`) and re-syncs the selection
+                // (`EnsureActiveConversation` — a no-op in the TUI). The open
+                // conversation + its chat are deliberately left untouched. These
+                // are all view-effects, so `apply_core` fully handles them and
+                // returns nothing for the loop to run.
+                let effects = app.apply_core(UiMessage::ConversationListRefetched(convs));
+                debug_assert!(
+                    effects.is_empty(),
+                    "ConversationListRefetched must emit only view-effects: {effects:?}"
+                );
                 if let Some(msg) = on_success {
                     app.status_message = msg;
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -144,9 +144,13 @@ impl From<CliArgs> for ConnectionConfig {
             ws_login_password: None,
             ws_subject,
             socket_path,
-            // Mint the socket-handshake JWT locally (#101/#316), not over the
-            // deprecated D-Bus path (see `Profile::to_connection_config`).
-            minter_socket: desktop_assistant_client_common::minter::default_minter_socket_path(),
+            // Mint the UDS handshake JWT locally (#101/#316), not over the
+            // deprecated D-Bus path. UDS-only — see `Profile::to_connection_config`.
+            minter_socket: if matches!(transport_mode, TransportMode::Uds) {
+                desktop_assistant_client_common::minter::default_minter_socket_path()
+            } else {
+                None
+            },
             ..Default::default()
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -550,8 +550,7 @@ async fn run(
             let mut picked_outcome = None;
             if let Some(conn) = connector.clone() {
                 let current = app
-                    .current_conversation
-                    .as_ref()
+                    .current_conversation()
                     .and_then(|c| c.model_selection.clone());
                 let mut sink = SubScreenSink {
                     app: &mut app,
@@ -597,8 +596,7 @@ async fn run(
             // Only reachable with a loaded conversation (handle_action gates on
             // `current_conversation`), but re-check so the borrow stays clean.
             let conv_info = app
-                .current_conversation
-                .as_ref()
+                .current_conversation()
                 .map(|conv| (conv.id.clone(), conv.conversation_personality));
             if let (Some(conn), Some((conv_id, current))) = (connector.clone(), conv_info) {
                 let mut sink = SubScreenSink {
@@ -625,10 +623,9 @@ async fn run(
             }
             // Apply the result AFTER the sink's borrow of `app` ends.
             if let Some(personality_selector::Outcome::Saved(stored)) = saved_outcome {
-                if let Some(c) = app.current_conversation.as_mut() {
-                    c.conversation_personality = Some(stored);
-                }
-                app.status_message = if stored == Default::default() {
+                let cleared = stored == Default::default();
+                app.set_open_conversation_personality(stored);
+                app.status_message = if cleared {
                     "Personality cleared (using global)".into()
                 } else {
                     "Personality saved for this conversation".into()
@@ -675,8 +672,7 @@ async fn run(
                             // when the daemon is absent.
                             if voice_daemon.is_available().await {
                                 let conv = app
-                                    .current_conversation
-                                    .as_ref()
+                                    .current_conversation()
                                     .map(|c| c.id.clone());
                                 // Barge-in: stop any in-progress narration before
                                 // we start listening, so the mic doesn't capture
@@ -782,9 +778,7 @@ async fn run(
                         // exists daemon-side) and reselect it by ID — the
                         // sidebar selection is positional and the refreshed
                         // list may have reordered.
-                        if let Some(open_id) =
-                            app.current_conversation.as_ref().map(|c| c.id.clone())
-                        {
+                        if let Some(open_id) = app.current_conversation().map(|c| c.id.clone()) {
                             app.select_conversation_by_id(&open_id);
                             match conn.client().get_conversation(&open_id).await {
                                 Ok(detail) => app.load_conversation(detail),
@@ -1440,7 +1434,7 @@ async fn handle_action(
             }
         }
         Action::EnterEditMode => {
-            if app.current_conversation.is_some() {
+            if app.current_conversation().is_some() {
                 app.enter_editing_mode();
             } else {
                 app.status_message = "Open a conversation first (Enter) or create one (n)".into();
@@ -1641,7 +1635,7 @@ async fn handle_action(
         Action::OpenPersonalityPicker => {
             if client.is_none() {
                 app.status_message = "Not connected — personality picker unavailable".into();
-            } else if app.current_conversation.is_none() {
+            } else if app.current_conversation().is_none() {
                 app.status_message =
                     "Open a conversation first (Enter) — personality is per-conversation".into();
             } else {
@@ -2077,8 +2071,7 @@ async fn init_background_tasks(
 /// open and empty otherwise. The command is set-replace, so an empty list tells
 /// the daemon to stop fanning any conversation's turn events to this connection.
 fn open_conversation_ids(app: &App) -> Vec<String> {
-    app.current_conversation
-        .as_ref()
+    app.current_conversation()
         .map(|c| vec![c.id.clone()])
         .unwrap_or_default()
 }
@@ -2337,7 +2330,7 @@ mod tests {
     #[test]
     fn open_conversation_ids_is_empty_with_nothing_open() {
         let app = App::new();
-        assert!(app.current_conversation.is_none());
+        assert!(app.current_conversation().is_none());
         // Set-replace semantics: an empty set tells the daemon to stop fanning
         // any conversation's turn events here (e.g. the initial connect, before
         // anything is opened).

--- a/src/main.rs
+++ b/src/main.rs
@@ -239,23 +239,6 @@ enum ReconnectState {
 const RECONNECT_INITIAL_SECS: u64 = 2;
 const RECONNECT_MAX_SECS: u64 = 30;
 
-/// The system refinement to attach on the next send for `conversation_id`,
-/// chosen by its `Adele:` level: `OnDemand` → brief/conversational/speakable;
-/// `Always` → speakable-but-full (don't shorten); `Disabled` → none. Pure
-/// decision the send path consults to choose the refinement string (empty =
-/// none).
-///
-/// The refinement prose + the level→refinement mapping now live in the shared
-/// `adele-voice-client-common` crate (desktop-assistant#274) so the GTK and TUI
-/// clients send byte-identical refinements. The shared helper returns
-/// `Option<&str>`; we keep this client's empty-string-means-none convention so
-/// the send call sites are untouched.
-fn refinement_for_send(app: &App, conversation_id: &str) -> &'static str {
-    app.adele_output_for(conversation_id)
-        .send_refinement()
-        .unwrap_or("")
-}
-
 fn next_backoff(prev_secs: u64) -> u64 {
     prev_secs.saturating_mul(2).min(RECONNECT_MAX_SECS)
 }
@@ -1946,53 +1929,69 @@ fn insert_dictated_text(app: &mut App, text: &str) {
 /// (which appends a transcript to the input, then submits via the same route),
 /// so both honor the staged model override and the same ack handling.
 ///
-/// The connected/streaming gates run BEFORE any state mutation
-/// (`App::prepare_submission`, TUI-2/TUI-7), and a failed send RPC rolls the
-/// optimistic transcript append back and refills the composer
-/// (`App::restore_failed_submission`).
+/// The send *decision* lives in the shared core (`UiMessage::SubmitPrompt`,
+/// Phase-2): it runs the streaming/empty gate (TUI-7), draws the user bubble
+/// optimistically, and — when accepted — hands back an [`Effect::SendPrompt`]
+/// for this executor to run as the actual RPC. Only the connection gate and the
+/// transport-specific RPC + override stay here. A failed send rolls the
+/// optimistic bubble back via `UiMessage::SendFailed` and refills the composer.
 async fn send_prompt_from_input(app: &mut App, connector: &Option<Rc<Connector>>) {
-    if let Some((conv_id, prompt)) = app.prepare_submission(connector.is_some())
-        && let Some(connector) = connector.as_ref()
-    {
-        let client = connector.client();
-        let override_selection = app.take_pending_override();
-        // Per the conversation's `Adele:` level (adele-tui#77) carry a system
-        // refinement so the reply is shaped for speech: OnDemand → brief and
-        // conversational; Always → speakable but full (not shortened); Disabled →
-        // none. It only refines the system prompt for THIS turn — never stored,
-        // never in the transcript.
-        let refinement = refinement_for_send(app, &conv_id);
-        // Use the command-channel `send_prompt_full` when a model override is
-        // staged (model picker) and/or a refinement applies; the high-level
-        // `send_prompt` carries neither. `as_commands()` is `Some` on both
-        // socket transports (UDS + WS) but `None` on D-Bus. The Connector's
-        // refinement helper already folds the refinement into the prompt over
-        // D-Bus, so the no-override voice-mode path works everywhere.
-        let result = match (override_selection, client.as_commands()) {
-            (Some(ovr), Some(commands)) => {
-                commands
-                    .send_prompt_full(&conv_id, &prompt, Some(ovr), refinement.to_string())
-                    .await
-            }
-            (Some(_), None) => {
-                app.status_message =
-                    "Model override isn't supported over D-Bus — sent without override".into();
-                connector
-                    .send_prompt_with_system_refinement(&conv_id, &prompt, refinement)
-                    .await
-            }
-            (None, _) => {
-                connector
-                    .send_prompt_with_system_refinement(&conv_id, &prompt, refinement)
-                    .await
-            }
-        };
-        match result {
-            Ok(task_id) => app.apply_prompt_ack(task_id, conv_id.clone()),
-            Err(e) => {
-                app.restore_failed_submission(&conv_id, &prompt);
-                app.status_message = format!("Send error: {e} (your text is preserved)");
-            }
+    // Connection gate: transport state the core doesn't own.
+    let Some(connector) = connector.as_ref() else {
+        app.status_message = "Not connected — message not sent (your text is preserved)".into();
+        return;
+    };
+    let prompt = app.textarea_content();
+    let effects = app.apply_core(UiMessage::SubmitPrompt { prompt });
+    let Some(Effect::SendPrompt {
+        conversation_id,
+        prompt,
+        system_refinement,
+    }) = effects
+        .into_iter()
+        .find(|e| matches!(e, Effect::SendPrompt { .. }))
+    else {
+        // Rejected (still streaming / empty / no open conversation): the core
+        // already surfaced any status message and left the composer untouched.
+        return;
+    };
+    // Accepted: the user bubble is drawn, so clear the composer and snap to the
+    // bottom, then run the RPC. `send_prompt_full` carries the staged model
+    // override (socket transports only); over D-Bus the refinement folds into the
+    // prompt, so the no-override voice path works everywhere. `system_refinement`
+    // is `None` when the conversation's `Adele:` level is Disabled.
+    app.clear_composer();
+    app.scroll_to_bottom();
+    let client = connector.client();
+    let refinement = system_refinement.as_deref().unwrap_or("");
+    let result = match (app.take_pending_override(), client.as_commands()) {
+        (Some(ovr), Some(commands)) => {
+            commands
+                .send_prompt_full(&conversation_id, &prompt, Some(ovr), refinement.to_string())
+                .await
+        }
+        (Some(_), None) => {
+            app.status_message =
+                "Model override isn't supported over D-Bus — sent without override".into();
+            connector
+                .send_prompt_with_system_refinement(&conversation_id, &prompt, refinement)
+                .await
+        }
+        (None, _) => {
+            connector
+                .send_prompt_with_system_refinement(&conversation_id, &prompt, refinement)
+                .await
+        }
+    };
+    match result {
+        Ok(task_id) => app.apply_prompt_ack(task_id, conversation_id),
+        Err(e) => {
+            let _ = app.apply_core(UiMessage::SendFailed {
+                conversation_id,
+                prompt: prompt.clone(),
+            });
+            app.set_composer(&prompt);
+            app.status_message = format!("Send error: {e} (your text is preserved)");
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -651,6 +651,12 @@ async fn run(
                     if key.kind == KeyEventKind::Release {
                         continue;
                     }
+                    // The help overlay is informational: while it's open, ANY key
+                    // dismisses it (and does nothing else).
+                    if app.show_help {
+                        app.show_help = false;
+                        continue;
+                    }
                     if let Some(action) = handle_key_event(key, &app.mode, app.tasks.visible) {
                         if action == Action::Dictate {
                             // Push-to-talk (adele-tui#77). Prefer the voice
@@ -1544,6 +1550,7 @@ async fn handle_action(
                 "Conversation list hidden (Ctrl+B to show)".into()
             };
         }
+        Action::ToggleHelp => app.toggle_help(),
         Action::SwitchConnection => {
             app.switch_requested = true;
             app.status_message = "Switching connection...".into();

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -21,12 +21,7 @@ use syntect::{
     util::LinesWithEndings,
 };
 
-const COLOR_HEADING: Color = Color::Rgb(166, 182, 255);
-const COLOR_CODE_FG: Color = Color::Rgb(244, 228, 188);
-const COLOR_CODE_BG: Color = Color::Rgb(40, 44, 56);
-const COLOR_LINK: Color = Color::Rgb(132, 204, 232);
-const COLOR_BLOCKQUOTE: Color = Color::Rgb(170, 178, 196);
-const COLOR_TABLE_BORDER: Color = Color::Rgb(82, 90, 110);
+use crate::theme::theme;
 
 /// Theme used for code-block syntax highlighting. `base16-ocean.dark` reads
 /// well on the dark TUI background and ships with syntect by default.
@@ -64,7 +59,7 @@ fn syntax_for_lang<'a>(syntaxes: &'a SyntaxSet, lang: Option<&str>) -> Option<&'
 
 fn synstyle_to_ratatui(style: SynStyle) -> Style {
     let fg = Color::Rgb(style.foreground.r, style.foreground.g, style.foreground.b);
-    let mut out = Style::default().fg(fg).bg(COLOR_CODE_BG);
+    let mut out = Style::default().fg(fg).bg(theme().code_bg);
     if style.font_style.contains(FontStyle::BOLD) {
         out = out.add_modifier(Modifier::BOLD);
     }
@@ -166,7 +161,7 @@ impl Renderer {
                 self.flush_line();
                 self.lines.push(Line::from(Span::styled(
                     "─".repeat(40),
-                    Style::default().fg(COLOR_TABLE_BORDER),
+                    Style::default().fg(theme().hint_sep),
                 )));
             }
             Event::TaskListMarker(checked) => {
@@ -357,7 +352,7 @@ impl Renderer {
     }
 
     fn push_inline_code(&mut self, code: &str) {
-        let style = Style::default().fg(COLOR_CODE_FG).bg(COLOR_CODE_BG);
+        let style = Style::default().fg(theme().code_fg).bg(theme().code_bg);
         self.in_code_span = true;
         self.current.push(Span::styled(format!("`{code}`"), style));
         self.in_code_span = false;
@@ -369,7 +364,9 @@ impl Renderer {
             self.current.push(Span::styled(text, style));
             self.current.push(Span::styled(
                 format!(" ({target})"),
-                Style::default().fg(COLOR_LINK).add_modifier(Modifier::DIM),
+                Style::default()
+                    .fg(theme().link)
+                    .add_modifier(Modifier::DIM),
             ));
         } else if self.table.as_ref().is_some_and(|t| t.in_cell) {
             // Cell text is collected into the current cell, not the line buffer.
@@ -388,13 +385,13 @@ impl Renderer {
                 HeadingLevel::H1 => Modifier::BOLD | Modifier::UNDERLINED,
                 _ => Modifier::BOLD,
             };
-            style = style.fg(COLOR_HEADING).add_modifier(extra);
+            style = style.fg(theme().title).add_modifier(extra);
         }
         if self.blockquote_depth > 0 {
-            style = style.fg(COLOR_BLOCKQUOTE).add_modifier(Modifier::ITALIC);
+            style = style.fg(theme().blockquote).add_modifier(Modifier::ITALIC);
         }
         if self.link_target.is_some() {
-            style = style.fg(COLOR_LINK).add_modifier(Modifier::UNDERLINED);
+            style = style.fg(theme().link).add_modifier(Modifier::UNDERLINED);
         }
         if !self.modifier.is_empty() {
             style = style.add_modifier(self.modifier);
@@ -404,7 +401,7 @@ impl Renderer {
 
     fn start_blockquote_line(&mut self) {
         self.current
-            .push(Span::styled("│ ", Style::default().fg(COLOR_BLOCKQUOTE)));
+            .push(Span::styled("│ ", Style::default().fg(theme().blockquote)));
     }
 
     fn flush_line(&mut self) {
@@ -444,11 +441,11 @@ impl Renderer {
                     let trimmed_line = raw_line.trim_end_matches('\n');
                     let mut spans: Vec<Span<'static>> = Vec::with_capacity(regions.len() + 2);
                     // Leading gutter so the bg covers a small left margin.
-                    spans.push(Span::styled(" ", Style::default().bg(COLOR_CODE_BG)));
+                    spans.push(Span::styled(" ", Style::default().bg(theme().code_bg)));
                     if regions.is_empty() {
                         spans.push(Span::styled(
                             trimmed_line.to_string(),
-                            Style::default().fg(COLOR_CODE_FG).bg(COLOR_CODE_BG),
+                            Style::default().fg(theme().code_fg).bg(theme().code_bg),
                         ));
                     } else {
                         for (style, segment) in regions {
@@ -461,13 +458,13 @@ impl Renderer {
                             spans.push(Span::styled(text, synstyle_to_ratatui(style)));
                         }
                     }
-                    spans.push(Span::styled(" ", Style::default().bg(COLOR_CODE_BG)));
+                    spans.push(Span::styled(" ", Style::default().bg(theme().code_bg)));
                     self.lines.push(Line::from(spans));
                 }
             }
             None => {
                 // Unknown language — fall back to the muted plain code style.
-                let style = Style::default().fg(COLOR_CODE_FG).bg(COLOR_CODE_BG);
+                let style = Style::default().fg(theme().code_fg).bg(theme().code_bg);
                 for raw_line in source.split('\n') {
                     self.lines
                         .push(Line::from(Span::styled(format!(" {raw_line} "), style)));
@@ -503,7 +500,7 @@ impl Renderer {
             }
         }
 
-        let border = Style::default().fg(COLOR_TABLE_BORDER);
+        let border = Style::default().fg(theme().hint_sep);
         for (row_idx, row) in t.rows.iter().enumerate() {
             let mut spans: Vec<Span<'static>> = Vec::new();
             for (col_idx, cell) in row.iter().enumerate() {
@@ -600,7 +597,7 @@ mod tests {
         let any_code_styled = lines
             .iter()
             .flat_map(|l| l.spans.iter())
-            .any(|s| s.style.bg == Some(COLOR_CODE_BG) && s.content.contains("let x = 1;"));
+            .any(|s| s.style.bg == Some(theme().code_bg) && s.content.contains("let x = 1;"));
         assert!(
             any_code_styled,
             "expected a span with code bg on the code line"
@@ -674,7 +671,7 @@ mod tests {
         let fgs: std::collections::HashSet<_> = lines
             .iter()
             .flat_map(|l| l.spans.iter())
-            .filter(|s| s.style.bg == Some(COLOR_CODE_BG) && !s.content.trim().is_empty())
+            .filter(|s| s.style.bg == Some(theme().code_bg) && !s.content.trim().is_empty())
             .filter_map(|s| s.style.fg)
             .collect();
         // Highlighted rust should produce more than one distinct fg color
@@ -692,7 +689,7 @@ mod tests {
         let plain_span = lines
             .iter()
             .flat_map(|l| l.spans.iter())
-            .any(|s| s.style.bg == Some(COLOR_CODE_BG) && s.content.contains("literal content"));
+            .any(|s| s.style.bg == Some(theme().code_bg) && s.content.contains("literal content"));
         assert!(plain_span);
     }
 
@@ -702,7 +699,7 @@ mod tests {
         let src = "```\nplain block content\n```\n";
         let lines = render_test(src);
         let plain_span = lines.iter().flat_map(|l| l.spans.iter()).any(|s| {
-            s.style.bg == Some(COLOR_CODE_BG) && s.content.contains("plain block content")
+            s.style.bg == Some(theme().code_bg) && s.content.contains("plain block content")
         });
         assert!(plain_span);
     }

--- a/src/model_selector.rs
+++ b/src/model_selector.rs
@@ -34,7 +34,12 @@ use ratatui::{
     widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph},
 };
 
+use crate::in_flight::InFlight;
 use crate::screen::Screen;
+
+/// Result of the off-loop `list_available_models` RPC (modal-freeze fix): the
+/// model list, or a user-facing error string.
+type ModelsResult = Result<Vec<ModelListing>, String>;
 
 const COLOR_BORDER: Color = Color::Rgb(82, 104, 173);
 const COLOR_TITLE: Color = Color::Rgb(166, 182, 255);
@@ -75,6 +80,9 @@ struct State {
 struct ModelSelectorScreen<'a> {
     state: State,
     client: &'a TransportClient,
+    /// In-flight `list_available_models` RPC, polled off the draw loop by
+    /// `poll_pending` so the picker never freezes during a (re)load.
+    pending: InFlight<'a, ModelsResult>,
 }
 
 impl Screen for ModelSelectorScreen<'_> {
@@ -84,12 +92,25 @@ impl Screen for ModelSelectorScreen<'_> {
         draw(frame, &self.state);
     }
 
-    async fn handle_key(&mut self, key: KeyEvent) {
-        handle_key(&mut self.state, key, self.client).await;
+    fn handle_key(&mut self, key: KeyEvent) -> impl std::future::Future<Output = ()> {
+        // Synchronous: a refresh enqueues an off-loop RPC into `pending` instead
+        // of awaiting it here, so the key handler never blocks the draw/input loop.
+        handle_key(&mut self.state, key, self.client, &mut self.pending);
+        std::future::ready(())
     }
 
     fn take_outcome(&mut self) -> Option<Outcome> {
         self.state.outcome.take()
+    }
+
+    fn has_pending(&self) -> bool {
+        !self.pending.is_empty()
+    }
+
+    async fn poll_pending(&mut self) {
+        if let Some(result) = self.pending.next().await {
+            apply_models_result(&mut self.state, result);
+        }
     }
 }
 
@@ -111,22 +132,29 @@ pub async fn run(
             outcome: None,
         },
         client,
+        pending: InFlight::new(),
     };
 
-    refresh(&mut screen.state, client, false).await;
-    seed_selection(&mut screen.state);
+    // Kick the initial load off-loop too, so the "Loading models…" line shows and
+    // the picker stays responsive while it lands (seeding happens on arrival).
+    refresh(&mut screen.state, &mut screen.pending, client, false);
 
     crate::screen::run_screen(terminal, &mut screen, signal_rx, sink).await
 }
 
-async fn handle_key(state: &mut State, key: KeyEvent, client: &TransportClient) {
+fn handle_key<'a>(
+    state: &mut State,
+    key: KeyEvent,
+    client: &'a TransportClient,
+    pending: &mut InFlight<'a, ModelsResult>,
+) {
     match (key.code, key.modifiers) {
         (KeyCode::Esc | KeyCode::Char('q'), m) if m.is_empty() => {
             state.outcome = Some(Outcome::Cancelled);
         }
         (KeyCode::Char('j') | KeyCode::Down, m) if m.is_empty() => advance(state, 1),
         (KeyCode::Char('k') | KeyCode::Up, m) if m.is_empty() => advance(state, -1),
-        (KeyCode::Char('r'), KeyModifiers::NONE) => refresh(state, client, true).await,
+        (KeyCode::Char('r'), KeyModifiers::NONE) => refresh(state, pending, client, true),
         (KeyCode::Enter, m) if m.is_empty() => {
             if let Some(model) = state.models.get(state.selected) {
                 state.outcome = Some(Outcome::Selected(SendPromptOverride {
@@ -158,30 +186,44 @@ fn advance(state: &mut State, delta: i32) {
     state.selected = idx as usize;
 }
 
-async fn refresh(state: &mut State, client: &TransportClient, refresh_cache: bool) {
-    let Some(commands) = client.as_commands() else {
-        state.error = Some(
-            "Model selection isn't available over D-Bus — switch transport with --transport ws or the local socket"
-                .into(),
-        );
-        state.busy = None;
-        return;
-    };
+/// Enqueue a model-list refresh as an off-loop RPC (modal-freeze fix). Sets the
+/// `busy` line and returns immediately; the result is applied by
+/// `apply_models_result` once `poll_pending` resolves it.
+fn refresh<'a>(
+    state: &mut State,
+    pending: &mut InFlight<'a, ModelsResult>,
+    client: &'a TransportClient,
+    refresh_cache: bool,
+) {
     state.busy = Some(if refresh_cache {
         "Refreshing models from daemon...".into()
     } else {
         "Loading models...".into()
     });
-    match commands.list_available_models(None, refresh_cache).await {
+    pending.push(async move {
+        match client.as_commands() {
+            Some(commands) => commands
+                .list_available_models(None, refresh_cache)
+                .await
+                .map_err(|e| format!("Failed to load models: {e}")),
+            None => Err(
+                "Model selection isn't available over D-Bus — switch transport with --transport ws or the local socket"
+                    .into(),
+            ),
+        }
+    });
+}
+
+/// Apply a resolved model-list RPC to the picker state.
+fn apply_models_result(state: &mut State, result: ModelsResult) {
+    state.busy = None;
+    match result {
         Ok(models) => {
             state.models = models;
-            state.busy = None;
+            state.error = None;
             seed_selection(state);
         }
-        Err(e) => {
-            state.error = Some(format!("Failed to load models: {e}"));
-            state.busy = None;
-        }
+        Err(e) => state.error = Some(e),
     }
 }
 

--- a/src/model_selector.rs
+++ b/src/model_selector.rs
@@ -29,7 +29,7 @@ use ratatui::{
     Frame, Terminal,
     backend::CrosstermBackend,
     layout::{Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph},
 };
@@ -41,15 +41,7 @@ use crate::screen::Screen;
 /// model list, or a user-facing error string.
 type ModelsResult = Result<Vec<ModelListing>, String>;
 
-const COLOR_BORDER: Color = Color::Rgb(82, 104, 173);
-const COLOR_TITLE: Color = Color::Rgb(166, 182, 255);
-const COLOR_HINT_KEY: Color = Color::Rgb(216, 223, 236);
-const COLOR_HINT_DESC: Color = Color::Rgb(143, 153, 174);
-const COLOR_HINT_SEP: Color = Color::Rgb(82, 90, 110);
-const COLOR_LIST_HIGHLIGHT: Color = Color::Rgb(72, 102, 180);
-const COLOR_LIST_HIGHLIGHT_FG: Color = Color::Rgb(245, 248, 255);
-const COLOR_ERROR: Color = Color::Rgb(232, 130, 130);
-const COLOR_CURRENT_PICK: Color = Color::Rgb(255, 207, 119);
+use crate::theme::theme;
 
 /// Outcome of running the picker.
 #[derive(Default)]
@@ -283,20 +275,20 @@ fn draw_header(f: &mut Frame, state: &State, area: Rect) {
     let mut lines = vec![Line::from(Span::styled(
         "Pick a model for this conversation",
         Style::default()
-            .fg(COLOR_TITLE)
+            .fg(theme().title)
             .add_modifier(Modifier::BOLD),
     ))];
     if let Some(current) = &state.current {
         lines.push(Line::from(Span::styled(
             format!("Current: {} · {}", current.connection_id, current.model_id),
             Style::default()
-                .fg(COLOR_CURRENT_PICK)
+                .fg(theme().pinned)
                 .add_modifier(Modifier::ITALIC),
         )));
     } else {
         lines.push(Line::from(Span::styled(
             "Current: (none — daemon will use the interactive purpose default)",
-            Style::default().fg(COLOR_HINT_DESC),
+            Style::default().fg(theme().text_dim),
         )));
     }
     f.render_widget(Paragraph::new(lines), area);
@@ -306,7 +298,7 @@ fn draw_list(f: &mut Frame, state: &State, area: Rect) {
     let items: Vec<ListItem> = if state.models.is_empty() {
         vec![ListItem::new(Line::from(Span::styled(
             "(no models — configure connections via F3 first)",
-            Style::default().fg(COLOR_HINT_DESC),
+            Style::default().fg(theme().text_dim),
         )))]
     } else {
         state
@@ -318,7 +310,7 @@ fn draw_list(f: &mut Frame, state: &State, area: Rect) {
                     c.connection_id == listing.connection_id && c.model_id == listing.model.id
                 });
                 if is_current {
-                    spans.push(Span::styled("★ ", Style::default().fg(COLOR_CURRENT_PICK)));
+                    spans.push(Span::styled("★ ", Style::default().fg(theme().pinned)));
                 } else {
                     spans.push(Span::raw("  "));
                 }
@@ -326,12 +318,12 @@ fn draw_list(f: &mut Frame, state: &State, area: Rect) {
                     listing.connection_label.clone(),
                     Style::default().add_modifier(Modifier::BOLD),
                 ));
-                spans.push(Span::styled("  ·  ", Style::default().fg(COLOR_HINT_SEP)));
+                spans.push(Span::styled("  ·  ", Style::default().fg(theme().hint_sep)));
                 spans.push(Span::styled(listing.model.id.clone(), Style::default()));
                 if listing.model.display_name != listing.model.id {
                     spans.push(Span::styled(
                         format!("  ({})", listing.model.display_name),
-                        Style::default().fg(COLOR_HINT_DESC),
+                        Style::default().fg(theme().text_dim),
                     ));
                 }
                 ListItem::new(Line::from(spans))
@@ -349,18 +341,18 @@ fn draw_list(f: &mut Frame, state: &State, area: Rect) {
         .block(
             Block::default()
                 .borders(Borders::ALL)
-                .border_style(Style::default().fg(COLOR_BORDER))
+                .border_style(Style::default().fg(theme().border))
                 .title(Line::from(Span::styled(
                     title,
                     Style::default()
-                        .fg(COLOR_TITLE)
+                        .fg(theme().title)
                         .add_modifier(Modifier::BOLD),
                 ))),
         )
         .highlight_style(
             Style::default()
-                .bg(COLOR_LIST_HIGHLIGHT)
-                .fg(COLOR_LIST_HIGHLIGHT_FG)
+                .bg(theme().list_highlight)
+                .fg(theme().list_highlight_fg)
                 .add_modifier(Modifier::BOLD),
         )
         .highlight_symbol("▸ ");
@@ -375,14 +367,14 @@ fn draw_list(f: &mut Frame, state: &State, area: Rect) {
 fn draw_status(f: &mut Frame, state: &State, area: Rect) {
     if let Some(busy) = &state.busy {
         let style = Style::default()
-            .fg(Color::Rgb(178, 220, 245))
+            .fg(theme().assistant_indicator)
             .add_modifier(Modifier::ITALIC);
         f.render_widget(
             Paragraph::new(Span::styled(format!(" ● {busy}"), style)),
             area,
         );
     } else if let Some(err) = &state.error {
-        let style = Style::default().fg(COLOR_ERROR);
+        let style = Style::default().fg(theme().error);
         f.render_widget(
             Paragraph::new(Span::styled(format!(" • {err}"), style)),
             area,
@@ -395,18 +387,18 @@ fn draw_hints(f: &mut Frame, area: Rect) {
     let mut spans: Vec<Span> = Vec::new();
     for (idx, (key, desc)) in hints.iter().enumerate() {
         if idx > 0 {
-            spans.push(Span::styled("  ·  ", Style::default().fg(COLOR_HINT_SEP)));
+            spans.push(Span::styled("  ·  ", Style::default().fg(theme().hint_sep)));
         }
         spans.push(Span::styled(
             (*key).to_string(),
             Style::default()
-                .fg(COLOR_HINT_KEY)
+                .fg(theme().hint_key)
                 .add_modifier(Modifier::BOLD),
         ));
         spans.push(Span::raw(" "));
         spans.push(Span::styled(
             (*desc).to_string(),
-            Style::default().fg(COLOR_HINT_DESC),
+            Style::default().fg(theme().text_dim),
         ));
     }
     f.render_widget(Paragraph::new(Line::from(spans)), area);

--- a/src/personality_selector.rs
+++ b/src/personality_selector.rs
@@ -28,7 +28,7 @@ use ratatui::{
     Frame, Terminal,
     backend::CrosstermBackend,
     layout::{Constraint, Direction, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph},
 };
@@ -40,16 +40,7 @@ use crate::screen::Screen;
 /// the stored override, or a user-facing error string.
 type SaveResult = Result<ConversationPersonalityView, String>;
 
-const COLOR_BORDER: Color = Color::Rgb(82, 104, 173);
-const COLOR_TITLE: Color = Color::Rgb(166, 182, 255);
-const COLOR_HINT_KEY: Color = Color::Rgb(216, 223, 236);
-const COLOR_HINT_DESC: Color = Color::Rgb(143, 153, 174);
-const COLOR_HINT_SEP: Color = Color::Rgb(82, 90, 110);
-const COLOR_LIST_HIGHLIGHT: Color = Color::Rgb(72, 102, 180);
-const COLOR_LIST_HIGHLIGHT_FG: Color = Color::Rgb(245, 248, 255);
-const COLOR_ERROR: Color = Color::Rgb(232, 130, 130);
-const COLOR_GLOBAL: Color = Color::Rgb(143, 153, 174);
-const COLOR_PINNED: Color = Color::Rgb(255, 207, 119);
+use crate::theme::theme;
 
 /// The seven traits in their canonical wire order. Each entry pairs a display
 /// label with getters/setters into a [`ConversationPersonalityView`], so the
@@ -343,12 +334,12 @@ fn draw_header(f: &mut Frame, area: Rect) {
         Line::from(Span::styled(
             "Personality for this conversation",
             Style::default()
-                .fg(COLOR_TITLE)
+                .fg(theme().title)
                 .add_modifier(Modifier::BOLD),
         )),
         Line::from(Span::styled(
             "Global inherits your default; any level pins it here.",
-            Style::default().fg(COLOR_HINT_DESC),
+            Style::default().fg(theme().text_dim),
         )),
     ];
     f.render_widget(Paragraph::new(lines), area);
@@ -361,10 +352,10 @@ fn draw_list(f: &mut Frame, state: &State, area: Rect) {
         .map(|t| {
             let level = (t.get)(&state.draft);
             let value_style = if level.is_none() {
-                Style::default().fg(COLOR_GLOBAL)
+                Style::default().fg(theme().text_dim)
             } else {
                 Style::default()
-                    .fg(COLOR_PINNED)
+                    .fg(theme().pinned)
                     .add_modifier(Modifier::BOLD)
             };
             let spans = vec![
@@ -373,9 +364,9 @@ fn draw_list(f: &mut Frame, state: &State, area: Rect) {
                     Style::default().add_modifier(Modifier::BOLD),
                 ),
                 Span::styled("   ", Style::default()),
-                Span::styled("◂ ", Style::default().fg(COLOR_HINT_SEP)),
+                Span::styled("◂ ", Style::default().fg(theme().hint_sep)),
                 Span::styled(format!("{:^9}", level_label(level)), value_style),
-                Span::styled(" ▸", Style::default().fg(COLOR_HINT_SEP)),
+                Span::styled(" ▸", Style::default().fg(theme().hint_sep)),
             ];
             ListItem::new(Line::from(spans))
         })
@@ -385,18 +376,18 @@ fn draw_list(f: &mut Frame, state: &State, area: Rect) {
         .block(
             Block::default()
                 .borders(Borders::ALL)
-                .border_style(Style::default().fg(COLOR_BORDER))
+                .border_style(Style::default().fg(theme().border))
                 .title(Line::from(Span::styled(
                     "Traits",
                     Style::default()
-                        .fg(COLOR_TITLE)
+                        .fg(theme().title)
                         .add_modifier(Modifier::BOLD),
                 ))),
         )
         .highlight_style(
             Style::default()
-                .bg(COLOR_LIST_HIGHLIGHT)
-                .fg(COLOR_LIST_HIGHLIGHT_FG)
+                .bg(theme().list_highlight)
+                .fg(theme().list_highlight_fg)
                 .add_modifier(Modifier::BOLD),
         )
         .highlight_symbol("▸ ");
@@ -409,14 +400,14 @@ fn draw_list(f: &mut Frame, state: &State, area: Rect) {
 fn draw_status(f: &mut Frame, state: &State, area: Rect) {
     if let Some(busy) = &state.busy {
         let style = Style::default()
-            .fg(Color::Rgb(178, 220, 245))
+            .fg(theme().assistant_indicator)
             .add_modifier(Modifier::ITALIC);
         f.render_widget(
             Paragraph::new(Span::styled(format!(" ● {busy}"), style)),
             area,
         );
     } else if let Some(err) = &state.error {
-        let style = Style::default().fg(COLOR_ERROR);
+        let style = Style::default().fg(theme().error);
         f.render_widget(
             Paragraph::new(Span::styled(format!(" • {err}"), style)),
             area,
@@ -434,18 +425,18 @@ fn draw_hints(f: &mut Frame, area: Rect) {
     let mut spans: Vec<Span> = Vec::new();
     for (idx, (key, desc)) in hints.iter().enumerate() {
         if idx > 0 {
-            spans.push(Span::styled("  ·  ", Style::default().fg(COLOR_HINT_SEP)));
+            spans.push(Span::styled("  ·  ", Style::default().fg(theme().hint_sep)));
         }
         spans.push(Span::styled(
             (*key).to_string(),
             Style::default()
-                .fg(COLOR_HINT_KEY)
+                .fg(theme().hint_key)
                 .add_modifier(Modifier::BOLD),
         ));
         spans.push(Span::raw(" "));
         spans.push(Span::styled(
             (*desc).to_string(),
-            Style::default().fg(COLOR_HINT_DESC),
+            Style::default().fg(theme().text_dim),
         ));
     }
     f.render_widget(Paragraph::new(Line::from(spans)), area);

--- a/src/personality_selector.rs
+++ b/src/personality_selector.rs
@@ -33,7 +33,12 @@ use ratatui::{
     widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph},
 };
 
+use crate::in_flight::InFlight;
 use crate::screen::Screen;
+
+/// Result of the off-loop `set_conversation_personality` RPC (modal-freeze fix):
+/// the stored override, or a user-facing error string.
+type SaveResult = Result<ConversationPersonalityView, String>;
 
 const COLOR_BORDER: Color = Color::Rgb(82, 104, 173);
 const COLOR_TITLE: Color = Color::Rgb(166, 182, 255);
@@ -158,6 +163,9 @@ struct State {
 struct PersonalityScreen<'a> {
     state: State,
     client: &'a TransportClient,
+    /// In-flight `set_conversation_personality` RPC, polled off the draw loop by
+    /// `poll_pending` so the picker never freezes while saving.
+    pending: InFlight<'a, SaveResult>,
 }
 
 impl Screen for PersonalityScreen<'_> {
@@ -167,12 +175,25 @@ impl Screen for PersonalityScreen<'_> {
         draw(frame, &self.state);
     }
 
-    async fn handle_key(&mut self, key: KeyEvent) {
-        handle_key(&mut self.state, key, self.client).await;
+    fn handle_key(&mut self, key: KeyEvent) -> impl std::future::Future<Output = ()> {
+        // Synchronous: a save enqueues an off-loop RPC into `pending` instead of
+        // awaiting it here, so the key handler never blocks the draw/input loop.
+        handle_key(&mut self.state, key, self.client, &mut self.pending);
+        std::future::ready(())
     }
 
     fn take_outcome(&mut self) -> Option<Outcome> {
         self.state.outcome.take()
+    }
+
+    fn has_pending(&self) -> bool {
+        !self.pending.is_empty()
+    }
+
+    async fn poll_pending(&mut self) {
+        if let Some(result) = self.pending.next().await {
+            apply_save_result(&mut self.state, result);
+        }
     }
 }
 
@@ -194,12 +215,18 @@ pub async fn run(
             outcome: None,
         },
         client,
+        pending: InFlight::new(),
     };
 
     crate::screen::run_screen(terminal, &mut screen, signal_rx, sink).await
 }
 
-async fn handle_key(state: &mut State, key: KeyEvent, client: &TransportClient) {
+fn handle_key<'a>(
+    state: &mut State,
+    key: KeyEvent,
+    client: &'a TransportClient,
+    pending: &mut InFlight<'a, SaveResult>,
+) {
     match (key.code, key.modifiers) {
         (KeyCode::Esc | KeyCode::Char('q'), m) if m.is_empty() => {
             state.outcome = Some(Outcome::Cancelled);
@@ -208,7 +235,7 @@ async fn handle_key(state: &mut State, key: KeyEvent, client: &TransportClient) 
         (KeyCode::Char('k') | KeyCode::Up, m) if m.is_empty() => advance(state, -1),
         (KeyCode::Char('l') | KeyCode::Right, m) if m.is_empty() => cycle_selected(state, true),
         (KeyCode::Char('h') | KeyCode::Left, m) if m.is_empty() => cycle_selected(state, false),
-        (KeyCode::Enter, m) if m.is_empty() => save(state, client).await,
+        (KeyCode::Enter, m) if m.is_empty() => save(state, pending, client),
         _ => {}
     }
 }
@@ -239,28 +266,39 @@ fn cycle_selected(state: &mut State, forward: bool) {
     (t.set)(&mut state.draft, next);
 }
 
-async fn save(state: &mut State, client: &TransportClient) {
-    let Some(commands) = client.as_commands() else {
-        state.error = Some(
-            "Personality selection isn't available over D-Bus — switch transport with --transport ws or the local socket"
-                .into(),
-        );
-        return;
-    };
+/// Enqueue a personality save as an off-loop RPC (modal-freeze fix). Sets the
+/// `busy` line and returns immediately; the result is applied by
+/// `apply_save_result` once `poll_pending` resolves it.
+fn save<'a>(
+    state: &mut State,
+    pending: &mut InFlight<'a, SaveResult>,
+    client: &'a TransportClient,
+) {
     state.busy = Some("Saving personality...".into());
     state.error = None;
-    match commands
-        .set_conversation_personality(&state.conversation_id, state.draft)
-        .await
-    {
-        Ok(stored) => {
-            state.busy = None;
-            state.outcome = Some(Outcome::Saved(stored));
+    let conversation_id = state.conversation_id.clone();
+    let draft = state.draft;
+    pending.push(async move {
+        match client.as_commands() {
+            Some(commands) => commands
+                .set_conversation_personality(&conversation_id, draft)
+                .await
+                .map_err(|e| format!("Failed to save personality: {e}")),
+            None => Err(
+                "Personality selection isn't available over D-Bus — switch transport with --transport ws or the local socket"
+                    .into(),
+            ),
         }
-        Err(e) => {
-            state.busy = None;
-            state.error = Some(format!("Failed to save personality: {e}"));
-        }
+    });
+}
+
+/// Apply a resolved personality-save RPC to the picker state. On success this
+/// sets the `Saved` outcome, which closes the screen on the next loop turn.
+fn apply_save_result(state: &mut State, result: SaveResult) {
+    state.busy = None;
+    match result {
+        Ok(stored) => state.outcome = Some(Outcome::Saved(stored)),
+        Err(e) => state.error = Some(e),
     }
 }
 

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -25,15 +25,7 @@ use crate::{
     profile::{Profile, ProfileStore},
 };
 
-const COLOR_BORDER: Color = Color::Rgb(82, 104, 173);
-const COLOR_BORDER_ACTIVE: Color = Color::Rgb(120, 183, 109);
-const COLOR_TITLE: Color = Color::Rgb(166, 182, 255);
-const COLOR_HINT_KEY: Color = Color::Rgb(216, 223, 236);
-const COLOR_HINT_DESC: Color = Color::Rgb(143, 153, 174);
-const COLOR_HINT_SEP: Color = Color::Rgb(82, 90, 110);
-const COLOR_LIST_HIGHLIGHT: Color = Color::Rgb(72, 102, 180);
-const COLOR_LIST_HIGHLIGHT_FG: Color = Color::Rgb(245, 248, 255);
-const COLOR_ERROR: Color = Color::Rgb(232, 130, 130);
+use crate::theme::theme;
 
 /// Outcome of running the picker.
 pub enum PickerOutcome {
@@ -662,12 +654,12 @@ fn draw_header(f: &mut Frame, area: Rect) {
         Line::from(Span::styled(
             "Adele connection profiles",
             Style::default()
-                .fg(COLOR_TITLE)
+                .fg(theme().title)
                 .add_modifier(Modifier::BOLD),
         )),
         Line::from(Span::styled(
             "Pick a daemon to connect to, or create a new profile.",
-            Style::default().fg(COLOR_HINT_DESC),
+            Style::default().fg(theme().text_dim),
         )),
     ]);
     f.render_widget(title, area);
@@ -677,7 +669,7 @@ fn draw_list(f: &mut Frame, state: &PickerState, area: Rect) {
     let items: Vec<ListItem> = if state.store.profiles.is_empty() {
         vec![ListItem::new(Line::from(Span::styled(
             "(no saved profiles — press 'a' to add one)",
-            Style::default().fg(COLOR_HINT_DESC),
+            Style::default().fg(theme().text_dim),
         )))]
     } else {
         state
@@ -688,10 +680,7 @@ fn draw_list(f: &mut Frame, state: &PickerState, area: Rect) {
             .map(|(idx, p)| {
                 let mut spans: Vec<Span<'static>> = Vec::new();
                 if state.store.last_used_index() == Some(idx) {
-                    spans.push(Span::styled(
-                        "★ ",
-                        Style::default().fg(Color::Rgb(255, 207, 119)),
-                    ));
+                    spans.push(Span::styled("★ ", Style::default().fg(theme().pinned)));
                 }
                 spans.push(Span::styled(p.display_label(), Style::default()));
                 ListItem::new(Line::from(spans))
@@ -703,18 +692,18 @@ fn draw_list(f: &mut Frame, state: &PickerState, area: Rect) {
         .block(
             Block::default()
                 .borders(Borders::ALL)
-                .border_style(Style::default().fg(COLOR_BORDER))
+                .border_style(Style::default().fg(theme().border))
                 .title(Line::from(Span::styled(
                     "Profiles",
                     Style::default()
-                        .fg(COLOR_TITLE)
+                        .fg(theme().title)
                         .add_modifier(Modifier::BOLD),
                 ))),
         )
         .highlight_style(
             Style::default()
-                .bg(COLOR_LIST_HIGHLIGHT)
-                .fg(COLOR_LIST_HIGHLIGHT_FG)
+                .bg(theme().list_highlight)
+                .fg(theme().list_highlight_fg)
                 .add_modifier(Modifier::BOLD),
         )
         .highlight_symbol("▸ ");
@@ -729,7 +718,7 @@ fn draw_list(f: &mut Frame, state: &PickerState, area: Rect) {
 fn draw_form(f: &mut Frame, state: &PickerState, area: Rect) {
     let block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(COLOR_BORDER))
+        .border_style(Style::default().fg(theme().border))
         .title(Line::from(Span::styled(
             if state.form.editing_id.is_some() {
                 "Edit profile"
@@ -737,7 +726,7 @@ fn draw_form(f: &mut Frame, state: &PickerState, area: Rect) {
                 "New profile"
             },
             Style::default()
-                .fg(COLOR_TITLE)
+                .fg(theme().title)
                 .add_modifier(Modifier::BOLD),
         )));
     let inner = block.inner(area);
@@ -829,10 +818,10 @@ fn draw_form(f: &mut Frame, state: &PickerState, area: Rect) {
 fn draw_field_label(f: &mut Frame, area: Rect, label: &str, focused: bool) {
     let style = if focused {
         Style::default()
-            .fg(COLOR_BORDER_ACTIVE)
+            .fg(theme().border_active)
             .add_modifier(Modifier::BOLD)
     } else {
-        Style::default().fg(COLOR_HINT_DESC)
+        Style::default().fg(theme().text_dim)
     };
     f.render_widget(Paragraph::new(Span::styled(label.to_string(), style)), area);
 }
@@ -840,9 +829,9 @@ fn draw_field_label(f: &mut Frame, area: Rect, label: &str, focused: bool) {
 fn draw_text_field(f: &mut Frame, area: Rect, textarea: &TextArea<'static>, focused: bool) {
     let mut ta = textarea.clone();
     let border_color = if focused {
-        COLOR_BORDER_ACTIVE
+        theme().border_active
     } else {
-        COLOR_BORDER
+        theme().border
     };
     ta.set_block(
         Block::default()
@@ -855,9 +844,9 @@ fn draw_text_field(f: &mut Frame, area: Rect, textarea: &TextArea<'static>, focu
 fn draw_transport_toggle(f: &mut Frame, area: Rect, state: &PickerState) {
     let focused = state.form.focus == Field::Transport;
     let border_color = if focused {
-        COLOR_BORDER_ACTIVE
+        theme().border_active
     } else {
-        COLOR_BORDER
+        theme().border
     };
     let block = Block::default()
         .borders(Borders::ALL)
@@ -869,10 +858,10 @@ fn draw_transport_toggle(f: &mut Frame, area: Rect, state: &PickerState) {
         let style = if selected {
             Style::default()
                 .fg(Color::Black)
-                .bg(COLOR_BORDER_ACTIVE)
+                .bg(theme().border_active)
                 .add_modifier(Modifier::BOLD)
         } else {
-            Style::default().fg(COLOR_HINT_DESC)
+            Style::default().fg(theme().text_dim)
         };
         Span::styled(format!(" {label} "), style)
     };
@@ -905,11 +894,11 @@ fn draw_delete_overlay(f: &mut Frame, state: &PickerState, area: Rect) {
     f.render_widget(Clear, popup);
     let block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Rgb(232, 130, 130)))
+        .border_style(Style::default().fg(theme().error))
         .title(Line::from(Span::styled(
             "Delete profile",
             Style::default()
-                .fg(Color::Rgb(255, 200, 200))
+                .fg(theme().error_text)
                 .add_modifier(Modifier::BOLD),
         )));
     let inner = block.inner(popup);
@@ -921,7 +910,7 @@ fn draw_delete_overlay(f: &mut Frame, state: &PickerState, area: Rect) {
         )),
         Line::from(Span::styled(
             "y/Enter = confirm · any other key = cancel",
-            Style::default().fg(COLOR_HINT_DESC),
+            Style::default().fg(theme().text_dim),
         )),
     ])
     .wrap(Wrap { trim: true });
@@ -931,14 +920,14 @@ fn draw_delete_overlay(f: &mut Frame, state: &PickerState, area: Rect) {
 fn draw_error(f: &mut Frame, state: &PickerState, area: Rect) {
     if let Some(busy) = &state.busy {
         let style = Style::default()
-            .fg(Color::Rgb(178, 220, 245))
+            .fg(theme().assistant_indicator)
             .add_modifier(Modifier::ITALIC);
         f.render_widget(
             Paragraph::new(Span::styled(format!(" ● {busy}"), style)),
             area,
         );
     } else if let Some(err) = &state.error {
-        let style = Style::default().fg(COLOR_ERROR);
+        let style = Style::default().fg(theme().error);
         f.render_widget(
             Paragraph::new(Span::styled(format!(" • {err}"), style)),
             area,
@@ -967,18 +956,18 @@ fn draw_hints(f: &mut Frame, state: &PickerState, area: Rect) {
     let mut spans: Vec<Span> = Vec::with_capacity(hints.len() * 4);
     for (idx, (key, desc)) in hints.iter().enumerate() {
         if idx > 0 {
-            spans.push(Span::styled("  ·  ", Style::default().fg(COLOR_HINT_SEP)));
+            spans.push(Span::styled("  ·  ", Style::default().fg(theme().hint_sep)));
         }
         spans.push(Span::styled(
             (*key).to_string(),
             Style::default()
-                .fg(COLOR_HINT_KEY)
+                .fg(theme().hint_key)
                 .add_modifier(Modifier::BOLD),
         ));
         spans.push(Span::raw(" "));
         spans.push(Span::styled(
             (*desc).to_string(),
-            Style::default().fg(COLOR_HINT_DESC),
+            Style::default().fg(theme().text_dim),
         ));
     }
     f.render_widget(Paragraph::new(Line::from(spans)), area);

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -381,6 +381,24 @@ fn advance_selection(state: &mut PickerState, delta: i32) {
     state.selected = idx as usize;
 }
 
+/// Validate and commit the connection form: on success, store the profile and
+/// return to the list; on failure, surface the validation error in place.
+/// Shared by the Enter key and the Ctrl+S accelerator.
+fn submit_form(state: &mut PickerState) {
+    match state.form.submit() {
+        Ok(submitted) => {
+            if let Err(e) = apply_submission(state, submitted) {
+                state.error = Some(e);
+            } else {
+                state.error = None;
+                state.mode = Mode::List;
+                state.form = FormState::empty();
+            }
+        }
+        Err(msg) => state.error = Some(msg),
+    }
+}
+
 fn handle_form_key(state: &mut PickerState, key: KeyEvent) {
     // Ctrl+L: launch OAuth flow against the URL currently in the form.
     if key.code == KeyCode::Char('l') && key.modifiers.contains(KeyModifiers::CONTROL) {
@@ -392,6 +410,15 @@ fn handle_form_key(state: &mut PickerState, key: KeyEvent) {
             state.error =
                 Some("OAuth requires a WebSocket URL — fill in the URL field first".into());
         }
+        return;
+    }
+
+    // Ctrl+S saves the form — the universal "submit a form" accelerator shared
+    // with the modal screens (KB / connections / purposes). There a multi-line
+    // field makes Enter a newline, so Ctrl+S is the only save key; here the
+    // fields are single-line so Enter also saves, but Ctrl+S works everywhere.
+    if key.code == KeyCode::Char('s') && key.modifiers.contains(KeyModifiers::CONTROL) {
+        submit_form(state);
         return;
     }
 
@@ -414,18 +441,7 @@ fn handle_form_key(state: &mut PickerState, key: KeyEvent) {
         (KeyCode::BackTab, _) => state.form.prev_field(),
         (KeyCode::Up, m) if m.is_empty() => state.form.prev_field(),
         (KeyCode::Down, m) if m.is_empty() => state.form.next_field(),
-        (KeyCode::Enter, m) if m.is_empty() => match state.form.submit() {
-            Ok(submitted) => {
-                if let Err(e) = apply_submission(state, submitted) {
-                    state.error = Some(e);
-                } else {
-                    state.error = None;
-                    state.mode = Mode::List;
-                    state.form = FormState::empty();
-                }
-            }
-            Err(msg) => state.error = Some(msg),
-        },
+        (KeyCode::Enter, m) if m.is_empty() => submit_form(state),
         // Transport field cycles Local → WebSocket → D-Bus with left/right
         // (space steps forward).
         (KeyCode::Right | KeyCode::Char(' '), _) if state.form.focus == Field::Transport => {
@@ -951,7 +967,7 @@ fn draw_hints(f: &mut Frame, state: &PickerState, area: Rect) {
         ],
         Mode::Form => &[
             ("Tab", "next field"),
-            ("Enter", "save"),
+            ("Enter/Ctrl+S", "save"),
             ("Ctrl+L", "OAuth sign-in"),
             ("Esc", "back"),
         ],
@@ -1027,6 +1043,15 @@ mod tests {
         KeyEvent {
             code,
             modifiers: KeyModifiers::NONE,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::NONE,
+        }
+    }
+
+    fn ctrl(code: KeyCode) -> KeyEvent {
+        KeyEvent {
+            code,
+            modifiers: KeyModifiers::CONTROL,
             kind: KeyEventKind::Press,
             state: KeyEventState::NONE,
         }
@@ -1123,6 +1148,33 @@ mod tests {
         handle_form_key(&mut state, key(KeyCode::Enter));
         assert!(state.error.is_some());
         assert_eq!(state.mode, Mode::Form);
+    }
+
+    #[test]
+    fn form_ctrl_s_saves_like_enter() {
+        // Ctrl+S is the universal form-save accelerator (it's the only save key
+        // in the multi-line modal forms); on a valid form it must commit the
+        // profile and return to the list, exactly as Enter does here.
+        let mut state = make_state(vec![]);
+        state.mode = Mode::Form;
+        state.form.name.insert_str("My Conn"); // UDS default needs only a name
+        handle_form_key(&mut state, ctrl(KeyCode::Char('s')));
+        assert_eq!(state.store.profiles.len(), 1);
+        assert_eq!(state.store.profiles[0].name, "My Conn");
+        assert_eq!(state.mode, Mode::List);
+        assert!(state.error.is_none());
+    }
+
+    #[test]
+    fn form_ctrl_s_on_blank_form_records_error_like_enter() {
+        // And it routes through the same validation: a blank form errors in
+        // place rather than committing.
+        let mut state = make_state(vec![]);
+        state.mode = Mode::Form;
+        handle_form_key(&mut state, ctrl(KeyCode::Char('s')));
+        assert!(state.error.is_some());
+        assert_eq!(state.mode, Mode::Form);
+        assert!(state.store.profiles.is_empty());
     }
 
     #[test]

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -613,7 +613,12 @@ fn handle_delete_key(state: &mut PickerState, key: KeyEvent) {
                 state.form = FormState::empty();
             }
         }
-        _ => state.mode = Mode::List,
+        // A destructive confirm is dismissed only by an explicit cancel
+        // (n/Esc); any other key is ignored rather than silently closing it.
+        (KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc, _) => {
+            state.mode = Mode::List;
+        }
+        _ => {}
     }
 }
 
@@ -909,7 +914,7 @@ fn draw_delete_overlay(f: &mut Frame, state: &PickerState, area: Rect) {
             Style::default().fg(Color::White),
         )),
         Line::from(Span::styled(
-            "y/Enter = confirm · any other key = cancel",
+            "y/Enter = confirm · n/Esc = cancel",
             Style::default().fg(theme().text_dim),
         )),
     ])
@@ -950,7 +955,7 @@ fn draw_hints(f: &mut Frame, state: &PickerState, area: Rect) {
             ("Ctrl+L", "OAuth sign-in"),
             ("Esc", "back"),
         ],
-        Mode::DeleteConfirm => &[("y/Enter", "confirm"), ("any", "cancel")],
+        Mode::DeleteConfirm => &[("y/Enter", "confirm"), ("n/Esc", "cancel")],
     };
 
     let mut spans: Vec<Span> = Vec::with_capacity(hints.len() * 4);
@@ -1137,7 +1142,7 @@ mod tests {
     }
 
     #[test]
-    fn delete_confirm_other_key_cancels() {
+    fn delete_confirm_n_cancels() {
         let p = Profile::new(
             "Local".into(),
             TransportMode::Ws,
@@ -1149,5 +1154,37 @@ mod tests {
         handle_delete_key(&mut state, key(KeyCode::Char('n')));
         assert_eq!(state.store.profiles.len(), 1);
         assert_eq!(state.mode, Mode::List);
+    }
+
+    #[test]
+    fn delete_confirm_esc_cancels() {
+        let p = Profile::new(
+            "Local".into(),
+            TransportMode::Ws,
+            "ws://x".into(),
+            "s".into(),
+        );
+        let mut state = make_state(vec![p]);
+        state.mode = Mode::DeleteConfirm;
+        handle_delete_key(&mut state, key(KeyCode::Esc));
+        assert_eq!(state.store.profiles.len(), 1);
+        assert_eq!(state.mode, Mode::List);
+    }
+
+    #[test]
+    fn delete_confirm_stray_key_is_ignored() {
+        // A key that is neither confirm (y/Enter) nor cancel (n/Esc) must
+        // leave the overlay up rather than silently dismissing it.
+        let p = Profile::new(
+            "Local".into(),
+            TransportMode::Ws,
+            "ws://x".into(),
+            "s".into(),
+        );
+        let mut state = make_state(vec![p]);
+        state.mode = Mode::DeleteConfirm;
+        handle_delete_key(&mut state, key(KeyCode::Char('x')));
+        assert_eq!(state.store.profiles.len(), 1);
+        assert_eq!(state.mode, Mode::DeleteConfirm);
     }
 }

--- a/src/picker.rs
+++ b/src/picker.rs
@@ -1187,4 +1187,85 @@ mod tests {
         assert_eq!(state.store.profiles.len(), 1);
         assert_eq!(state.mode, Mode::DeleteConfirm);
     }
+
+    #[test]
+    fn delete_confirm_enter_confirms() {
+        // Enter is a second confirm binding alongside `y`; guard it so a
+        // refactor of the match arm can't silently drop it.
+        let p = Profile::new(
+            "Solo".into(),
+            TransportMode::Ws,
+            "ws://x".into(),
+            "s".into(),
+        );
+        let mut state = make_state(vec![p]);
+        state.mode = Mode::DeleteConfirm;
+        handle_delete_key(&mut state, key(KeyCode::Enter));
+        assert!(state.store.profiles.is_empty());
+    }
+
+    #[test]
+    fn delete_confirm_uppercase_y_confirms() {
+        // The confirm matrix is case-insensitive (`y`/`Y`).
+        let p = Profile::new(
+            "Solo".into(),
+            TransportMode::Ws,
+            "ws://x".into(),
+            "s".into(),
+        );
+        let mut state = make_state(vec![p]);
+        state.mode = Mode::DeleteConfirm;
+        handle_delete_key(&mut state, key(KeyCode::Char('Y')));
+        assert!(state.store.profiles.is_empty());
+    }
+
+    #[test]
+    fn delete_confirm_uppercase_n_cancels() {
+        // The cancel matrix is case-insensitive (`n`/`N`).
+        let p = Profile::new(
+            "Solo".into(),
+            TransportMode::Ws,
+            "ws://x".into(),
+            "s".into(),
+        );
+        let mut state = make_state(vec![p]);
+        state.mode = Mode::DeleteConfirm;
+        handle_delete_key(&mut state, key(KeyCode::Char('N')));
+        assert_eq!(state.store.profiles.len(), 1);
+        assert_eq!(state.mode, Mode::List);
+    }
+
+    #[test]
+    fn delete_confirm_with_multiple_profiles_returns_to_list_and_clamps_selection() {
+        // Deleting the last-selected of several profiles must keep the picker in
+        // the list (not fall back to the new-profile form) and clamp `selected`
+        // so it still points at a live row.
+        let alpha = Profile::new(
+            "Alpha".into(),
+            TransportMode::Ws,
+            "ws://a".into(),
+            "s".into(),
+        );
+        let beta = Profile::new(
+            "Beta".into(),
+            TransportMode::Ws,
+            "ws://b".into(),
+            "s".into(),
+        );
+        let mut state = make_state(vec![alpha, beta]);
+        state.selected = 1; // Beta, the last row
+        state.mode = Mode::DeleteConfirm;
+        handle_delete_key(&mut state, key(KeyCode::Char('y')));
+        assert_eq!(state.store.profiles.len(), 1);
+        assert_eq!(
+            state.store.profiles[0].name, "Alpha",
+            "the unselected profile survives"
+        );
+        assert_eq!(
+            state.mode,
+            Mode::List,
+            "stays in the list while profiles remain"
+        );
+        assert_eq!(state.selected, 0, "selection clamps to a valid row");
+    }
 }

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -92,12 +92,18 @@ impl Profile {
             ws_login_username: self.username.clone(),
             ws_login_password: password,
             socket_path: self.socket_path.clone(),
-            // Mint the socket-handshake JWT from the local `adelie-mint` minter
-            // (#101/#316) — the preferred, non-retiring source — rather than
-            // falling through to the deprecated D-Bus `generate_ws_jwt` path
-            // (which the cutover removed). Inert for the D-Bus transport, which
-            // authenticates by peer credentials and needs no token.
-            minter_socket: desktop_assistant_client_common::minter::default_minter_socket_path(),
+            // Mint the UDS handshake JWT from the local `adelie-mint` minter
+            // (#101/#316) — the preferred, non-retiring source — rather than the
+            // deprecated D-Bus `generate_ws_jwt` path (removed by the cutover).
+            // UDS-only: the minter issues tokens the *local* daemon trusts;
+            // WS targets a (possibly remote) server and must keep authenticating
+            // via OAuth/password (an explicit `ws_jwt` or the `/login` fallback),
+            // and D-Bus needs no token at all (peer credentials).
+            minter_socket: if matches!(self.transport, TransportMode::Uds) {
+                desktop_assistant_client_common::minter::default_minter_socket_path()
+            } else {
+                None
+            },
             ..Default::default()
         }
     }

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -92,6 +92,12 @@ impl Profile {
             ws_login_username: self.username.clone(),
             ws_login_password: password,
             socket_path: self.socket_path.clone(),
+            // Mint the socket-handshake JWT from the local `adelie-mint` minter
+            // (#101/#316) — the preferred, non-retiring source — rather than
+            // falling through to the deprecated D-Bus `generate_ws_jwt` path
+            // (which the cutover removed). Inert for the D-Bus transport, which
+            // authenticates by peer credentials and needs no token.
+            minter_socket: desktop_assistant_client_common::minter::default_minter_socket_path(),
             ..Default::default()
         }
     }

--- a/src/purposes.rs
+++ b/src/purposes.rs
@@ -174,6 +174,24 @@ impl EditState {
     }
 }
 
+use crate::in_flight::InFlight;
+
+/// Refreshed purposes-screen data — result of the sequential off-loop
+/// `ListConnections` → `GetPurposes` → `list_available_models` chain.
+struct RefreshData {
+    connections: Vec<ConnectionView>,
+    purposes: PurposesView,
+    models: Vec<ModelListing>,
+}
+
+/// Resolved outcome of an off-loop purposes RPC (modal-freeze fix).
+enum RpcOutcome {
+    // Boxed: `RefreshData` (three vecs) dwarfs the `Saved` variant, so box it to
+    // keep the enum small (clippy::large_enum_variant).
+    Refreshed(Result<Box<RefreshData>, String>),
+    Saved(Result<(), String>),
+}
+
 struct State {
     connections: Vec<ConnectionView>,
     models: Vec<ModelListing>,
@@ -193,6 +211,9 @@ struct State {
 struct PurposesScreen<'a> {
     state: State,
     client: &'a TransportClient,
+    /// In-flight list/save RPCs, polled off the draw loop by `poll_pending` so
+    /// the screen never freezes during the (sequential) refresh or a save.
+    pending: InFlight<'a, RpcOutcome>,
 }
 
 impl Screen for PurposesScreen<'_> {
@@ -202,15 +223,27 @@ impl Screen for PurposesScreen<'_> {
         draw(frame, &self.state);
     }
 
-    async fn handle_key(&mut self, key: KeyEvent) {
+    fn handle_key(&mut self, key: KeyEvent) -> impl std::future::Future<Output = ()> {
         match self.state.mode {
-            Mode::List => handle_list_key(&mut self.state, key, self.client).await,
-            Mode::Edit => handle_edit_key(&mut self.state, key, self.client).await,
+            Mode::List => handle_list_key(&mut self.state, key, self.client, &mut self.pending),
+            Mode::Edit => handle_edit_key(&mut self.state, key, self.client, &mut self.pending),
         }
+        std::future::ready(())
     }
 
     fn take_outcome(&mut self) -> Option<()> {
         self.state.closing.then_some(())
+    }
+
+    fn has_pending(&self) -> bool {
+        !self.pending.is_empty()
+    }
+
+    async fn poll_pending(&mut self) {
+        let resolved = self.pending.next().await;
+        if let Some(outcome) = resolved {
+            apply_outcome(&mut self.state, &mut self.pending, self.client, outcome);
+        }
     }
 }
 
@@ -233,65 +266,95 @@ pub async fn run(
             closing: false,
         },
         client,
+        pending: InFlight::new(),
     };
 
-    refresh_all(&mut screen.state, client).await;
+    refresh_all(&mut screen.state, &mut screen.pending, client);
 
     crate::screen::run_screen(terminal, &mut screen, signal_rx, sink).await
 }
 
-async fn refresh_all(state: &mut State, client: &TransportClient) {
+/// Enqueue the full refresh off-loop (modal-freeze fix). Sets `busy` and returns;
+/// `apply_outcome` installs the data once `poll_pending` resolves it.
+fn refresh_all<'a>(
+    state: &mut State,
+    pending: &mut InFlight<'a, RpcOutcome>,
+    client: &'a TransportClient,
+) {
     state.busy = Some("Loading purposes...".into());
-    let conns = send(client, Command::ListConnections).await;
-    let purposes = send(client, Command::GetPurposes).await;
-    state.busy = None;
-
-    match conns {
-        Ok(CommandResult::Connections(c)) => state.connections = c,
-        Ok(other) => {
-            state.error = Some(format!(
-                "Unexpected response listing connections: {other:?}"
-            ));
-            return;
-        }
-        Err(e) => {
-            state.error = Some(format!("Failed to list connections: {e}"));
-            return;
-        }
-    }
-
-    match purposes {
-        Ok(CommandResult::Purposes(p)) => state.purposes = p,
-        Ok(other) => {
-            state.error = Some(format!("Unexpected response loading purposes: {other:?}"));
-            return;
-        }
-        Err(e) => {
-            state.error = Some(format!("Failed to load purposes: {e}"));
-            return;
-        }
-    }
-
-    // Pre-fetch the full model list once; we filter client-side per
-    // connection in the editor cyclers. Refresh only on user request.
-    refresh_models(state, client, false).await;
+    pending.push(async move { RpcOutcome::Refreshed(load_all(client).await.map(Box::new)) });
 }
 
-async fn refresh_models(state: &mut State, client: &TransportClient, refresh_cache: bool) {
+/// Run the three refresh RPCs sequentially in one off-loop future, short-circuiting
+/// on the first failure. Pre-fetches the full model list once (filtered
+/// client-side per connection in the editor cyclers).
+async fn load_all(client: &TransportClient) -> Result<RefreshData, String> {
+    let connections = match send(client, Command::ListConnections).await {
+        Ok(CommandResult::Connections(c)) => c,
+        Ok(other) => {
+            return Err(format!(
+                "Unexpected response listing connections: {other:?}"
+            ));
+        }
+        Err(e) => return Err(format!("Failed to list connections: {e}")),
+    };
+    let purposes = match send(client, Command::GetPurposes).await {
+        Ok(CommandResult::Purposes(p)) => p,
+        Ok(other) => return Err(format!("Unexpected response loading purposes: {other:?}")),
+        Err(e) => return Err(format!("Failed to load purposes: {e}")),
+    };
     let Some(commands) = client.as_commands() else {
-        state.error = Some(
+        return Err(
             "Purposes management isn't available over D-Bus — switch transport with --transport ws or the local socket"
                 .into(),
         );
-        return;
     };
-    match commands.list_available_models(None, refresh_cache).await {
-        Ok(models) => state.models = models,
-        Err(e) => state.error = Some(format!("Failed to list models: {e}")),
+    let models = commands
+        .list_available_models(None, false)
+        .await
+        .map_err(|e| format!("Failed to list models: {e}"))?;
+    Ok(RefreshData {
+        connections,
+        purposes,
+        models,
+    })
+}
+
+/// Apply a resolved purposes RPC; chains a `refresh_all` after a successful save.
+fn apply_outcome<'a>(
+    state: &mut State,
+    pending: &mut InFlight<'a, RpcOutcome>,
+    client: &'a TransportClient,
+    outcome: RpcOutcome,
+) {
+    state.busy = None;
+    match outcome {
+        RpcOutcome::Refreshed(Ok(data)) => {
+            let RefreshData {
+                connections,
+                purposes,
+                models,
+            } = *data;
+            state.connections = connections;
+            state.purposes = purposes;
+            state.models = models;
+        }
+        RpcOutcome::Refreshed(Err(e)) => state.error = Some(e),
+        RpcOutcome::Saved(Ok(())) => {
+            state.error = None;
+            state.mode = Mode::List;
+            refresh_all(state, pending, client);
+        }
+        RpcOutcome::Saved(Err(e)) => state.error = Some(format!("Save failed: {e}")),
     }
 }
 
-async fn handle_list_key(state: &mut State, key: KeyEvent, client: &TransportClient) {
+fn handle_list_key<'a>(
+    state: &mut State,
+    key: KeyEvent,
+    client: &'a TransportClient,
+    pending: &mut InFlight<'a, RpcOutcome>,
+) {
     match (key.code, key.modifiers) {
         (KeyCode::Esc | KeyCode::Char('q'), m) if m.is_empty() => state.closing = true,
         (KeyCode::Char('j') | KeyCode::Down, m) if m.is_empty() => advance_selection(state, 1),
@@ -303,16 +366,21 @@ async fn handle_list_key(state: &mut State, key: KeyEvent, client: &TransportCli
             state.error = None;
             state.mode = Mode::Edit;
         }
-        (KeyCode::Char('r'), m) if m.is_empty() => refresh_all(state, client).await,
+        (KeyCode::Char('r'), m) if m.is_empty() => refresh_all(state, pending, client),
         _ => {}
     }
 }
 
-async fn handle_edit_key(state: &mut State, key: KeyEvent, client: &TransportClient) {
+fn handle_edit_key<'a>(
+    state: &mut State,
+    key: KeyEvent,
+    client: &'a TransportClient,
+    pending: &mut InFlight<'a, RpcOutcome>,
+) {
     let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
 
     if ctrl && key.code == KeyCode::Char('s') {
-        save_edit(state, client).await;
+        save_edit(state, pending, client);
         return;
     }
 
@@ -433,7 +501,11 @@ fn advance_selection(state: &mut State, delta: i32) {
     state.selected_row = idx as usize;
 }
 
-async fn save_edit(state: &mut State, client: &TransportClient) {
+fn save_edit<'a>(
+    state: &mut State,
+    pending: &mut InFlight<'a, RpcOutcome>,
+    client: &'a TransportClient,
+) {
     let config = match state.edit.submit() {
         Ok(c) => c,
         Err(e) => {
@@ -443,26 +515,15 @@ async fn save_edit(state: &mut State, client: &TransportClient) {
     };
 
     state.busy = Some("Saving...".into());
-    let result = send(
-        client,
-        Command::SetPurpose {
-            purpose: state.edit.purpose,
-            config,
-        },
-    )
-    .await;
-    state.busy = None;
-
-    match result {
-        Ok(_) => {
-            state.error = None;
-            state.mode = Mode::List;
-            refresh_all(state, client).await;
-        }
-        Err(e) => {
-            state.error = Some(format!("Save failed: {e}"));
-        }
-    }
+    let purpose = state.edit.purpose;
+    pending.push(async move {
+        RpcOutcome::Saved(
+            send(client, Command::SetPurpose { purpose, config })
+                .await
+                .map(|_| ())
+                .map_err(|e| e.to_string()),
+        )
+    });
 }
 
 fn purpose_slot(view: &PurposesView, kind: PurposeKindApi) -> Option<&PurposeConfigView> {

--- a/src/purposes.rs
+++ b/src/purposes.rs
@@ -44,16 +44,7 @@ use ratatui::{
 
 use crate::screen::Screen;
 
-const COLOR_BORDER: Color = Color::Rgb(82, 104, 173);
-const COLOR_BORDER_ACTIVE: Color = Color::Rgb(120, 183, 109);
-const COLOR_TITLE: Color = Color::Rgb(166, 182, 255);
-const COLOR_HINT_KEY: Color = Color::Rgb(216, 223, 236);
-const COLOR_HINT_DESC: Color = Color::Rgb(143, 153, 174);
-const COLOR_HINT_SEP: Color = Color::Rgb(82, 90, 110);
-const COLOR_LIST_HIGHLIGHT: Color = Color::Rgb(72, 102, 180);
-const COLOR_LIST_HIGHLIGHT_FG: Color = Color::Rgb(245, 248, 255);
-const COLOR_ERROR: Color = Color::Rgb(232, 130, 130);
-const COLOR_INHERIT: Color = Color::Rgb(140, 156, 196);
+use crate::theme::theme;
 
 /// The four purposes in display order.
 const PURPOSES: &[PurposeKindApi] = &[
@@ -593,12 +584,12 @@ fn draw_header(f: &mut Frame, area: Rect) {
         Span::styled(
             "Purposes",
             Style::default()
-                .fg(COLOR_TITLE)
+                .fg(theme().title)
                 .add_modifier(Modifier::BOLD),
         ),
         Span::styled(
             "  —  Esc to return to chat",
-            Style::default().fg(COLOR_HINT_DESC),
+            Style::default().fg(theme().text_dim),
         ),
     ]);
     f.render_widget(Paragraph::new(line), area);
@@ -626,7 +617,7 @@ fn draw_list(f: &mut Frame, state: &State, area: Rect) {
                             "(inherit primary)"
                         },
                         Style::default()
-                            .fg(COLOR_INHERIT)
+                            .fg(theme().debug_system)
                             .add_modifier(Modifier::ITALIC),
                     ));
                 }
@@ -642,12 +633,12 @@ fn draw_list(f: &mut Frame, state: &State, area: Rect) {
                         cfg.model.clone()
                     };
                     spans.push(Span::styled(connection_text, Style::default()));
-                    spans.push(Span::styled(" · ", Style::default().fg(COLOR_HINT_SEP)));
+                    spans.push(Span::styled(" · ", Style::default().fg(theme().hint_sep)));
                     spans.push(Span::styled(model_text, Style::default()));
                     if let Some(eff) = cfg.effort {
                         spans.push(Span::styled(
                             format!("  ({})", effort_label(Some(eff))),
-                            Style::default().fg(COLOR_HINT_DESC),
+                            Style::default().fg(theme().text_dim),
                         ));
                     }
                 }
@@ -660,18 +651,18 @@ fn draw_list(f: &mut Frame, state: &State, area: Rect) {
         .block(
             Block::default()
                 .borders(Borders::ALL)
-                .border_style(Style::default().fg(COLOR_BORDER))
+                .border_style(Style::default().fg(theme().border))
                 .title(Line::from(Span::styled(
                     "Purpose · Connection · Model · Effort",
                     Style::default()
-                        .fg(COLOR_TITLE)
+                        .fg(theme().title)
                         .add_modifier(Modifier::BOLD),
                 ))),
         )
         .highlight_style(
             Style::default()
-                .bg(COLOR_LIST_HIGHLIGHT)
-                .fg(COLOR_LIST_HIGHLIGHT_FG)
+                .bg(theme().list_highlight)
+                .fg(theme().list_highlight_fg)
                 .add_modifier(Modifier::BOLD),
         )
         .highlight_symbol("▸ ");
@@ -685,11 +676,11 @@ fn draw_edit_form(f: &mut Frame, state: &State, area: Rect) {
     let title = format!("Edit purpose: {}", purpose_label(state.edit.purpose));
     let block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(COLOR_BORDER))
+        .border_style(Style::default().fg(theme().border))
         .title(Line::from(Span::styled(
             title,
             Style::default()
-                .fg(COLOR_TITLE)
+                .fg(theme().title)
                 .add_modifier(Modifier::BOLD),
         )));
     let inner = block.inner(area);
@@ -711,10 +702,10 @@ fn draw_edit_form(f: &mut Frame, state: &State, area: Rect) {
     let label_for = |s: &str, focused: bool| {
         let style = if focused {
             Style::default()
-                .fg(COLOR_BORDER_ACTIVE)
+                .fg(theme().border_active)
                 .add_modifier(Modifier::BOLD)
         } else {
-            Style::default().fg(COLOR_HINT_DESC)
+            Style::default().fg(theme().text_dim)
         };
         Paragraph::new(Span::styled(s.to_string(), style))
     };
@@ -758,14 +749,14 @@ fn draw_edit_form(f: &mut Frame, state: &State, area: Rect) {
 fn draw_status(f: &mut Frame, state: &State, area: Rect) {
     if let Some(busy) = &state.busy {
         let style = Style::default()
-            .fg(Color::Rgb(178, 220, 245))
+            .fg(theme().assistant_indicator)
             .add_modifier(Modifier::ITALIC);
         f.render_widget(
             Paragraph::new(Span::styled(format!(" ● {busy}"), style)),
             area,
         );
     } else if let Some(err) = &state.error {
-        let style = Style::default().fg(COLOR_ERROR);
+        let style = Style::default().fg(theme().error);
         f.render_widget(
             Paragraph::new(Span::styled(format!(" • {err}"), style)),
             area,
@@ -786,18 +777,18 @@ fn draw_hints(f: &mut Frame, state: &State, area: Rect) {
     let mut spans: Vec<Span> = Vec::new();
     for (idx, (key, desc)) in hints.iter().enumerate() {
         if idx > 0 {
-            spans.push(Span::styled("  ·  ", Style::default().fg(COLOR_HINT_SEP)));
+            spans.push(Span::styled("  ·  ", Style::default().fg(theme().hint_sep)));
         }
         spans.push(Span::styled(
             (*key).to_string(),
             Style::default()
-                .fg(COLOR_HINT_KEY)
+                .fg(theme().hint_key)
                 .add_modifier(Modifier::BOLD),
         ));
         spans.push(Span::raw(" "));
         spans.push(Span::styled(
             (*desc).to_string(),
-            Style::default().fg(COLOR_HINT_DESC),
+            Style::default().fg(theme().text_dim),
         ));
     }
     f.render_widget(Paragraph::new(Line::from(spans)), area);

--- a/src/screen.rs
+++ b/src/screen.rs
@@ -67,6 +67,24 @@ pub trait Screen {
     fn on_timer(&mut self) -> impl Future<Output = ()> {
         async {}
     }
+
+    /// Whether this screen has an off-loop RPC in flight (modal-freeze fix). While
+    /// `true`, the driver keeps redrawing — so the `busy` indicator actually
+    /// renders — and arms [`poll_pending`](Screen::poll_pending). Default `false`
+    /// for screens that still `await` their RPCs inline.
+    fn has_pending(&self) -> bool {
+        false
+    }
+
+    /// Drive this screen's off-loop RPCs and apply the next one that resolves,
+    /// mirroring the chat loop's [`InFlight`](crate::in_flight::InFlight) driver so
+    /// a slow daemon round-trip no longer blocks redraw/input (no freeze, the
+    /// `busy` line shows, Esc stays live). Armed only while
+    /// [`has_pending`](Screen::has_pending) is `true`; the default is
+    /// pending-forever (inert) for screens with no in-flight set.
+    fn poll_pending(&mut self) -> impl Future<Output = ()> {
+        std::future::pending()
+    }
 }
 
 /// Sink for daemon signals drained while a modal screen is open (TUI-12).
@@ -146,6 +164,11 @@ where
             }, if next_timer.is_some() => {
                 screen.on_timer().await;
             }
+            // Modal-freeze fix: drive the screen's own off-loop RPCs so a slow
+            // daemon round-trip no longer blocks redraw/input. Armed only when the
+            // screen has work in flight; otherwise the branch is disabled and the
+            // screen keeps its old inline-`await` behaviour.
+            _ = screen.poll_pending(), if screen.has_pending() => {}
         }
     }
 }

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -246,24 +246,15 @@ impl TaskPane {
 
 // --- Rendering --------------------------------------------------------
 
-const COLOR_BORDER: Color = Color::Rgb(82, 104, 173);
-const COLOR_TITLE: Color = Color::Rgb(166, 182, 255);
-const COLOR_HINT_DESC: Color = Color::Rgb(143, 153, 174);
-const COLOR_LIST_HIGHLIGHT: Color = Color::Rgb(72, 102, 180);
-const COLOR_LIST_HIGHLIGHT_FG: Color = Color::Rgb(245, 248, 255);
-const COLOR_OK: Color = Color::Rgb(132, 218, 193);
-const COLOR_ERROR: Color = Color::Rgb(232, 130, 130);
-const COLOR_WARN: Color = Color::Rgb(232, 200, 130);
-const COLOR_RUN: Color = Color::Rgb(122, 163, 255);
-const COLOR_PEND: Color = Color::Rgb(178, 138, 220);
+use crate::theme::theme;
 
 fn status_chip(status: TaskStatus) -> Span<'static> {
     let (label, color) = match status {
-        TaskStatus::Pending => ("PEND", COLOR_PEND),
-        TaskStatus::Running => ("RUN ", COLOR_RUN),
-        TaskStatus::Completed => ("OK  ", COLOR_OK),
-        TaskStatus::Failed => ("FAIL", COLOR_ERROR),
-        TaskStatus::Cancelled => ("CXL ", COLOR_WARN),
+        TaskStatus::Pending => ("PEND", theme().debug_tool),
+        TaskStatus::Running => ("RUN ", theme().run),
+        TaskStatus::Completed => ("OK  ", theme().ok),
+        TaskStatus::Failed => ("FAIL", theme().error),
+        TaskStatus::Cancelled => ("CXL ", theme().warn),
     };
     Span::styled(
         format!(" {label} "),
@@ -276,9 +267,9 @@ fn status_chip(status: TaskStatus) -> Span<'static> {
 
 fn level_color(level: LogLevel) -> Color {
     match level {
-        LogLevel::Info => COLOR_OK,
-        LogLevel::Warn => COLOR_WARN,
-        LogLevel::Error => COLOR_ERROR,
+        LogLevel::Info => theme().ok,
+        LogLevel::Warn => theme().warn,
+        LogLevel::Error => theme().error,
     }
 }
 
@@ -339,18 +330,18 @@ pub fn draw_overlay(f: &mut Frame, pane: &TaskPane, area: Rect) {
         Span::styled(
             format!("Tasks ({} running)", pane.running_count()),
             Style::default()
-                .fg(COLOR_TITLE)
+                .fg(theme().title)
                 .add_modifier(Modifier::BOLD),
         ),
         Span::styled(
             "  —  j/k navigate · c cancel · Enter open conv · Ctrl+P close",
-            Style::default().fg(COLOR_HINT_DESC),
+            Style::default().fg(theme().text_dim),
         ),
     ]);
 
     let block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(COLOR_BORDER))
+        .border_style(Style::default().fg(theme().border))
         .title(title_line);
     let inner = block.inner(popup);
     f.render_widget(block, popup);
@@ -358,7 +349,7 @@ pub fn draw_overlay(f: &mut Frame, pane: &TaskPane, area: Rect) {
     if pane.tasks.is_empty() {
         let empty = Paragraph::new(Line::from(Span::styled(
             "(no background tasks — they will appear here as the daemon spawns them)",
-            Style::default().fg(COLOR_HINT_DESC),
+            Style::default().fg(theme().text_dim),
         )))
         .wrap(Wrap { trim: true });
         f.render_widget(empty, inner);
@@ -387,7 +378,7 @@ fn draw_task_list(f: &mut Frame, pane: &TaskPane, area: Rect) {
         .values()
         .map(|row| {
             let parent_indicator = if row.parent.is_some() {
-                Span::styled(" ↳", Style::default().fg(COLOR_HINT_DESC))
+                Span::styled(" ↳", Style::default().fg(theme().text_dim))
             } else {
                 Span::raw("  ")
             };
@@ -406,25 +397,28 @@ fn draw_task_list(f: &mut Frame, pane: &TaskPane, area: Rect) {
                         .fg(Color::White)
                         .add_modifier(Modifier::BOLD),
                 ),
-                Span::styled(format!("  {age:>4}"), Style::default().fg(COLOR_HINT_DESC)),
+                Span::styled(format!("  {age:>4}"), Style::default().fg(theme().text_dim)),
                 parent_indicator,
                 Span::raw(" "),
                 Span::styled(
                     format!("[{}] ", row.kind_label),
                     Style::default()
-                        .fg(COLOR_HINT_DESC)
+                        .fg(theme().text_dim)
                         .add_modifier(Modifier::DIM),
                 ),
                 Span::styled(row.title.clone(), Style::default().fg(Color::White)),
             ];
             if !progress.is_empty() {
-                spans.push(Span::styled(progress, Style::default().fg(COLOR_HINT_DESC)));
+                spans.push(Span::styled(
+                    progress,
+                    Style::default().fg(theme().text_dim),
+                ));
             }
             if let Some(err) = &row.last_error {
                 spans.push(Span::styled(
                     format!("  ·  {err}"),
                     Style::default()
-                        .fg(COLOR_ERROR)
+                        .fg(theme().error)
                         .add_modifier(Modifier::ITALIC),
                 ));
             }
@@ -436,18 +430,18 @@ fn draw_task_list(f: &mut Frame, pane: &TaskPane, area: Rect) {
         .block(
             Block::default()
                 .borders(Borders::ALL)
-                .border_style(Style::default().fg(COLOR_BORDER))
+                .border_style(Style::default().fg(theme().border))
                 .title(Line::from(Span::styled(
                     "Background tasks",
                     Style::default()
-                        .fg(COLOR_TITLE)
+                        .fg(theme().title)
                         .add_modifier(Modifier::BOLD),
                 ))),
         )
         .highlight_style(
             Style::default()
-                .bg(COLOR_LIST_HIGHLIGHT)
-                .fg(COLOR_LIST_HIGHLIGHT_FG)
+                .bg(theme().list_highlight)
+                .fg(theme().list_highlight_fg)
                 .add_modifier(Modifier::BOLD),
         )
         .highlight_symbol("▸ ");
@@ -460,11 +454,11 @@ fn draw_task_list(f: &mut Frame, pane: &TaskPane, area: Rect) {
 fn draw_task_logs(f: &mut Frame, pane: &TaskPane, area: Rect) {
     let block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(COLOR_BORDER))
+        .border_style(Style::default().fg(theme().border))
         .title(Line::from(Span::styled(
             "Logs",
             Style::default()
-                .fg(COLOR_TITLE)
+                .fg(theme().title)
                 .add_modifier(Modifier::BOLD),
         )));
     let inner = block.inner(area);
@@ -474,7 +468,7 @@ fn draw_task_logs(f: &mut Frame, pane: &TaskPane, area: Rect) {
     if logs.is_empty() {
         let empty = Paragraph::new(Line::from(Span::styled(
             "(no log entries yet)",
-            Style::default().fg(COLOR_HINT_DESC),
+            Style::default().fg(theme().text_dim),
         )));
         f.render_widget(empty, inner);
         return;
@@ -487,7 +481,7 @@ fn draw_task_logs(f: &mut Frame, pane: &TaskPane, area: Rect) {
             // long tool outputs are readable without word-wrap weirdness.
             let head = Span::styled(
                 format!("[{:>4}] ", entry.seq),
-                Style::default().fg(COLOR_HINT_DESC),
+                Style::default().fg(theme().text_dim),
             );
             let level_label = format!("{:?}", entry.level).to_uppercase();
             let level_span = Span::styled(
@@ -498,7 +492,7 @@ fn draw_task_logs(f: &mut Frame, pane: &TaskPane, area: Rect) {
             );
             let category_span = Span::styled(
                 format!(" {:?} ", entry.category).to_lowercase(),
-                Style::default().fg(COLOR_HINT_DESC),
+                Style::default().fg(theme().text_dim),
             );
             let mut out: Vec<Line<'static>> = Vec::new();
             let mut first = true;

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,0 +1,244 @@
+//! Centralized semantic color palette. Rich 24-bit RGB by default; when the
+//! `NO_COLOR` env var is set (https://no-color.org), falls back to the 16 ANSI
+//! named colors so the user's terminal theme governs the palette.
+//!
+//! Every field is named by ROLE, not by call site, and holds one DISTINCT rgb
+//! value. The `rich()` palette reproduces, byte-for-byte, every `Color::Rgb`
+//! triple the views used before this module existed; that byte-identity is the
+//! invariant that makes routing all of those sites through `theme()` a no-op in
+//! the default (non-`NO_COLOR`) case.
+use ratatui::style::Color;
+use std::sync::OnceLock;
+
+/// Semantic palette. One field per distinct color role.
+pub struct Theme {
+    /// Inactive panel/popup border.
+    pub border: Color,
+    /// Active/focused border (e.g. an edited field, an active pane).
+    pub border_active: Color,
+    /// Conversation-list (left pane) border.
+    pub list_border: Color,
+    /// Composer border while idle (not editing).
+    pub input_border_idle: Color,
+    /// Selected-row background in lists.
+    pub list_highlight: Color,
+    /// Selected-row foreground in lists.
+    pub list_highlight_fg: Color,
+    /// Panel/popup title text.
+    pub title: Color,
+    /// Conversation-list pane title text.
+    pub list_title: Color,
+    /// Hint-bar key glyphs.
+    pub hint_key: Color,
+    /// Hint-bar separators / table borders.
+    pub hint_sep: Color,
+    /// Dim secondary text (hint descriptions, status dim, "global" labels).
+    pub text_dim: Color,
+    /// Even dimmer count text (e.g. message counts).
+    pub count_dim: Color,
+    /// "You:" user-prefix accent (also the rename popup accent / mode chip bg).
+    pub user_prefix: Color,
+    /// Assistant name prefix.
+    pub assistant_prefix: Color,
+    /// Rename popup title text.
+    pub rename_title: Color,
+    /// Success / ok / streaming-assistant text.
+    pub ok: Color,
+    /// Warning text (distinct from the amber context-fill shade).
+    pub warn: Color,
+    /// Error text / error & delete borders.
+    pub error: Color,
+    /// Bright error message body text.
+    pub error_text: Color,
+    /// Context-fill indicator: comfortably under budget.
+    pub ctx_green: Color,
+    /// Context-fill indicator: approaching the compaction line.
+    pub ctx_amber: Color,
+    /// Context-fill indicator: at/over budget.
+    pub ctx_red: Color,
+    /// Debug tool-call accent / pending-task marker.
+    pub debug_tool: Color,
+    /// Debug system text / inherited-value marker / timestamps.
+    pub debug_system: Color,
+    /// Assistant indicator / informational blue accent.
+    pub assistant_indicator: Color,
+    /// Running-task accent / normal-mode chip bg / running badge.
+    pub run: Color,
+    /// Edit-mode chip background.
+    pub mode_edit_bg: Color,
+    /// Pinned / current-pick highlight.
+    pub pinned: Color,
+    /// Markdown code-span foreground.
+    pub code_fg: Color,
+    /// Markdown code-span background.
+    pub code_bg: Color,
+    /// Markdown link text.
+    pub link: Color,
+    /// Markdown blockquote text.
+    pub blockquote: Color,
+}
+
+impl Theme {
+    /// The 24-bit palette. Reproduces every current RGB value byte-for-byte.
+    fn rich() -> Self {
+        Self {
+            border: Color::Rgb(82, 104, 173),
+            border_active: Color::Rgb(120, 183, 109),
+            list_border: Color::Rgb(62, 125, 146),
+            input_border_idle: Color::Rgb(109, 122, 143),
+            list_highlight: Color::Rgb(72, 102, 180),
+            list_highlight_fg: Color::Rgb(245, 248, 255),
+            title: Color::Rgb(166, 182, 255),
+            list_title: Color::Rgb(136, 214, 240),
+            hint_key: Color::Rgb(216, 223, 236),
+            hint_sep: Color::Rgb(82, 90, 110),
+            text_dim: Color::Rgb(143, 153, 174),
+            count_dim: Color::Rgb(124, 132, 148),
+            user_prefix: Color::Rgb(255, 189, 89),
+            assistant_prefix: Color::Rgb(92, 206, 154),
+            rename_title: Color::Rgb(255, 220, 160),
+            ok: Color::Rgb(132, 218, 193),
+            warn: Color::Rgb(232, 200, 130),
+            error: Color::Rgb(232, 130, 130),
+            error_text: Color::Rgb(255, 200, 200),
+            ctx_green: Color::Rgb(122, 200, 132),
+            ctx_amber: Color::Rgb(232, 184, 96),
+            ctx_red: Color::Rgb(232, 106, 106),
+            debug_tool: Color::Rgb(178, 138, 220),
+            debug_system: Color::Rgb(140, 156, 196),
+            assistant_indicator: Color::Rgb(178, 220, 245),
+            run: Color::Rgb(122, 163, 255),
+            mode_edit_bg: Color::Rgb(120, 214, 118),
+            pinned: Color::Rgb(255, 207, 119),
+            code_fg: Color::Rgb(244, 228, 188),
+            code_bg: Color::Rgb(40, 44, 56),
+            link: Color::Rgb(132, 204, 232),
+            blockquote: Color::Rgb(170, 178, 196),
+        }
+    }
+
+    /// `NO_COLOR` fallback: nearest ANSI-16. Borders and recessive backgrounds
+    /// become `Color::Reset` (terminal default) so the user's terminal theme
+    /// shows through; the list-highlight background stays a visible `Blue` so
+    /// the selection remains legible.
+    fn plain() -> Self {
+        Self {
+            border: Color::Reset,
+            border_active: Color::Green,
+            list_border: Color::Reset,
+            input_border_idle: Color::Reset,
+            list_highlight: Color::Blue,
+            list_highlight_fg: Color::White,
+            title: Color::Cyan,
+            list_title: Color::LightBlue,
+            hint_key: Color::White,
+            hint_sep: Color::DarkGray,
+            text_dim: Color::Gray,
+            count_dim: Color::DarkGray,
+            user_prefix: Color::Yellow,
+            assistant_prefix: Color::Green,
+            rename_title: Color::LightYellow,
+            ok: Color::Green,
+            warn: Color::Yellow,
+            error: Color::Red,
+            error_text: Color::LightRed,
+            ctx_green: Color::Green,
+            ctx_amber: Color::Yellow,
+            ctx_red: Color::Red,
+            debug_tool: Color::Magenta,
+            debug_system: Color::LightBlue,
+            assistant_indicator: Color::LightCyan,
+            run: Color::LightBlue,
+            mode_edit_bg: Color::Green,
+            pinned: Color::LightYellow,
+            code_fg: Color::Yellow,
+            code_bg: Color::Reset,
+            link: Color::Cyan,
+            blockquote: Color::Gray,
+        }
+    }
+}
+
+static THEME: OnceLock<Theme> = OnceLock::new();
+
+/// Global palette accessor. Initialized once from the environment: the rich
+/// 24-bit palette by default, or the ANSI-16 `plain()` fallback when `NO_COLOR`
+/// is set.
+pub fn theme() -> &'static Theme {
+    THEME.get_or_init(|| {
+        if std::env::var_os("NO_COLOR").is_some() {
+            Theme::plain()
+        } else {
+            Theme::rich()
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Collect every field into a list so a test can assert a property over the
+    /// whole palette without naming each field twice.
+    fn all_colors(t: &Theme) -> Vec<Color> {
+        vec![
+            t.border,
+            t.border_active,
+            t.list_border,
+            t.input_border_idle,
+            t.list_highlight,
+            t.list_highlight_fg,
+            t.title,
+            t.list_title,
+            t.hint_key,
+            t.hint_sep,
+            t.text_dim,
+            t.count_dim,
+            t.user_prefix,
+            t.assistant_prefix,
+            t.rename_title,
+            t.ok,
+            t.warn,
+            t.error,
+            t.error_text,
+            t.ctx_green,
+            t.ctx_amber,
+            t.ctx_red,
+            t.debug_tool,
+            t.debug_system,
+            t.assistant_indicator,
+            t.run,
+            t.mode_edit_bg,
+            t.pinned,
+            t.code_fg,
+            t.code_bg,
+            t.link,
+            t.blockquote,
+        ]
+    }
+
+    #[test]
+    fn rich_constructs_and_border_is_unchanged() {
+        // Constructing must not panic, and a couple of fields must equal their
+        // known RGB triples — this guards the byte-identity invariant that
+        // makes routing the views through `theme()` safe in the default case.
+        let t = Theme::rich();
+        assert_eq!(t.border, Color::Rgb(82, 104, 173));
+        assert_eq!(t.list_highlight, Color::Rgb(72, 102, 180));
+        assert_eq!(t.error, Color::Rgb(232, 130, 130));
+        // Sanity: every field is populated (the list length tracks the count).
+        assert_eq!(all_colors(&t).len(), 32);
+    }
+
+    #[test]
+    fn plain_drops_all_rgb() {
+        // The NO_COLOR path must actually drop 24-bit color: no field may be a
+        // `Color::Rgb(..)` variant.
+        for c in all_colors(&Theme::plain()) {
+            assert!(
+                !matches!(c, Color::Rgb(..)),
+                "plain() field unexpectedly held an Rgb variant: {c:?}",
+            );
+        }
+    }
+}

--- a/src/toolbar.rs
+++ b/src/toolbar.rs
@@ -5,15 +5,13 @@
 //! from the right.
 
 use ratatui::{
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::Span,
 };
 
 use crate::app::InputMode;
 
-const COLOR_HINT_KEY: Color = Color::Rgb(216, 223, 236);
-const COLOR_HINT_DESC: Color = Color::Rgb(143, 153, 174);
-const COLOR_HINT_SEP: Color = Color::Rgb(82, 90, 110);
+use crate::theme::theme;
 
 const HINTS_NORMAL: &[(&str, &str)] = &[
     ("n", "new"),
@@ -72,18 +70,18 @@ pub fn render_hints(mode: &InputMode, max_width: u16) -> (Vec<Span<'static>>, u1
     let mut spans: Vec<Span<'static>> = Vec::with_capacity(chosen.len() * 4);
     for (idx, (key, desc)) in chosen.iter().enumerate() {
         if idx > 0 {
-            spans.push(Span::styled("  ·  ", Style::default().fg(COLOR_HINT_SEP)));
+            spans.push(Span::styled("  ·  ", Style::default().fg(theme().hint_sep)));
         }
         spans.push(Span::styled(
             (*key).to_string(),
             Style::default()
-                .fg(COLOR_HINT_KEY)
+                .fg(theme().hint_key)
                 .add_modifier(Modifier::BOLD),
         ));
         spans.push(Span::styled(" ", Style::default()));
         spans.push(Span::styled(
             (*desc).to_string(),
-            Style::default().fg(COLOR_HINT_DESC),
+            Style::default().fg(theme().text_dim),
         ));
     }
     (spans, width)

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -173,7 +173,7 @@ fn draw_rename_popup(f: &mut Frame, app: &mut App, area: Rect) {
 
 fn draw_conversation_list(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
     let items: Vec<ListItem> = app
-        .conversations
+        .conversations()
         .iter()
         .map(|c| {
             let mut spans = vec![];

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -465,13 +465,22 @@ fn draw_input(f: &mut Frame, app: &mut App, area: ratatui::layout::Rect) {
     // sent — is never mutated by terminal-width line breaks.
     let mut display = app.wrapped_display_textarea(wrap_width);
 
-    let (title, border_color) = match app.mode {
+    let (base_title, mode_color) = match app.mode {
         InputMode::Normal => ("Input (press 'i' to edit)", theme().input_border_idle),
         InputMode::Editing => (
             "Input (Esc cancel, Enter send, Shift+Enter/Ctrl+J newline)",
             theme().border_active,
         ),
         InputMode::Renaming => ("Input", theme().input_border_idle),
+    };
+    // When the daemon link is down the run loop projects `connected = false`;
+    // surface it where the user types — a warn-colored border plus an `offline`
+    // tag. The tag is text (not color-only) so it still reads under NO_COLOR,
+    // where the recolor is a no-op; the status bar carries the backoff detail.
+    let (title, border_color) = if app.connected {
+        (base_title.to_string(), mode_color)
+    } else {
+        (format!("offline · {base_title}"), theme().warn)
     };
 
     display.set_block(
@@ -763,6 +772,33 @@ mod tests {
         let mut app = App::new();
         app.status_message = "Error: connection lost".into();
         terminal.draw(|f| draw(f, &mut app)).unwrap();
+    }
+
+    #[test]
+    fn draw_input_marks_offline_when_disconnected() {
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut app = App::new();
+        app.connected = false;
+        terminal.draw(|f| draw(f, &mut app)).unwrap();
+        let buf = terminal.backend().buffer().clone();
+        let dump: String = buf.content.iter().map(|c| c.symbol()).collect();
+        assert!(
+            dump.contains("offline"),
+            "offline tag must show when disconnected"
+        );
+    }
+
+    #[test]
+    fn draw_input_has_no_offline_tag_when_connected() {
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut app = App::new();
+        // App::new() defaults connected = true.
+        terminal.draw(|f| draw(f, &mut app)).unwrap();
+        let buf = terminal.backend().buffer().clone();
+        let dump: String = buf.content.iter().map(|c| c.symbol()).collect();
+        assert!(!dump.contains("offline"), "no offline tag while connected");
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -12,6 +12,30 @@ use crate::theme::theme;
 const INPUT_VISIBLE_LINES: u16 = 4;
 const INPUT_TOTAL_HEIGHT: u16 = INPUT_VISIBLE_LINES + 2; // +2 for borders
 
+/// Below this width the conversation sidebar auto-hides so the chat keeps a
+/// usable column count. This is a render-time decision only — the user's
+/// `show_sidebar` toggle is never mutated, so widening the terminal restores it.
+const SIDEBAR_MIN_WIDTH: u16 = 50;
+/// The message area never shrinks below this; the input box gives up rows first
+/// on a short terminal (so messages can't be squeezed to nothing).
+const MIN_MESSAGE_ROWS: u16 = 1;
+
+/// Whether to actually render the sidebar: the user opted in *and* the terminal
+/// is wide enough to spare the columns.
+fn sidebar_visible(show_sidebar: bool, width: u16) -> bool {
+    show_sidebar && width >= SIDEBAR_MIN_WIDTH
+}
+
+/// Height for the composer box in a chat pane `available_height` rows tall, with
+/// `status_height` rows of assistant-status line. The box wants
+/// `INPUT_TOTAL_HEIGHT` rows but collapses on a short terminal so the message
+/// area keeps at least `MIN_MESSAGE_ROWS` (toolbar + status bar are 1 row each).
+fn chat_input_height(available_height: u16, status_height: u16) -> u16 {
+    let fixed_chrome = status_height + 2; // toolbar + status bar
+    let spare = available_height.saturating_sub(fixed_chrome + MIN_MESSAGE_ROWS);
+    INPUT_TOTAL_HEIGHT.min(spare)
+}
+
 fn mode_chip_style(mode: &InputMode) -> Style {
     match mode {
         InputMode::Normal => Style::default()
@@ -39,7 +63,7 @@ fn split_display_lines(content: &str) -> Vec<String> {
 }
 
 pub fn draw(f: &mut Frame, app: &mut App) {
-    if app.show_sidebar {
+    if sidebar_visible(app.show_sidebar, f.area().width) {
         let chunks = Layout::default()
             .direction(Direction::Horizontal)
             .constraints([Constraint::Percentage(30), Constraint::Percentage(70)])
@@ -206,13 +230,14 @@ fn draw_conversation_list(f: &mut Frame, app: &App, area: ratatui::layout::Rect)
 fn draw_chat_panel(f: &mut Frame, app: &mut App, area: ratatui::layout::Rect) {
     let show_status = app.assistant_status.is_some();
     let status_height: u16 = if show_status { 1 } else { 0 };
+    let input_height = chat_input_height(area.height, status_height);
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Min(1),
             Constraint::Length(status_height),
-            Constraint::Length(INPUT_TOTAL_HEIGHT),
+            Constraint::Length(input_height),
             Constraint::Length(1),
             Constraint::Length(1),
         ])
@@ -831,6 +856,84 @@ mod tests {
             !input_border_has_warn(&mut online),
             "no border should be warn-colored while connected"
         );
+    }
+
+    #[test]
+    fn sidebar_visible_requires_opt_in_and_width() {
+        assert!(sidebar_visible(true, 80));
+        assert!(sidebar_visible(true, SIDEBAR_MIN_WIDTH));
+        // One column under the threshold hides it even though the user opted in.
+        assert!(!sidebar_visible(true, SIDEBAR_MIN_WIDTH - 1));
+        // Opt-out always hides it, however wide the terminal.
+        assert!(!sidebar_visible(false, 200));
+    }
+
+    #[test]
+    fn chat_input_height_is_full_when_tall_and_shrinks_when_short() {
+        // Tall pane: the composer gets its full height, status line or not.
+        assert_eq!(chat_input_height(24, 0), INPUT_TOTAL_HEIGHT);
+        assert_eq!(chat_input_height(24, 1), INPUT_TOTAL_HEIGHT);
+        // Short pane (height 8, no status): chrome(2) + message(1) leaves 5.
+        assert_eq!(chat_input_height(8, 0), 5);
+        // Tiny pane: shrinks toward zero rather than starving the messages.
+        assert_eq!(chat_input_height(4, 0), 1);
+        assert_eq!(chat_input_height(3, 0), 0);
+    }
+
+    #[test]
+    fn chat_input_height_always_leaves_a_message_row_when_possible() {
+        // Whenever the pane is tall enough to hold the fixed chrome plus a
+        // message row, the composer must not consume that row.
+        for h in 0..40u16 {
+            for status in 0..=1u16 {
+                let consumed = chat_input_height(h, status) + status + 2;
+                if h >= status + 2 + MIN_MESSAGE_ROWS {
+                    assert!(
+                        h.saturating_sub(consumed) >= MIN_MESSAGE_ROWS,
+                        "h={h} status={status}: only {} rows left for messages",
+                        h.saturating_sub(consumed)
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn draw_auto_hides_sidebar_on_a_narrow_terminal() {
+        // Wide terminal: the opted-in sidebar (its "Conversations" title) shows.
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        let mut app = App::new(); // show_sidebar defaults true
+        terminal.draw(|f| draw(f, &mut app)).unwrap();
+        let wide: String = terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .map(|c| c.symbol())
+            .collect();
+        assert!(
+            wide.contains("Conversations"),
+            "sidebar should show on a wide terminal"
+        );
+
+        // Narrow terminal, same opted-in state: the sidebar is suppressed so the
+        // chat keeps the columns — and the user's toggle is left untouched.
+        let backend = TestBackend::new(40, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|f| draw(f, &mut app)).unwrap();
+        let narrow: String = terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .map(|c| c.symbol())
+            .collect();
+        assert!(
+            !narrow.contains("Conversations"),
+            "sidebar should auto-hide on a narrow terminal"
+        );
+        assert!(app.show_sidebar, "the user's toggle must be left untouched");
     }
 
     #[test]

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -412,27 +412,26 @@ fn draw_messages(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
         .map(|sel| format!("  ·  {} · {}", sel.connection_id, sel.model_id))
         .unwrap_or_default();
     // Persistent cue for the two per-conversation voice controls (adele-tui#77),
-    // so the user can always see both states. `Adele:` (voice output, Ctrl+S
-    // cycles) shows only when not Disabled — the common default stays
-    // uncluttered; `You:` (voice input, Ctrl+V toggles) shows only when Enabled.
-    // A speaker glyph for Adele, a mic glyph for You so they read distinctly.
+    // so the user can always see both states. `Adele:` (voice output) shows only
+    // when not Disabled — the common default stays uncluttered; `You:` (voice
+    // input) shows only when Enabled. The keybindings (Ctrl+S / Ctrl+V) live in
+    // the `?`/F1 help overlay and the mode toolbar, so they aren't repeated in
+    // the title (declutter, CC-4); plain ASCII labels keep it width-safe (the
+    // former 🔊/🎙 glyphs risked double-width cells on some terminals).
     let adele_suffix = match app.current_adele_output() {
         AdeleOutput::Disabled => String::new(),
-        level => format!("  ·  🔊 Adele: {} (Ctrl+S)", level.label()),
+        level => format!("  ·  Adele: {}", level.label()),
     };
     let you_suffix = if app.current_voice_in() {
-        "  ·  🎙 You: Enabled (Ctrl+V)"
+        "  ·  You: on"
     } else {
         ""
     };
-    let title = if app.scroll_offset > 0 {
-        format!(
-            "{chat_title}{model_suffix}{adele_suffix}{you_suffix} \
-             (Ctrl+u/d scroll, Ctrl+e bottom)"
-        )
-    } else {
-        format!("{chat_title}{model_suffix}{adele_suffix}{you_suffix}")
-    };
+    // A bare up-arrow marks "scrolled up from the bottom"; the scroll keys
+    // themselves are in the help overlay / toolbar, so the old verbose
+    // "(Ctrl+u/d scroll, Ctrl+e bottom)" prose is gone (declutter, CC-4).
+    let scroll_marker = if app.scroll_offset > 0 { "  ↑" } else { "" };
+    let title = format!("{chat_title}{model_suffix}{adele_suffix}{you_suffix}{scroll_marker}");
 
     let block = Block::default()
         .borders(Borders::ALL)

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -7,42 +7,24 @@ use ratatui::{
 };
 
 use crate::app::{AdeleOutput, App, InputMode};
+use crate::theme::theme;
 
 const INPUT_VISIBLE_LINES: u16 = 4;
 const INPUT_TOTAL_HEIGHT: u16 = INPUT_VISIBLE_LINES + 2; // +2 for borders
-const COLOR_PANEL_BORDER: Color = Color::Rgb(82, 104, 173);
-const COLOR_LIST_BORDER: Color = Color::Rgb(62, 125, 146);
-const COLOR_INPUT_BORDER_IDLE: Color = Color::Rgb(109, 122, 143);
-const COLOR_INPUT_BORDER_EDIT: Color = Color::Rgb(120, 183, 109);
-const COLOR_LIST_HIGHLIGHT: Color = Color::Rgb(72, 102, 180);
-const COLOR_LIST_HIGHLIGHT_FG: Color = Color::Rgb(245, 248, 255);
-const COLOR_USER_PREFIX: Color = Color::Rgb(255, 189, 89);
-const COLOR_ASSISTANT_PREFIX: Color = Color::Rgb(92, 206, 154);
-const COLOR_ASSISTANT_STREAMING: Color = Color::Rgb(132, 218, 193);
-const COLOR_STATUS_DIM: Color = Color::Rgb(143, 153, 174);
-// Context-fill indicator colours (#341): green well under the 0.85
-// compaction line, amber approaching it, red at/over budget.
-const COLOR_CTX_GREEN: Color = Color::Rgb(122, 200, 132);
-const COLOR_CTX_AMBER: Color = Color::Rgb(232, 184, 96);
-const COLOR_CTX_RED: Color = Color::Rgb(232, 106, 106);
-const COLOR_COUNT_DIM: Color = Color::Rgb(124, 132, 148);
-const COLOR_DEBUG_TOOL: Color = Color::Rgb(178, 138, 220);
-const COLOR_DEBUG_SYSTEM: Color = Color::Rgb(140, 156, 196);
-const COLOR_ASSISTANT_INDICATOR: Color = Color::Rgb(178, 220, 245);
 
 fn mode_chip_style(mode: &InputMode) -> Style {
     match mode {
         InputMode::Normal => Style::default()
             .fg(Color::Black)
-            .bg(Color::Rgb(122, 163, 255))
+            .bg(theme().run)
             .add_modifier(Modifier::BOLD),
         InputMode::Editing => Style::default()
             .fg(Color::Black)
-            .bg(Color::Rgb(120, 214, 118))
+            .bg(theme().mode_edit_bg)
             .add_modifier(Modifier::BOLD),
         InputMode::Renaming => Style::default()
             .fg(Color::Black)
-            .bg(Color::Rgb(255, 189, 89))
+            .bg(theme().user_prefix)
             .add_modifier(Modifier::BOLD),
     }
 }
@@ -92,16 +74,16 @@ fn draw_help_overlay(f: &mut Frame, area: Rect) {
         lines.push(Line::from(Span::styled(
             *section,
             Style::default()
-                .fg(Color::Rgb(166, 182, 255))
+                .fg(theme().title)
                 .add_modifier(Modifier::BOLD),
         )));
         for (key, desc) in *binds {
             lines.push(Line::from(vec![
                 Span::styled(
                     format!("  {key:<22}"),
-                    Style::default().fg(Color::Rgb(216, 223, 236)),
+                    Style::default().fg(theme().hint_key),
                 ),
-                Span::styled(*desc, Style::default().fg(Color::Rgb(143, 153, 174))),
+                Span::styled(*desc, Style::default().fg(theme().text_dim)),
             ]));
         }
         lines.push(Line::from(""));
@@ -109,7 +91,7 @@ fn draw_help_overlay(f: &mut Frame, area: Rect) {
     lines.push(Line::from(Span::styled(
         "Inside modal screens (KB / connections / purposes), Ctrl+S = save.",
         Style::default()
-            .fg(Color::Rgb(143, 153, 174))
+            .fg(theme().text_dim)
             .add_modifier(Modifier::ITALIC),
     )));
 
@@ -119,11 +101,11 @@ fn draw_help_overlay(f: &mut Frame, area: Rect) {
     f.render_widget(Clear, popup);
     let block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Rgb(82, 104, 173)))
+        .border_style(Style::default().fg(theme().border))
         .title(Line::from(Span::styled(
             " Keys — press any key to close ",
             Style::default()
-                .fg(Color::Rgb(166, 182, 255))
+                .fg(theme().title)
                 .add_modifier(Modifier::BOLD),
         )));
     let para = Paragraph::new(lines)
@@ -153,11 +135,11 @@ fn draw_rename_popup(f: &mut Frame, app: &mut App, area: Rect) {
 
     let block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Rgb(255, 189, 89)))
+        .border_style(Style::default().fg(theme().user_prefix))
         .title(Line::from(Span::styled(
             "Rename (Enter save, Esc cancel)",
             Style::default()
-                .fg(Color::Rgb(255, 220, 160))
+                .fg(theme().rename_title)
                 .add_modifier(Modifier::BOLD),
         )));
 
@@ -184,7 +166,7 @@ fn draw_conversation_list(f: &mut Frame, app: &App, area: ratatui::layout::Rect)
             ));
             spans.push(Span::styled(
                 format!(" ({})", c.message_count),
-                Style::default().fg(COLOR_COUNT_DIM),
+                Style::default().fg(theme().count_dim),
             ));
             ListItem::new(Line::from(spans))
         })
@@ -200,18 +182,18 @@ fn draw_conversation_list(f: &mut Frame, app: &App, area: ratatui::layout::Rect)
         .block(
             Block::default()
                 .borders(Borders::ALL)
-                .border_style(Style::default().fg(COLOR_LIST_BORDER))
+                .border_style(Style::default().fg(theme().list_border))
                 .title(Line::from(Span::styled(
                     title,
                     Style::default()
-                        .fg(Color::Rgb(136, 214, 240))
+                        .fg(theme().list_title)
                         .add_modifier(Modifier::BOLD),
                 ))),
         )
         .highlight_style(
             Style::default()
-                .bg(COLOR_LIST_HIGHLIGHT)
-                .fg(COLOR_LIST_HIGHLIGHT_FG)
+                .bg(theme().list_highlight)
+                .fg(theme().list_highlight_fg)
                 .add_modifier(Modifier::BOLD),
         )
         .highlight_symbol("▸ ");
@@ -253,13 +235,13 @@ fn draw_assistant_status(f: &mut Frame, app: &App, area: ratatui::layout::Rect) 
         Span::styled(
             "● ",
             Style::default()
-                .fg(COLOR_ASSISTANT_INDICATOR)
+                .fg(theme().assistant_indicator)
                 .add_modifier(Modifier::BOLD),
         ),
         Span::styled(
             message,
             Style::default()
-                .fg(COLOR_ASSISTANT_INDICATOR)
+                .fg(theme().assistant_indicator)
                 .add_modifier(Modifier::ITALIC),
         ),
     ]));
@@ -366,32 +348,32 @@ fn draw_messages(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
             // only when the debug view is enabled.
             match msg.role.as_str() {
                 "user" => {
-                    let style = Style::default().fg(COLOR_USER_PREFIX);
+                    let style = Style::default().fg(theme().user_prefix);
                     push_user_message(&mut lines, &msg.content, style);
                     lines.push(Line::from(""));
                 }
                 "assistant" if !msg.content.trim().is_empty() => {
-                    let style = Style::default().fg(COLOR_ASSISTANT_PREFIX);
+                    let style = Style::default().fg(theme().assistant_prefix);
                     push_assistant_markdown(&mut lines, &msg.content, style);
                     lines.push(Line::from(""));
                 }
                 "tool" if app.show_debug => {
                     let style = Style::default()
-                        .fg(COLOR_DEBUG_TOOL)
+                        .fg(theme().debug_tool)
                         .add_modifier(Modifier::DIM | Modifier::ITALIC);
                     push_prefixed_message(&mut lines, "tool: ", &msg.content, style);
                     lines.push(Line::from(""));
                 }
                 "system" if app.show_debug => {
                     let style = Style::default()
-                        .fg(COLOR_DEBUG_SYSTEM)
+                        .fg(theme().debug_system)
                         .add_modifier(Modifier::DIM | Modifier::ITALIC);
                     push_prefixed_message(&mut lines, "system: ", &msg.content, style);
                     lines.push(Line::from(""));
                 }
                 "assistant" if app.show_debug => {
                     let style = Style::default()
-                        .fg(COLOR_ASSISTANT_PREFIX)
+                        .fg(theme().assistant_prefix)
                         .add_modifier(Modifier::DIM | Modifier::ITALIC);
                     push_prefixed_message(&mut lines, "Adele (empty): ", &msg.content, style);
                     lines.push(Line::from(""));
@@ -407,7 +389,7 @@ fn draw_messages(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
         // backgrounded turn keeps buffering invisibly and re-appears when the
         // user switches back to its conversation.
         if !app.streaming_buffer.is_empty() && app.streaming_is_for_current() {
-            let style = Style::default().fg(COLOR_ASSISTANT_STREAMING);
+            let style = Style::default().fg(theme().ok);
             push_assistant_markdown(&mut lines, &app.streaming_buffer, style);
             // Cursor on last line
             if let Some(last) = lines.last_mut() {
@@ -454,11 +436,11 @@ fn draw_messages(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
 
     let block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(COLOR_PANEL_BORDER))
+        .border_style(Style::default().fg(theme().border))
         .title(Line::from(Span::styled(
             title,
             Style::default()
-                .fg(Color::Rgb(166, 182, 255))
+                .fg(theme().title)
                 .add_modifier(Modifier::BOLD),
         )));
     let inner_width = block.inner(area).width;
@@ -485,12 +467,12 @@ fn draw_input(f: &mut Frame, app: &mut App, area: ratatui::layout::Rect) {
     let mut display = app.wrapped_display_textarea(wrap_width);
 
     let (title, border_color) = match app.mode {
-        InputMode::Normal => ("Input (press 'i' to edit)", COLOR_INPUT_BORDER_IDLE),
+        InputMode::Normal => ("Input (press 'i' to edit)", theme().input_border_idle),
         InputMode::Editing => (
             "Input (Esc cancel, Enter send, Shift+Enter/Ctrl+J newline)",
-            COLOR_INPUT_BORDER_EDIT,
+            theme().border_active,
         ),
-        InputMode::Renaming => ("Input", COLOR_INPUT_BORDER_IDLE),
+        InputMode::Renaming => ("Input", theme().input_border_idle),
     };
 
     display.set_block(
@@ -499,7 +481,7 @@ fn draw_input(f: &mut Frame, app: &mut App, area: ratatui::layout::Rect) {
             .border_style(Style::default().fg(border_color))
             .title(Line::from(Span::styled(
                 title,
-                Style::default().fg(Color::Rgb(216, 223, 236)),
+                Style::default().fg(theme().hint_key),
             ))),
     );
 
@@ -538,7 +520,7 @@ fn draw_status_bar(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
         return;
     }
     let mut spans: Vec<Span> = Vec::with_capacity(4);
-    spans.push(Span::styled(" • ", Style::default().fg(COLOR_STATUS_DIM)));
+    spans.push(Span::styled(" • ", Style::default().fg(theme().text_dim)));
     spans.push(Span::styled(
         app.status_message.as_str(),
         Style::default().fg(Color::White),
@@ -548,7 +530,7 @@ fn draw_status_bar(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
         spans.push(Span::styled(
             badge,
             Style::default()
-                .fg(Color::Rgb(122, 163, 255))
+                .fg(theme().run)
                 .add_modifier(Modifier::BOLD),
         ));
     }
@@ -560,10 +542,12 @@ fn draw_status_bar(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
 /// Pure so the colour-threshold contract is unit-testable without a frame.
 fn context_usage_span(usage: crate::app::ContextUsageView) -> (String, Color) {
     use crate::app::ContextFillLevel;
+    // Context-fill indicator colours (#341): green well under the 0.85
+    // compaction line, amber approaching it, red at/over budget.
     let color = match usage.level() {
-        ContextFillLevel::Green => COLOR_CTX_GREEN,
-        ContextFillLevel::Amber => COLOR_CTX_AMBER,
-        ContextFillLevel::Red => COLOR_CTX_RED,
+        ContextFillLevel::Green => theme().ctx_green,
+        ContextFillLevel::Amber => theme().ctx_amber,
+        ContextFillLevel::Red => theme().ctx_red,
     };
     (usage.readout(), color)
 }
@@ -583,13 +567,13 @@ mod tests {
             compaction_active: false,
         };
         // Green below 0.85.
-        assert_eq!(context_usage_span(mk(12_000, 32_000)).1, COLOR_CTX_GREEN);
+        assert_eq!(context_usage_span(mk(12_000, 32_000)).1, theme().ctx_green);
         // Amber at exactly 0.85 (27_200) and between line and budget.
-        assert_eq!(context_usage_span(mk(27_200, 32_000)).1, COLOR_CTX_AMBER);
-        assert_eq!(context_usage_span(mk(30_000, 32_000)).1, COLOR_CTX_AMBER);
+        assert_eq!(context_usage_span(mk(27_200, 32_000)).1, theme().ctx_amber);
+        assert_eq!(context_usage_span(mk(30_000, 32_000)).1, theme().ctx_amber);
         // Red at/over budget.
-        assert_eq!(context_usage_span(mk(32_000, 32_000)).1, COLOR_CTX_RED);
-        assert_eq!(context_usage_span(mk(40_000, 32_000)).1, COLOR_CTX_RED);
+        assert_eq!(context_usage_span(mk(32_000, 32_000)).1, theme().ctx_red);
+        assert_eq!(context_usage_span(mk(40_000, 32_000)).1, theme().ctx_red);
         // Text carries the readout.
         assert_eq!(context_usage_span(mk(12_000, 32_000)).0, "12k / 32k (38%)");
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -413,9 +413,9 @@ fn draw_messages(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
         // when the in-flight stream belongs to THIS conversation (TUI-4): a
         // backgrounded turn keeps buffering invisibly and re-appears when the
         // user switches back to its conversation.
-        if !app.streaming_buffer.is_empty() && app.streaming_is_for_current() {
+        if !app.streaming_buffer().is_empty() && app.streaming_is_active_for_view() {
             let style = Style::default().fg(theme().ok);
-            push_assistant_markdown(&mut lines, &app.streaming_buffer, style);
+            push_assistant_markdown(&mut lines, app.streaming_buffer(), style);
             // Cursor on last line
             if let Some(last) = lines.last_mut() {
                 last.spans.push(Span::styled("▌", style));
@@ -765,18 +765,25 @@ mod tests {
 
     #[test]
     fn draw_with_streaming_buffer_does_not_panic() {
+        use client_ui_common::UiMessage;
         let backend = TestBackend::new(80, 24);
         let mut terminal = Terminal::new(backend).unwrap();
         let mut app = App::new();
-        app.current_conversation = Some(ConversationDetail {
+        // `load_conversation` dual-writes the open-conversation id into core so
+        // the in-flight stream is active for the view; the chunk then buffers and
+        // paints through the same render guard production uses.
+        app.load_conversation(ConversationDetail {
             id: "1".into(),
             title: "Test".into(),
             messages: vec![],
             model_selection: None,
             conversation_personality: None,
         });
-        app.start_streaming("req1".into(), "1".into());
-        app.receive_chunk("req1", "Partial response...");
+        app.apply_prompt_ack("task1".into(), "1".into());
+        app.apply_core(UiMessage::StreamChunk {
+            request_id: "req1".into(),
+            chunk: "Partial response...".into(),
+        });
         terminal.draw(|f| draw(f, &mut app)).unwrap();
     }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -77,6 +77,59 @@ pub fn draw(f: &mut Frame, app: &mut App) {
     if app.tasks.visible {
         crate::tasks::draw_overlay(f, &app.tasks, f.area());
     }
+
+    // Keymap help (?/F1) sits on top of everything.
+    if app.show_help {
+        draw_help_overlay(f, f.area());
+    }
+}
+
+/// The `?`/F1 keymap help overlay. Content comes from `keys::help_sections` so
+/// the bindings stay single-sourced.
+fn draw_help_overlay(f: &mut Frame, area: Rect) {
+    let mut lines: Vec<Line> = Vec::new();
+    for (section, binds) in crate::keys::help_sections() {
+        lines.push(Line::from(Span::styled(
+            *section,
+            Style::default()
+                .fg(Color::Rgb(166, 182, 255))
+                .add_modifier(Modifier::BOLD),
+        )));
+        for (key, desc) in *binds {
+            lines.push(Line::from(vec![
+                Span::styled(
+                    format!("  {key:<22}"),
+                    Style::default().fg(Color::Rgb(216, 223, 236)),
+                ),
+                Span::styled(*desc, Style::default().fg(Color::Rgb(143, 153, 174))),
+            ]));
+        }
+        lines.push(Line::from(""));
+    }
+    lines.push(Line::from(Span::styled(
+        "Inside modal screens (KB / connections / purposes), Ctrl+S = save.",
+        Style::default()
+            .fg(Color::Rgb(143, 153, 174))
+            .add_modifier(Modifier::ITALIC),
+    )));
+
+    let height = (lines.len() as u16 + 2).min(area.height.saturating_sub(2));
+    let width = 60u16.min(area.width.saturating_sub(4));
+    let popup = centered_rect(width, height, area);
+    f.render_widget(Clear, popup);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Rgb(82, 104, 173)))
+        .title(Line::from(Span::styled(
+            " Keys — press any key to close ",
+            Style::default()
+                .fg(Color::Rgb(166, 182, 255))
+                .add_modifier(Modifier::BOLD),
+        )));
+    let para = Paragraph::new(lines)
+        .block(block)
+        .wrap(Wrap { trim: false });
+    f.render_widget(para, popup);
 }
 
 fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -366,7 +366,7 @@ fn push_assistant_markdown(lines: &mut Vec<Line<'static>>, content: &str, style:
 fn draw_messages(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
     let mut lines: Vec<Line> = Vec::new();
 
-    if let Some(conv) = &app.current_conversation {
+    if let Some(conv) = app.current_conversation() {
         for msg in &conv.messages {
             // Roles fall into a few buckets: user/assistant render normally
             // (assistant via markdown); tool/system/empty-assistant render
@@ -426,13 +426,11 @@ fn draw_messages(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
     }
 
     let chat_title = app
-        .current_conversation
-        .as_ref()
+        .current_conversation()
         .map(|conv| conv.title.as_str())
         .unwrap_or("Chat");
     let model_suffix = app
-        .current_conversation
-        .as_ref()
+        .current_conversation()
         .and_then(|conv| conv.model_selection.as_ref())
         .map(|sel| format!("  ·  {} · {}", sel.connection_id, sel.model_id))
         .unwrap_or_default();
@@ -674,7 +672,7 @@ mod tests {
         let backend = TestBackend::new(80, 24);
         let mut terminal = Terminal::new(backend).unwrap();
         let mut app = App::new();
-        app.current_conversation = Some(ConversationDetail {
+        app.load_conversation(ConversationDetail {
             id: "1".into(),
             title: "Test".into(),
             messages: vec![
@@ -714,7 +712,7 @@ mod tests {
         // the chat title only when the open conversation's level is not Disabled,
         // and reflects the current level label.
         let mut app = App::new();
-        app.current_conversation = Some(ConversationDetail {
+        app.load_conversation(ConversationDetail {
             id: "c1".into(),
             title: "ChatProbe".into(),
             messages: vec![],
@@ -747,7 +745,7 @@ mod tests {
         // the chat title only while the open conversation's You is Enabled, and
         // is distinct from the Adele cue.
         let mut app = App::new();
-        app.current_conversation = Some(ConversationDetail {
+        app.load_conversation(ConversationDetail {
             id: "c1".into(),
             title: "ChatProbe".into(),
             messages: vec![],
@@ -1006,7 +1004,7 @@ mod tests {
     fn app_with_debug_messages(show_debug: bool) -> App {
         let mut app = App::new();
         app.show_debug = show_debug;
-        app.current_conversation = Some(ConversationDetail {
+        app.load_conversation(ConversationDetail {
             id: "1".into(),
             title: "Test".into(),
             messages: vec![
@@ -1077,7 +1075,7 @@ mod tests {
         let backend = TestBackend::new(80, 24);
         let mut terminal = Terminal::new(backend).unwrap();
         let mut app = App::new();
-        app.current_conversation = Some(ConversationDetail {
+        app.load_conversation(ConversationDetail {
             id: "1".into(),
             title: "Test".into(),
             messages: vec![],
@@ -1138,7 +1136,7 @@ mod tests {
         let backend = TestBackend::new(80, 24);
         let mut terminal = Terminal::new(backend).unwrap();
         let mut app = App::new();
-        app.current_conversation = Some(ConversationDetail {
+        app.load_conversation(ConversationDetail {
             id: "1".into(),
             title: "Test".into(),
             messages: vec![ChatMessage {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -802,6 +802,38 @@ mod tests {
     }
 
     #[test]
+    fn draw_input_border_recolors_to_warn_only_when_disconnected() {
+        // The disconnect cue is two-channel: the text tag (asserted above, the
+        // NO_COLOR-safe channel) *and* a warn-recolored input border. `warn` is
+        // unique among the palette's border colors, so a warn-colored border
+        // glyph appears iff the link is down — letting us assert the recolor
+        // directly rather than only the tag.
+        fn input_border_has_warn(app: &mut App) -> bool {
+            let backend = TestBackend::new(80, 24);
+            let mut terminal = Terminal::new(backend).unwrap();
+            terminal.draw(|f| draw(f, app)).unwrap();
+            let buf = terminal.backend().buffer().clone();
+            buf.content.iter().any(|c| {
+                matches!(c.symbol(), "┌" | "┐" | "└" | "┘" | "│" | "─") && c.fg == theme().warn
+            })
+        }
+
+        let mut offline = App::new();
+        offline.connected = false;
+        assert!(
+            input_border_has_warn(&mut offline),
+            "a disconnected input border must be warn-colored"
+        );
+
+        let mut online = App::new();
+        // App::new() defaults connected = true.
+        assert!(
+            !input_border_has_warn(&mut online),
+            "no border should be warn-colored while connected"
+        );
+    }
+
+    #[test]
     fn draw_small_terminal_does_not_panic() {
         let backend = TestBackend::new(20, 8);
         let mut terminal = Terminal::new(backend).unwrap();


### PR DESCRIPTION
Makes adele-tui a thin client over the shared `client-ui-common` crate — the companion to adele-gtk's port (#105). Both Rust clients now run on one reducer; the ~70-80% state-logic duplication the epic targeted is gone from the running binaries.

**Moved into the shared core (consumed here):**
- **Streaming** — in-flight request/stream state machine, narration gate, external-turn handling; the view reads `core.streaming_buffer()` / `streaming_is_active_for_view()`.
- **Conversation list + mutations** — list, delete (with per-conversation voice-state prune), rename, live title-change all route through `core.apply`.
- **Open conversation** — the App↔core dual-copy collapsed; the transcript lives in `core.current_conversation`, so `CompleteStreaming`/`AddUserMessage`/`ClearChat` are view-level no-ops.
- **Send path** — `UiMessage::SubmitPrompt` → `Effect::SendPrompt` (the Phase-2 RPC effect); App's bespoke `submit_prompt`/`prepare_submission`/`restore_failed_submission` deleted.
- **Per-conversation voice** state.

**adele-tui-side cleanups:**
- `ScreenRequest` enum replaces the 5 independent `*_requested` modal-open bools (mutual exclusion + one dispatch point).
- `minter_socket` wired (UDS-only) so it connects via the local `adelie-mint` minter, not the removed D-Bus path.

~392 tests green; `just check` clean (fmt + clippy `-D warnings` + build + test). `client-ui-common` is a local path-dep (no remote runner build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)