### PR TITLE
feat: client-side MCP host — run local MCP servers, exposed to the (remote) brain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,7 +29,7 @@ dependencies = [
  "serde_json",
  "syntect",
  "tokio",
- "toml",
+ "toml 0.9.12+spec-1.1.0",
  "tracing",
  "unicode-width",
  "url",
@@ -500,6 +500,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
+ "untrusted 0.7.1",
  "zeroize",
 ]
 
@@ -832,6 +833,17 @@ dependencies = [
  "aws-smithy-types",
  "rustc_version",
  "tracing",
+]
+
+[[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
+ "gloo-timers",
+ "tokio",
 ]
 
 [[package]]
@@ -1270,7 +1282,7 @@ dependencies = [
  "alsa",
  "coreaudio-rs",
  "dasp_sample",
- "jni 0.21.1",
+ "jni",
  "js-sys",
  "libc",
  "mach2",
@@ -1493,6 +1505,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "desktop-assistant-auth-jwt"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "jsonwebtoken",
+ "serde",
+ "uuid",
+]
+
+[[package]]
 name = "desktop-assistant-client-common"
 version = "0.1.0"
 dependencies = [
@@ -1500,16 +1522,37 @@ dependencies = [
  "async-trait",
  "desktop-assistant-api-model",
  "desktop-assistant-frame-codec",
+ "desktop-assistant-mcp-client",
  "futures",
- "reqwest 0.13.3",
+ "reqwest 0.13.1",
  "rustls",
  "rustls-pki-types",
+ "serde",
  "serde_json",
  "tokio",
  "tokio-tungstenite",
+ "toml 1.1.2+spec-1.1.0",
  "tracing",
  "uuid",
  "zbus",
+]
+
+[[package]]
+name = "desktop-assistant-core"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "backon",
+ "chrono",
+ "desktop-assistant-auth-jwt",
+ "desktop-assistant-protocol",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -1517,6 +1560,26 @@ name = "desktop-assistant-frame-codec"
 version = "0.1.0"
 dependencies = [
  "tokio",
+]
+
+[[package]]
+name = "desktop-assistant-mcp-client"
+version = "0.1.0"
+dependencies = [
+ "base64",
+ "chrono",
+ "desktop-assistant-core",
+ "rand 0.9.4",
+ "reqwest 0.13.1",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
+ "tokio",
+ "toml 1.1.2+spec-1.1.0",
+ "tracing",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -1964,6 +2027,18 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "h2"
@@ -2459,36 +2534,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jni"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
-dependencies = [
- "cfg-if",
- "combine",
- "jni-macros",
- "jni-sys 0.4.1",
- "log",
- "simd_cesu8",
- "thiserror 2.0.18",
- "walkdir",
- "windows-link",
-]
-
-[[package]]
-name = "jni-macros"
-version = "0.22.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
-dependencies = [
- "proc-macro2",
- "quote",
- "rustc_version",
- "simd_cesu8",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2536,6 +2581,24 @@ dependencies = [
  "futures-util",
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "10.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+dependencies = [
+ "aws-lc-rs",
+ "base64",
+ "getrandom 0.2.17",
+ "js-sys",
+ "pem",
+ "serde",
+ "serde_json",
+ "signature",
+ "simple_asn1",
+ "zeroize",
 ]
 
 [[package]]
@@ -3225,6 +3288,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3830,9 +3903,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.3"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
+checksum = "04e9018c9d814e5f30cc16a0f03271aeab3571e609612d9fe78c1aa8d11c2f62"
 dependencies = [
  "base64",
  "bytes",
@@ -3866,6 +3939,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -3878,7 +3952,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -3991,13 +4065,13 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.7.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni 0.22.4",
+ "jni",
  "log",
  "once_cell",
  "rustls",
@@ -4025,7 +4099,7 @@ dependencies = [
  "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -4269,26 +4343,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
-name = "simd_cesu8"
-version = "1.1.1"
+name = "simple_asn1"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
- "rustc_version",
- "simdutf8",
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
 ]
-
-[[package]]
-name = "simdutf8"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -4722,6 +4801,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.2",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.7.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4939,6 +5033,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"
@@ -5927,6 +6027,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ zbus = { version = "5", default-features = false, features = ["tokio"] }
 # Shared protocol + transport crates live in the desktop-assistant repo.
 # Cargo resolves the package by name from that workspace; Cargo.lock pins
 # the exact revision for reproducibility.
-desktop-assistant-client-common = { git = "https://github.com/adelie-ai/desktop-assistant.git", branch = "main" }
+desktop-assistant-client-common = { git = "https://github.com/adelie-ai/desktop-assistant.git", branch = "main", features = ["mcp-host"] }
 desktop-assistant-api-model = { git = "https://github.com/adelie-ai/desktop-assistant.git", branch = "main" }
 
 # The shared view-agnostic model+controller (CC-3, desktop-assistant#358).

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,7 @@
+use std::rc::Rc;
+
 use desktop_assistant_api_model::TaskId;
+use desktop_assistant_client_common::mcp_host::McpHost;
 pub use desktop_assistant_client_common::{ChatMessage, ConversationDetail, ConversationSummary};
 use ratatui::style::Style;
 use ratatui_textarea::{CursorMove, DataCursor, TextArea};
@@ -151,6 +154,11 @@ pub struct App {
     /// first draw. (CC-3 moves this into the shared `core` once signals route
     /// through the reducer.)
     pub connected: bool,
+    /// Client-side MCP host (`client-mcp.toml`): local MCP servers whose tools
+    /// are exposed to the daemon as client-side tools. Created once at startup,
+    /// shared (`Rc`) between the register site and client-tool dispatch; `None`
+    /// when no servers are configured for this surface.
+    pub mcp_host: Option<Rc<McpHost>>,
     pub should_quit: bool,
     /// Whether the `?`/F1 keymap help overlay is shown. Any key closes it.
     pub show_help: bool,
@@ -260,6 +268,7 @@ impl App {
             tasks: TaskPane::new(),
             pending_task_cancel: None,
             core: WindowState::default(),
+            mcp_host: None,
         }
     }
 

--- a/src/kb.rs
+++ b/src/kb.rs
@@ -294,8 +294,7 @@ impl Screen for KbScreen<'_> {
         // pass writes entries (or another client edits one). Refetch the list so
         // the browser updates in place while it stays open. Only when not mid-edit,
         // so a refetch never clobbers an in-progress entry the user is typing.
-        if matches!(signal, SignalEvent::KnowledgeChanged)
-            && !matches!(self.state.mode, Mode::Edit)
+        if matches!(signal, SignalEvent::KnowledgeChanged) && !matches!(self.state.mode, Mode::Edit)
         {
             refresh_list(&mut self.state, &mut self.pending, self.client);
         }
@@ -389,7 +388,13 @@ fn handle_list_key<'a>(
         // y/Y confirm keys below. `D`/`C` fire immediately; `E` (a full re-embed
         // of the whole KB) is gated behind a confirm overlay.
         (KeyCode::Char('D'), _) => {
-            start_maintenance(state, pending, client, MaintenanceOp::Extraction, "Extraction");
+            start_maintenance(
+                state,
+                pending,
+                client,
+                MaintenanceOp::Extraction,
+                "Extraction",
+            );
         }
         (KeyCode::Char('C'), _) => {
             start_maintenance(
@@ -977,9 +982,7 @@ fn draw_hints(f: &mut Frame, state: &State, area: Rect) {
         ],
         Mode::Search => &[("Enter", "search"), ("Esc", "clear & back")],
         Mode::Edit => &[("Tab", "next field"), ("Ctrl+S", "save"), ("Esc", "cancel")],
-        Mode::DeleteConfirm | Mode::RecalcConfirm => {
-            &[("y/Enter", "confirm"), ("n/Esc", "cancel")]
-        }
+        Mode::DeleteConfirm | Mode::RecalcConfirm => &[("y/Enter", "confirm"), ("n/Esc", "cancel")],
     };
 
     let mut spans: Vec<Span> = Vec::with_capacity(hints.len() * 4);

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,6 +99,21 @@ struct CliArgs {
         default_value = DEFAULT_WS_SUBJECT
     )]
     ws_subject: String,
+    /// Send a single prompt non-interactively, print the reply to stdout, and
+    /// exit — no TUI. Client-hosted MCP tools (client-mcp.toml) still work, so
+    /// this can drive a local or remote (k8s) brain end to end.
+    #[arg(long, value_name = "TEXT")]
+    prompt: Option<String>,
+    /// Bearer (JWT) for the WebSocket transport, skipping interactive login.
+    #[arg(long = "ws-jwt", env = "DESKTOP_ASSISTANT_TUI_WS_JWT")]
+    ws_jwt: Option<String>,
+    /// Username for WebSocket password login (with --ws-login-password).
+    #[arg(long = "ws-login-username", env = "DESKTOP_ASSISTANT_TUI_WS_USERNAME")]
+    ws_login_username: Option<String>,
+    /// Password for WebSocket password login. Prefer the env var so it doesn't
+    /// land in shell history / the process list.
+    #[arg(long = "ws-login-password", env = "DESKTOP_ASSISTANT_TUI_WS_PASSWORD")]
+    ws_login_password: Option<String>,
 }
 
 impl From<CliArgs> for ConnectionConfig {
@@ -144,9 +159,9 @@ impl From<CliArgs> for ConnectionConfig {
         Self {
             transport_mode,
             ws_url,
-            ws_jwt: None,
-            ws_login_username: None,
-            ws_login_password: None,
+            ws_jwt: cli.ws_jwt,
+            ws_login_username: cli.ws_login_username,
+            ws_login_password: cli.ws_login_password,
             ws_subject,
             socket_path,
             // Local UDS authenticates by kernel peer-cred (desktop-assistant#407):
@@ -201,6 +216,13 @@ async fn main() -> Result<()> {
     let cli = CliArgs::from_arg_matches(&matches)?;
     let cli_explicit = any_explicit_connection_arg(&matches);
 
+    // Headless one-shot: `--prompt "…"` connects, prints the reply, and exits
+    // without ever entering the TUI. Runs before any terminal setup.
+    if let Some(prompt) = cli.prompt.clone() {
+        let config: ConnectionConfig = cli.into();
+        return run_headless(&config, prompt).await;
+    }
+
     // Restore the terminal on panic BEFORE any state is pushed, chaining the
     // default hook so the panic message lands on a usable screen (TUI-1).
     install_panic_hook();
@@ -232,6 +254,109 @@ async fn main() -> Result<()> {
     terminal.show_cursor()?;
 
     result
+}
+
+/// Headless one-shot mode (`--prompt`): connect, register client-hosted MCP
+/// tools, send the prompt, stream the reply to stdout, and exit. A client tool
+/// call during the turn is routed to the MCP host (or resolved via the built-in
+/// dispatch) and its result submitted so the turn always resumes.
+async fn run_headless(config: &ConnectionConfig, prompt: String) -> Result<()> {
+    use std::io::Write as _;
+
+    let conn = Connector::connect(config)
+        .await
+        .map_err(|e| anyhow::anyhow!("connection failed: {e}"))?;
+    let mut signal_rx = conn.subscribe();
+
+    // Start the client-side MCP host for the `tui` surface and advertise its
+    // tools (merged with the built-ins) so a headless prompt can trigger local
+    // tools exactly like the interactive client.
+    let servers: Vec<_> = ClientMcpConfig::load(&default_client_mcp_path())
+        .resolved_servers("tui")
+        .into_iter()
+        .cloned()
+        .collect();
+    let host = if servers.is_empty() {
+        None
+    } else {
+        Some(McpHost::start(&servers).await)
+    };
+    let host_tools = host.as_ref().map(|h| h.registrations()).unwrap_or_default();
+    let builtins = vec![
+        client_tools::say_this_registration(),
+        client_tools::request_voice_registration(),
+        client_tools::stop_voice_registration(),
+    ];
+    // Best-effort: client tools need a command channel (UDS/WS), not D-Bus.
+    let _ = conn
+        .register_client_tools(merge_registrations(builtins, host_tools))
+        .await;
+
+    let conversation_id = conn
+        .client()
+        .create_conversation("adele --prompt")
+        .await
+        .map_err(|e| anyhow::anyhow!("could not create conversation: {e}"))?;
+    let request_id = conn
+        .send_prompt_with_system_refinement(&conversation_id, &prompt, "")
+        .await
+        .map_err(|e| anyhow::anyhow!("could not send prompt: {e}"))?;
+
+    let mut stdout = io::stdout();
+    let mut streamed = false;
+    while let Some(event) = signal_rx.recv().await {
+        match event {
+            SignalEvent::Chunk {
+                request_id: rid,
+                chunk,
+                ..
+            } if rid == request_id => {
+                streamed = true;
+                let _ = stdout.write_all(chunk.as_bytes());
+                let _ = stdout.flush();
+            }
+            SignalEvent::Complete {
+                request_id: rid,
+                full_response,
+                ..
+            } if rid == request_id => {
+                // Some providers don't stream chunks; fall back to the final text.
+                if !streamed {
+                    let _ = stdout.write_all(full_response.as_bytes());
+                }
+                let _ = writeln!(stdout);
+                break;
+            }
+            SignalEvent::Error {
+                request_id: rid,
+                error,
+                ..
+            } if rid == request_id => {
+                return Err(anyhow::anyhow!("{error}"));
+            }
+            SignalEvent::ClientToolCall {
+                task_id,
+                tool_call_id,
+                tool_name,
+                arguments,
+                ..
+            } => {
+                let result = match host.as_ref() {
+                    Some(host) if host.handles(&tool_name) => {
+                        host.call(&tool_name, arguments).await
+                    }
+                    // The built-in client tools are TUI-visual (speak / show);
+                    // headless just resolves them so the turn completes.
+                    _ => client_tools::dispatch(&tool_name, &arguments, false).result,
+                };
+                let _ = conn
+                    .submit_client_tool_result(&task_id, &tool_call_id, result)
+                    .await;
+            }
+            _ => {}
+        }
+    }
+    Ok(())
 }
 
 /// Reconnect backoff state machine. Sequence: 2s → 4s → 8s → 16s → 30s,

--- a/src/main.rs
+++ b/src/main.rs
@@ -49,6 +49,11 @@ use adele::{
     purposes, screen, ui, voice,
 };
 use client_ui_common::{Effect, UiMessage};
+use desktop_assistant_api_model::ClientToolRegistration;
+use desktop_assistant_client_common::mcp_host::{
+    ClientMcpConfig, McpHost, default_client_mcp_path, dispatch_client_tool_call,
+    merge_registrations,
+};
 
 const DEFAULT_WS_URL: &str = desktop_assistant_client_common::config::DEFAULT_WS_URL;
 const DEFAULT_WS_SUBJECT: &str = desktop_assistant_client_common::config::DEFAULT_WS_SUBJECT;
@@ -327,6 +332,19 @@ async fn run(
     let mut app = App::new();
     let settings = Settings::load();
     app.show_debug = settings.show_debug;
+
+    // Start any client-side MCP servers configured for the `tui` surface and hold
+    // the host in `App` so its tools are advertised (register) and routed
+    // (dispatch) to whichever daemon we connect to — local or remote (k8s).
+    let mcp_cfg = ClientMcpConfig::load(&default_client_mcp_path());
+    let mcp_servers: Vec<_> = mcp_cfg
+        .resolved_servers("tui")
+        .into_iter()
+        .cloned()
+        .collect();
+    if !mcp_servers.is_empty() {
+        app.mcp_host = Some(Rc::new(McpHost::start(&mcp_servers).await));
+    }
 
     // The `Connector` owns the transport AND the signal stream, pumping every
     // `SignalEvent` to its subscribers from a dedicated task (client-common
@@ -1791,6 +1809,23 @@ async fn handle_client_tool_call(
     // Gate on the call's OWN conversation, not the open one, so the per-
     // conversation controls are honored even if the user has since switched
     // tabs. The say_this aside gate is `Adele ∈ {OnDemand, Always}` (adele-tui#77).
+    // A client-hosted MCP tool takes precedence: if the local MCP host owns this
+    // tool name it invokes it and submits the result, and we're done. Otherwise
+    // fall through to the TUI's built-in client tools (say_this / voice mode).
+    if let (Some(host), Some(conn)) = (app.mcp_host.clone(), connector.as_ref())
+        && dispatch_client_tool_call(
+            host.as_ref(),
+            conn.as_ref(),
+            &call.task_id,
+            &call.tool_call_id,
+            &call.tool_name,
+            call.arguments.clone(),
+        )
+        .await
+    {
+        return;
+    }
+
     let say_this_spoken = app.say_this_spoken_for(&call.conversation_id);
     let outcome = client_tools::dispatch(&call.tool_name, &call.arguments, say_this_spoken);
 
@@ -1868,7 +1903,14 @@ async fn finish_connection_init(app: &mut App, conn: &Connector) {
     // open conversation was already re-fetched by the reconnect resync before this
     // call, so this re-points the daemon's fan-out at it.
     subscribe_to_open_conversation(app, conn).await;
-    register_client_tools(conn).await;
+    register_client_tools(
+        conn,
+        app.mcp_host
+            .as_ref()
+            .map(|h| h.registrations())
+            .unwrap_or_default(),
+    )
+    .await;
     app.status_message = conn.label().to_string();
 }
 
@@ -1878,13 +1920,16 @@ async fn finish_connection_init(app: &mut App, conn: &Connector) {
 /// voice playback is a convenience, so a failure to register is only logged and
 /// never blocks the chat. Over D-Bus (no command channel for client tools) this
 /// is expected to fail and is silently skipped.
-async fn register_client_tools(conn: &Connector) {
+async fn register_client_tools(conn: &Connector, host_tools: Vec<ClientToolRegistration>) {
+    // Merge the TUI's built-in client tools with the MCP host's tools into the
+    // single set the daemon expects (it replaces the whole set per call).
+    let builtins = vec![
+        client_tools::say_this_registration(),
+        client_tools::request_voice_registration(),
+        client_tools::stop_voice_registration(),
+    ];
     if let Err(e) = conn
-        .register_client_tools(vec![
-            client_tools::say_this_registration(),
-            client_tools::request_voice_registration(),
-            client_tools::stop_voice_registration(),
-        ])
+        .register_client_tools(merge_registrations(builtins, host_tools))
         .await
     {
         tracing::debug!("client tool registration skipped: {e}");


### PR DESCRIPTION
Wires adele-tui to `client-common`'s `mcp_host` module (desktop-assistant#464 / #465–467): the TUI can host **local MCP servers** and advertise their tools to the daemon as client-side tools — so a brain running remotely (e.g. in k8s) can invoke tools that act on *this* machine.

- Enable the `mcp-host` feature on the `client-common` dep.
- Startup: load `~/.config/adele/client-mcp.toml` for `surface="tui"`, `McpHost::start(...)`, held in `App`.
- Register: `merge_registrations(builtins, host.registrations())` into the one `register_client_tools` call.
- Dispatch: `handle_client_tool_call` tries `dispatch_client_tool_call` first; non-host tools fall through to the existing `say_this`/voice dispatch.

Also pins reqwest 0.13 → 0.13.1 (the daemon's version): 0.13.2+ dropped the `webpki-roots` feature that `mcp-client` requests. Underlying `mcp-client` dep hygiene is a desktop-assistant follow-up.

Closes #112. Part of desktop-assistant#464.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
