### PR TITLE
Confirm before deleting a conversation in the chat sidebar

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -154,6 +154,15 @@ pub struct App {
     pub should_quit: bool,
     /// Whether the `?`/F1 keymap help overlay is shown. Any key closes it.
     pub show_help: bool,
+    /// Title of the conversation awaiting a delete confirmation, or `None` when
+    /// no confirm overlay is up. Set when `d` is pressed in the sidebar (it no
+    /// longer deletes immediately — matching the KB / connections / profile
+    /// destructive-delete convention); the overlay names this title. `y`/`Enter`
+    /// confirms (runs the delete against the still-selected row), `n`/`Esc`
+    /// cancels; any other key is ignored. Held only for display — the delete
+    /// itself operates on `selected_conversation`, which the overlay blocks the
+    /// user from moving.
+    pub pending_delete_conversation: Option<String>,
     /// Lines scrolled up from the bottom. 0 = auto-scroll to bottom.
     pub scroll_offset: u16,
     /// Whether to include archived conversations in the list.
@@ -235,6 +244,7 @@ impl App {
             connected: true,
             should_quit: false,
             show_help: false,
+            pending_delete_conversation: None,
             scroll_offset: 0,
             show_archived: false,
             rename_textarea: new_textarea(),
@@ -955,6 +965,41 @@ impl App {
             title: title.to_string(),
         });
         self.set_open_conversation_title(conversation_id, title);
+    }
+
+    // --- Delete confirmation ---
+
+    /// Arm the delete-confirm overlay for the selected conversation, stashing its
+    /// title for the prompt. No-op when nothing is selected (so a stray `d` on an
+    /// empty list does nothing). The overlay is dismissed by [`Self::confirm_delete`]
+    /// or [`Self::cancel_delete_confirm`]; the actual removal still goes through
+    /// [`Self::delete_selected_conversation`] on confirm.
+    pub fn begin_delete_confirm(&mut self) {
+        let Some(idx) = self.selected_conversation else {
+            return;
+        };
+        let Some(conv) = self.core.conversations.get(idx) else {
+            return;
+        };
+        self.pending_delete_conversation = Some(conv.title.clone());
+    }
+
+    /// Whether the delete-confirm overlay is currently up.
+    pub fn delete_confirm_pending(&self) -> bool {
+        self.pending_delete_conversation.is_some()
+    }
+
+    /// Dismiss the delete-confirm overlay on confirmation, returning `true` when
+    /// it was actually up (the caller then runs the delete). The removal itself is
+    /// left to [`Self::delete_selected_conversation`] so the existing delete path
+    /// is unchanged.
+    pub fn confirm_delete(&mut self) -> bool {
+        self.pending_delete_conversation.take().is_some()
+    }
+
+    /// Dismiss the delete-confirm overlay without deleting.
+    pub fn cancel_delete_confirm(&mut self) {
+        self.pending_delete_conversation = None;
     }
 
     pub fn delete_selected_conversation(&mut self) -> Option<String> {
@@ -1986,6 +2031,66 @@ mod tests {
             "deleting the active conversation clears the open chat"
         );
         assert_eq!(app.selected_conversation, Some(1)); // stays at 1 (now "Third")
+    }
+
+    // --- Delete-confirm gate (mirrors picker.rs's confirm tests; the event loop
+    // routes y/Enter → confirm_delete + delete, n/Esc → cancel_delete_confirm). ---
+
+    #[test]
+    fn begin_delete_confirm_arms_overlay_with_selected_title() {
+        let mut app = app_with_conversations();
+        assert!(!app.delete_confirm_pending(), "starts disarmed");
+        app.selected_conversation = Some(1); // "Second"
+        app.begin_delete_confirm();
+        assert!(app.delete_confirm_pending());
+        assert_eq!(app.pending_delete_conversation.as_deref(), Some("Second"));
+    }
+
+    #[test]
+    fn begin_delete_confirm_without_selection_is_noop() {
+        let mut app = app_with_conversations();
+        assert!(app.selected_conversation.is_none());
+        app.begin_delete_confirm();
+        assert!(
+            !app.delete_confirm_pending(),
+            "a stray `d` on nothing selected does not arm the overlay"
+        );
+    }
+
+    #[test]
+    fn confirm_delete_then_delete_removes_the_row() {
+        // The loop's y/Enter path: confirm_delete() clears the overlay and
+        // reports it was up, then delete_selected_conversation() removes the row.
+        let mut app = app_with_conversations();
+        app.selected_conversation = Some(1); // "Second"
+        app.begin_delete_confirm();
+        assert!(app.confirm_delete(), "reports the overlay was up");
+        assert!(!app.delete_confirm_pending(), "overlay cleared on confirm");
+        let deleted = app.delete_selected_conversation();
+        assert_eq!(deleted, Some("2".to_string()));
+        assert_eq!(app.conversations().len(), 2);
+        assert!(app.conversations().iter().all(|c| c.id != "2"));
+    }
+
+    #[test]
+    fn confirm_delete_returns_false_when_not_armed() {
+        // Guards the loop's gate: the confirm branch only runs the delete when
+        // the overlay was actually up (it checks `delete_confirm_pending` first,
+        // and confirm_delete() reports false otherwise).
+        let mut app = app_with_conversations();
+        assert!(!app.confirm_delete());
+    }
+
+    #[test]
+    fn cancel_delete_confirm_dismisses_without_deleting() {
+        // The loop's n/Esc path: cancel clears the overlay and the row survives.
+        let mut app = app_with_conversations();
+        app.selected_conversation = Some(1); // "Second"
+        app.begin_delete_confirm();
+        app.cancel_delete_confirm();
+        assert!(!app.delete_confirm_pending());
+        assert_eq!(app.conversations().len(), 3, "nothing was deleted");
+        assert!(app.conversations().iter().any(|c| c.id == "2"));
     }
 
     #[test]

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -8,6 +8,13 @@ pub enum Action {
     NextConversation,
     PreviousConversation,
     OpenConversation,
+    /// Arm the delete-confirm overlay for the selected conversation (`d` in the
+    /// sidebar). Deletion no longer fires on the first keypress — matching the
+    /// KB / connections / profile destructive-delete flows, which all confirm
+    /// first. The overlay's `y`/`Enter` then dispatches [`Action::DeleteConversation`].
+    BeginDeleteConversation,
+    /// Perform the conversation delete. Dispatched by the confirm overlay
+    /// (`y`/`Enter`), not bound to a key directly.
     DeleteConversation,
     ArchiveConversation,
     NewConversation,
@@ -187,7 +194,7 @@ pub fn handle_key_event(
                 KeyCode::Char('q') => Some(Action::Quit),
                 KeyCode::Char('j') | KeyCode::Down => Some(Action::NextConversation),
                 KeyCode::Char('k') | KeyCode::Up => Some(Action::PreviousConversation),
-                KeyCode::Char('d') => Some(Action::DeleteConversation),
+                KeyCode::Char('d') => Some(Action::BeginDeleteConversation),
                 KeyCode::Char('n') => Some(Action::NewConversation),
                 KeyCode::Char('a') => Some(Action::ToggleShowArchived),
                 KeyCode::Char('A') => Some(Action::ArchiveConversation),
@@ -390,10 +397,14 @@ mod tests {
     }
 
     #[test]
-    fn normal_d_deletes() {
+    fn normal_d_arms_delete_confirm() {
+        // `d` no longer deletes immediately — it arms the confirm overlay
+        // (matching the KB / connections / profile destructive-delete flows).
+        // The actual `DeleteConversation` is dispatched by the overlay on
+        // `y`/`Enter`, not bound to a key.
         assert_eq!(
             handle_key_event(key(KeyCode::Char('d')), &InputMode::Normal, false),
-            Some(Action::DeleteConversation)
+            Some(Action::BeginDeleteConversation)
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,8 +12,8 @@ use anyhow::Result;
 use clap::{CommandFactory, FromArgMatches, Parser, parser::ValueSource};
 use crossterm::{
     event::{
-        DisableBracketedPaste, EnableBracketedPaste, Event, KeyEventKind, KeyboardEnhancementFlags,
-        PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
+        DisableBracketedPaste, EnableBracketedPaste, Event, KeyCode, KeyEventKind,
+        KeyboardEnhancementFlags, PopKeyboardEnhancementFlags, PushKeyboardEnhancementFlags,
     },
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
@@ -613,6 +613,30 @@ async fn run(
                     // dismisses it (and does nothing else).
                     if app.show_help {
                         app.show_help = false;
+                        continue;
+                    }
+                    // The delete-confirm overlay is modal: while it's up, only an
+                    // explicit confirm (y/Y/Enter) or cancel (n/N/Esc) is honored;
+                    // every other key is ignored (matching the KB / connections /
+                    // profile confirms). Confirm runs the existing delete path.
+                    if app.delete_confirm_pending() {
+                        match key.code {
+                            KeyCode::Char('y') | KeyCode::Char('Y') | KeyCode::Enter => {
+                                if app.confirm_delete() {
+                                    handle_action(
+                                        &mut app,
+                                        &connector,
+                                        &mut in_flight,
+                                        Action::DeleteConversation,
+                                    )
+                                    .await;
+                                }
+                            }
+                            KeyCode::Char('n') | KeyCode::Char('N') | KeyCode::Esc => {
+                                app.cancel_delete_confirm();
+                            }
+                            _ => {}
+                        }
                         continue;
                     }
                     if let Some(action) = handle_key_event(key, &app.mode, app.tasks.visible) {
@@ -1316,6 +1340,13 @@ async fn handle_action(
                     }
                 });
             }
+        }
+        Action::BeginDeleteConversation => {
+            // `d` arms the confirm overlay instead of deleting outright (matching
+            // the other destructive deletes). The overlay's y/Enter dispatches
+            // `DeleteConversation`; n/Esc cancels. Both are driven in the event
+            // loop, which renders the overlay while it's armed.
+            app.begin_delete_confirm();
         }
         Action::DeleteConversation => {
             // Check connectivity BEFORE mutating local state (TUI-2's shape):

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -84,10 +84,50 @@ pub fn draw(f: &mut Frame, app: &mut App) {
         crate::tasks::draw_overlay(f, &app.tasks, f.area());
     }
 
+    // Delete-confirm overlay (armed by `d` in the sidebar). Modal: the event
+    // loop only honors confirm/cancel keys while it's up. Rendered on top of the
+    // chat, matching the KB / connections / profile destructive-delete confirms.
+    if let Some(title) = &app.pending_delete_conversation {
+        draw_delete_overlay(f, title, f.area());
+    }
+
     // Keymap help (?/F1) sits on top of everything.
     if app.show_help {
         draw_help_overlay(f, f.area());
     }
+}
+
+/// Confirm overlay for conversation-delete (`d`). Mirrors the destructive-delete
+/// confirms in `kb.rs` / `connections.rs` / `picker.rs`: red border, the named
+/// target, and the shared `y/Enter = confirm · n/Esc = cancel` footer.
+fn draw_delete_overlay(f: &mut Frame, title: &str, area: Rect) {
+    let popup_width = 60u16.min(area.width.saturating_sub(4));
+    let popup_height = 5u16.min(area.height.saturating_sub(2));
+    let popup = centered_rect(popup_width, popup_height, area);
+    f.render_widget(Clear, popup);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme().error))
+        .title(Line::from(Span::styled(
+            "Delete conversation",
+            Style::default()
+                .fg(theme().error_text)
+                .add_modifier(Modifier::BOLD),
+        )));
+    let inner = block.inner(popup);
+    f.render_widget(block, popup);
+    let body = Paragraph::new(vec![
+        Line::from(Span::styled(
+            format!("Delete \"{title}\"?"),
+            Style::default().fg(Color::White),
+        )),
+        Line::from(Span::styled(
+            "y/Enter = confirm · n/Esc = cancel",
+            Style::default().fg(theme().text_dim),
+        )),
+    ])
+    .wrap(Wrap { trim: true });
+    f.render_widget(body, inner);
 }
 
 /// The `?`/F1 keymap help overlay. Content comes from `keys::help_sections` so


### PR DESCRIPTION
Conversation-delete fired immediately on a single d in the chat sidebar, with no confirm step — unlike the KB-entry, connection, and profile deletes, which all show a confirm overlay. Since the conversation delete is optimistic and only resyncs on RPC failure, a stray d permanently removed a conversation with no undo.

d now arms a delete-confirm overlay matching the existing destructive-confirm convention: y/Y/Enter confirms (runs the existing delete path), n/N/Esc cancels, any other key is ignored; the overlay names the conversation being deleted with the shared "y/Enter = confirm / n/Esc = cancel" footer. View-layer only (keys.rs, app.rs, main.rs, ui.rs); 6 new tests; build / clippy / test / fmt all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)