### PR TITLE
Drop minter_socket (peer-cred local auth) + handle Consolidation purpose

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -500,7 +500,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
- "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -836,17 +835,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "backon"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
-dependencies = [
- "fastrand",
- "gloo-timers",
- "tokio",
-]
-
-[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1160,7 +1148,6 @@ version = "0.1.0"
 dependencies = [
  "adele-voice-client-common",
  "desktop-assistant-api-model",
- "desktop-assistant-client-common",
  "serde",
  "serde_json",
 ]
@@ -1500,19 +1487,9 @@ dependencies = [
 name = "desktop-assistant-api-model"
 version = "0.1.0"
 dependencies = [
- "desktop-assistant-core",
+ "desktop-assistant-protocol",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "desktop-assistant-auth-jwt"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "jsonwebtoken",
- "serde",
- "uuid",
 ]
 
 [[package]]
@@ -1536,27 +1513,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "desktop-assistant-core"
-version = "0.1.0"
-dependencies = [
- "async-trait",
- "backon",
- "chrono",
- "desktop-assistant-auth-jwt",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tokio",
- "tokio-util",
- "tracing",
- "uuid",
-]
-
-[[package]]
 name = "desktop-assistant-frame-codec"
 version = "0.1.0"
 dependencies = [
  "tokio",
+]
+
+[[package]]
+name = "desktop-assistant-protocol"
+version = "0.1.0"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1997,18 +1964,6 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
-name = "gloo-timers"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "h2"
@@ -2581,24 +2536,6 @@ dependencies = [
  "futures-util",
  "once_cell",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "jsonwebtoken"
-version = "10.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
-dependencies = [
- "aws-lc-rs",
- "base64",
- "getrandom 0.2.17",
- "js-sys",
- "pem",
- "serde",
- "serde_json",
- "signature",
- "simple_asn1",
- "zeroize",
 ]
 
 [[package]]
@@ -3288,16 +3225,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
-name = "pem"
-version = "3.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
-dependencies = [
- "base64",
- "serde_core",
-]
-
-[[package]]
 name = "pem-rfc7468"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3951,7 +3878,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -4098,7 +4025,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
@@ -4342,15 +4269,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signature"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
-dependencies = [
- "rand_core 0.6.4",
-]
-
-[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4371,18 +4289,6 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
-
-[[package]]
-name = "simple_asn1"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
-dependencies = [
- "num-bigint",
- "num-traits",
- "thiserror 2.0.18",
- "time",
-]
 
 [[package]]
 name = "siphasher"
@@ -5033,12 +4939,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -6027,20 +5927,6 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
 
 [[package]]
 name = "zerotrie"

--- a/src/main.rs
+++ b/src/main.rs
@@ -144,13 +144,8 @@ impl From<CliArgs> for ConnectionConfig {
             ws_login_password: None,
             ws_subject,
             socket_path,
-            // Mint the UDS handshake JWT locally (#101/#316), not over the
-            // deprecated D-Bus path. UDS-only — see `Profile::to_connection_config`.
-            minter_socket: if matches!(transport_mode, TransportMode::Uds) {
-                desktop_assistant_client_common::minter::default_minter_socket_path()
-            } else {
-                None
-            },
+            // Local UDS authenticates by kernel peer-cred (desktop-assistant#407):
+            // no token is minted — see `Profile::to_connection_config`.
             ..Default::default()
         }
     }

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -92,18 +92,9 @@ impl Profile {
             ws_login_username: self.username.clone(),
             ws_login_password: password,
             socket_path: self.socket_path.clone(),
-            // Mint the UDS handshake JWT from the local `adelie-mint` minter
-            // (#101/#316) — the preferred, non-retiring source — rather than the
-            // deprecated D-Bus `generate_ws_jwt` path (removed by the cutover).
-            // UDS-only: the minter issues tokens the *local* daemon trusts;
-            // WS targets a (possibly remote) server and must keep authenticating
-            // via OAuth/password (an explicit `ws_jwt` or the `/login` fallback),
-            // and D-Bus needs no token at all (peer credentials).
-            minter_socket: if matches!(self.transport, TransportMode::Uds) {
-                desktop_assistant_client_common::minter::default_minter_socket_path()
-            } else {
-                None
-            },
+            // Local UDS authenticates by kernel peer-cred (desktop-assistant#407):
+            // no token is minted. WS still authenticates via an explicit `ws_jwt`
+            // or the `/login` fallback; D-Bus needs no token either (peer creds).
             ..Default::default()
         }
     }

--- a/src/purposes.rs
+++ b/src/purposes.rs
@@ -50,6 +50,7 @@ use crate::theme::theme;
 const PURPOSES: &[PurposeKindApi] = &[
     PurposeKindApi::Interactive,
     PurposeKindApi::Dreaming,
+    PurposeKindApi::Consolidation,
     PurposeKindApi::Embedding,
     PurposeKindApi::Titling,
 ];
@@ -521,6 +522,7 @@ fn purpose_slot(view: &PurposesView, kind: PurposeKindApi) -> Option<&PurposeCon
     match kind {
         PurposeKindApi::Interactive => view.interactive.as_ref(),
         PurposeKindApi::Dreaming => view.dreaming.as_ref(),
+        PurposeKindApi::Consolidation => view.consolidation.as_ref(),
         PurposeKindApi::Embedding => view.embedding.as_ref(),
         PurposeKindApi::Titling => view.titling.as_ref(),
     }
@@ -530,6 +532,7 @@ fn purpose_label(kind: PurposeKindApi) -> &'static str {
     match kind {
         PurposeKindApi::Interactive => "Interactive",
         PurposeKindApi::Dreaming => "Dreaming",
+        PurposeKindApi::Consolidation => "Consolidation",
         PurposeKindApi::Embedding => "Embedding",
         PurposeKindApi::Titling => "Titling",
     }


### PR DESCRIPTION
## What
The daemon now authenticates local UDS connections by **kernel peer-cred** (desktop-assistant#407) and the `adelie-mint` minter is retired. `client-common` dropped the `minter` module and the `minter_socket` / `minter_ttl_seconds` config fields, so this client stops setting them — the local UDS handshake is now **tokenless** (the `ConnectionConfig` defaults cover it).

Touches `src/profile.rs` + `src/main.rs` (both built a `ConnectionConfig` with a `minter_socket`).

## Also (unblocks the build)
The protocol's `PurposeKind` gained a **`Consolidation`** variant (desktop-assistant#402), so the non-exhaustive `purpose_slot` / `purpose_label` matches no longer compiled against current `client-common`. Surfaced it like the other purposes (list + slot + label in `src/purposes.rs`).

## Verified
- `cargo install --path . --force` succeeds; `adele` reinstalled.
- `cargo fmt --check` + `cargo clippy --all-targets` clean.
- Local UDS path is tokenless; live daemon (on merged main) already verified accepting peer-cred connections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)