### PR TITLE
Three-way voice output + Spoken/SpeechDisabled render (voice#126 Phase 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1566,19 +1566,14 @@ dependencies = [
 name = "desktop-assistant-mcp-client"
 version = "0.1.0"
 dependencies = [
- "base64",
  "chrono",
  "desktop-assistant-core",
- "rand 0.9.4",
- "reqwest 0.13.1",
  "serde",
  "serde_json",
- "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",
  "toml 1.1.2+spec-1.1.0",
  "tracing",
- "url",
  "uuid",
 ]
 
@@ -3939,7 +3934,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.7",
 ]
 
 [[package]]

--- a/src/app.rs
+++ b/src/app.rs
@@ -2,7 +2,9 @@ use std::rc::Rc;
 
 use desktop_assistant_api_model::TaskId;
 use desktop_assistant_client_common::mcp_host::McpHost;
-pub use desktop_assistant_client_common::{ChatMessage, ConversationDetail, ConversationSummary};
+pub use desktop_assistant_client_common::{
+    ChatMessage, ConversationDetail, ConversationSummary, MessageKind,
+};
 use ratatui::style::Style;
 use ratatui_textarea::{CursorMove, DataCursor, TextArea};
 
@@ -386,12 +388,34 @@ impl App {
         self.core.say_this_spoken_for(conversation_id)
     }
 
-    /// Render a `say_this` call whose aside is NOT spoken (Adele == Disabled) as
-    /// an inline note in the transcript instead (adele-tui#77). Appended to
-    /// `conversation_id` only when that is the open conversation, so a call from
-    /// a stale/other conversation never bleeds into the visible chat. Returns
-    /// whether the note was shown.
+    /// Render a `say_this` call whose aside is NOT spoken (Adele ≠ OnDemand, or
+    /// no speech backend) as a transcript line instead (adele-tui#77). Appended
+    /// to `conversation_id` only when that is the open conversation, so a call
+    /// from a stale/other conversation never bleeds into the visible chat.
+    /// Returns whether the note was shown. The line carries clean `content` and
+    /// `MessageKind::SpeechDisabled`; the "(speech mode disabled)" marker is
+    /// added at render time from the metadata, not baked into the text
+    /// (voice#126).
     pub fn push_speech_disabled_note(&mut self, conversation_id: &str, text: &str) -> bool {
+        self.push_local_say_this(conversation_id, text, MessageKind::SpeechDisabled)
+    }
+
+    /// Render a `say_this` aside that WAS spoken as a transcript line tagged
+    /// `MessageKind::Spoken` (voice#126), so the user sees what Adele voiced.
+    /// Same open-conversation guard as [`Self::push_speech_disabled_note`].
+    pub fn push_spoken_note(&mut self, conversation_id: &str, text: &str) -> bool {
+        self.push_local_say_this(conversation_id, text, MessageKind::Spoken)
+    }
+
+    /// Shared body for the two `say_this` transcript lines: push a client-local
+    /// assistant message with clean `content` and an explicit presentation
+    /// `kind`, only when `conversation_id` is the open conversation.
+    fn push_local_say_this(
+        &mut self,
+        conversation_id: &str,
+        text: &str,
+        kind: MessageKind,
+    ) -> bool {
         let Some(conv) = self.core.current_conversation_mut() else {
             return false;
         };
@@ -399,12 +423,13 @@ impl App {
             return false;
         }
         conv.messages.push(ChatMessage {
-            // Local-only inline note (never persisted daemon-side), so it has no
+            // Local-only line (never persisted daemon-side), so it has no
             // daemon-assigned message id (#1): the dedupe/ordering cursor is only
             // meaningful for daemon-sourced messages.
             id: String::new(),
             role: "assistant".to_string(),
-            content: format!("(speech mode disabled) {text}"),
+            content: text.to_string(),
+            kind,
         });
         self.scroll_offset = 0;
         true
@@ -1967,11 +1992,13 @@ mod tests {
                     id: "m1".into(),
                     role: "user".into(),
                     content: "hello".into(),
+                    kind: crate::app::MessageKind::Normal,
                 },
                 ChatMessage {
                     id: "m2".into(),
                     role: "assistant".into(),
                     content: "hi there".into(),
+                    kind: crate::app::MessageKind::Normal,
                 },
             ],
             model_selection: None,
@@ -2601,40 +2628,37 @@ mod tests {
 
     #[test]
     fn adele_always_narrates_regardless_of_you() {
-        // Always reads every reply aloud whether or not You is Enabled.
+        // Always reads every reply aloud whether or not You is Enabled; say_this
+        // is NOT its spoken channel (voice#126) — the whole reply already is.
         for you in [false, true] {
             let mut app = app_with_open_conversation("c1");
             app.set_voice_in("c1", you);
             app.set_adele_output("c1", AdeleOutput::Always);
             assert!(app.narrate_for("c1"), "Always must narrate (You={you})");
             assert!(
-                app.say_this_spoken_for("c1"),
-                "Always always speaks say_this (You={you})"
+                !app.say_this_spoken_for("c1"),
+                "Always does not separately speak say_this (You={you})"
             );
         }
     }
 
     #[test]
-    fn adele_on_demand_narrates_only_when_you_enabled() {
-        // The gate's OnDemand arm: spoken iff You == Enabled.
+    fn adele_on_demand_never_narrates_but_say_this_speaks() {
+        // On-demand's spoken channel is say_this, not auto-narration (voice#126);
+        // decoupled from You — neither value narrates, both speak say_this.
         let mut app = app_with_open_conversation("c1");
         app.set_adele_output("c1", AdeleOutput::OnDemand);
-
-        // You Disabled → reply text-only, but say_this aside still spoken.
-        app.set_voice_in("c1", false);
-        assert!(
-            !app.narrate_for("c1"),
-            "OnDemand + You=Disabled: no narration"
-        );
-        assert!(
-            app.say_this_spoken_for("c1"),
-            "OnDemand say_this aside spoken even when You=Disabled"
-        );
-
-        // You Enabled → reply narrated.
-        app.set_voice_in("c1", true);
-        assert!(app.narrate_for("c1"), "OnDemand + You=Enabled narrates");
-        assert!(app.say_this_spoken_for("c1"));
+        for you in [false, true] {
+            app.set_voice_in("c1", you);
+            assert!(
+                !app.narrate_for("c1"),
+                "OnDemand must not auto-narrate (You={you})"
+            );
+            assert!(
+                app.say_this_spoken_for("c1"),
+                "OnDemand say_this aside is spoken (You={you})"
+            );
+        }
     }
 
     #[test]
@@ -2729,7 +2753,21 @@ mod tests {
         let msgs = &app.current_conversation().unwrap().messages;
         assert_eq!(msgs.len(), 1);
         assert_eq!(msgs[0].role, "assistant");
-        assert_eq!(msgs[0].content, "(speech mode disabled) the kettle is on");
+        // Content is clean; the "(speech mode disabled)" marker is added at
+        // render time from the metadata, not baked in (voice#126).
+        assert_eq!(msgs[0].content, "the kettle is on");
+        assert_eq!(msgs[0].kind, MessageKind::SpeechDisabled);
+    }
+
+    #[test]
+    fn push_spoken_note_tags_the_line_spoken() {
+        let mut app = app_with_open_conversation("c1");
+        assert!(app.push_spoken_note("c1", "the kettle is on"));
+        let msgs = &app.current_conversation().unwrap().messages;
+        assert_eq!(msgs.len(), 1);
+        assert_eq!(msgs[0].role, "assistant");
+        assert_eq!(msgs[0].content, "the kettle is on");
+        assert_eq!(msgs[0].kind, MessageKind::Spoken);
     }
 
     #[test]

--- a/src/client_tools.rs
+++ b/src/client_tools.rs
@@ -16,10 +16,10 @@
 //! The TUI understands three tools:
 //!
 //! * `say_this` — "speak this text aloud". Whether it actually speaks is gated
-//!   by whether the call's conversation's `Adele` level is `OnDemand` or
-//!   `Always` (i.e. not `Disabled`); the caller passes that boolean as
-//!   `say_this_spoken`. Spoken ⇒ speak (daemon-first, chunked); not spoken ⇒
-//!   render `(speech mode disabled) <text>` inline instead.
+//!   by whether the call's conversation's `Adele` level is `OnDemand` — its sole
+//!   spoken channel (voice#126); the caller passes that boolean as
+//!   `say_this_spoken`. Spoken ⇒ speak (daemon-first, chunked) AND show the line
+//!   tagged `Spoken`; not spoken ⇒ show it tagged `SpeechDisabled` instead.
 //! * `request_voice` (adele-tui#77) — the model switching this conversation into
 //!   spoken voice mode ("ok, let's talk by voice"). Sets `Adele = OnDemand`.
 //! * `stop_voice` (adele-tui#77) — the model leaving voice mode; sets
@@ -37,8 +37,8 @@ pub const SAY_THIS: &str = "say_this";
 
 /// The model-driven "enter voice mode" tool (adele-tui#77). The model calls it
 /// when the user asks to talk by voice; it sets the conversation's `Adele`
-/// output level to `OnDemand` (replies narrated when `You == Enabled` + shaped
-/// for speech, `say_this` asides always spoken).
+/// output level to `OnDemand` — the written reply stays text and `say_this` is
+/// the model's spoken channel (voice#126).
 pub const REQUEST_VOICE: &str = "request_voice";
 
 /// The model-driven "leave voice mode" tool (adele-tui#77). Sets the
@@ -125,8 +125,8 @@ pub fn handle_request_voice() -> ToolOutcome {
     ToolOutcome {
         effect: ToolEffect::SetAdeleOutput(AdeleOutput::OnDemand),
         result: Ok(
-            "voice mode on: this conversation is now spoken — replies will be read aloud and \
-             kept brief and conversational"
+            "voice mode on (on-demand): your written reply is shown as text and not read aloud; \
+             speak to the user by calling say_this, kept brief and conversational"
                 .to_string(),
         ),
     }
@@ -191,10 +191,10 @@ pub fn say_this_registration() -> desktop_assistant_api_model::ClientToolRegistr
 pub fn request_voice_registration() -> desktop_assistant_api_model::ClientToolRegistration {
     desktop_assistant_api_model::ClientToolRegistration {
         name: REQUEST_VOICE.to_string(),
-        description: "Switch this conversation into spoken voice mode (the user asked to talk by \
-            voice); replies are read aloud and kept short and conversational. Call when the user \
-            says something like \"let's talk by voice\" or \"read your replies to me\". No \
-            arguments."
+        description: "Switch this conversation into spoken (on-demand) voice mode (the user asked \
+            to talk by voice). Your written reply stays text; to speak, call say_this with a \
+            brief spoken version. Call when the user says something like \"let's talk by voice\" \
+            or \"read your replies to me\". No arguments."
             .to_string(),
         input_schema: serde_json::json!({
             "type": "object",

--- a/src/main.rs
+++ b/src/main.rs
@@ -1964,6 +1964,9 @@ async fn handle_client_tool_call(
             // showing the text inline instead of dropping it silently.
             let has_backend = voice_daemon.is_available().await || voice_session.is_some();
             if has_backend {
+                // Show the spoken line in the transcript too (voice#126), tagged
+                // Spoken, so the user sees what Adele voiced — then speak it.
+                app.push_spoken_note(&call.conversation_id, &text);
                 enqueue_narration(narration_tx, voice_daemon, voice_session, text);
             } else {
                 app.push_speech_disabled_note(&call.conversation_id, &text);

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -6,7 +6,7 @@ use ratatui::{
     widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap},
 };
 
-use crate::app::{AdeleOutput, App, InputMode};
+use crate::app::{AdeleOutput, App, InputMode, MessageKind};
 use crate::theme::theme;
 
 const INPUT_VISIBLE_LINES: u16 = 4;
@@ -408,6 +408,34 @@ fn draw_messages(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
 
     if let Some(conv) = app.current_conversation() {
         for msg in &conv.messages {
+            // Client-local `say_this` lines (voice#126) carry explicit
+            // presentation metadata; render their marker from `kind` rather than
+            // parsing the content. Always shown (not debug-gated) — they're real
+            // user-facing content — with the marker as a bold prefix.
+            match msg.kind {
+                MessageKind::Spoken => {
+                    let style = Style::default()
+                        .fg(theme().assistant_prefix)
+                        .add_modifier(Modifier::ITALIC);
+                    push_prefixed_message(&mut lines, "Spoken: ", &msg.content, style);
+                    lines.push(Line::from(""));
+                    continue;
+                }
+                MessageKind::SpeechDisabled => {
+                    let style = Style::default()
+                        .fg(theme().assistant_prefix)
+                        .add_modifier(Modifier::DIM | Modifier::ITALIC);
+                    push_prefixed_message(
+                        &mut lines,
+                        "(speech mode disabled) ",
+                        &msg.content,
+                        style,
+                    );
+                    lines.push(Line::from(""));
+                    continue;
+                }
+                MessageKind::Normal => {}
+            }
             // Roles fall into a few buckets: user/assistant render normally
             // (assistant via markdown); tool/system/empty-assistant render
             // only when the debug view is enabled.
@@ -720,11 +748,13 @@ mod tests {
                     id: String::new(),
                     role: "user".into(),
                     content: "Hello".into(),
+                    kind: crate::app::MessageKind::Normal,
                 },
                 ChatMessage {
                     id: String::new(),
                     role: "assistant".into(),
                     content: "Hi there!".into(),
+                    kind: crate::app::MessageKind::Normal,
                 },
             ],
             model_selection: None,
@@ -1052,26 +1082,31 @@ mod tests {
                     id: String::new(),
                     role: "user".into(),
                     content: "Hello".into(),
+                    kind: crate::app::MessageKind::Normal,
                 },
                 ChatMessage {
                     id: String::new(),
                     role: "tool".into(),
                     content: "ran search(foo)".into(),
+                    kind: crate::app::MessageKind::Normal,
                 },
                 ChatMessage {
                     id: String::new(),
                     role: "system".into(),
                     content: "context updated".into(),
+                    kind: crate::app::MessageKind::Normal,
                 },
                 ChatMessage {
                     id: String::new(),
                     role: "assistant".into(),
                     content: "".into(), // empty — only shown in debug
+                    kind: crate::app::MessageKind::Normal,
                 },
                 ChatMessage {
                     id: String::new(),
                     role: "assistant".into(),
                     content: "Hi there!".into(),
+                    kind: crate::app::MessageKind::Normal,
                 },
             ],
             model_selection: None,
@@ -1183,6 +1218,7 @@ mod tests {
                 id: String::new(),
                 role: "assistant".into(),
                 content: "answer with **strong** word".into(),
+                kind: crate::app::MessageKind::Normal,
             }],
             model_selection: None,
             conversation_personality: None,


### PR DESCRIPTION
The TUI half of the voice#126 Phase 2 client rollout.

## What
- The say_this / narration gates already delegate to `client-ui-common` (`say_this_spoken_for` → OnDemand-only, `narrate_for` → Always-only), so decoupling from `You` comes for free. Updated the model-facing tool descriptions + result strings to match (on-demand: reply is text, speak via `say_this`).
- A spoken say_this now shows in the transcript too, tagged `MessageKind::Spoken` (new `push_spoken_note`), alongside the audio. The not-spoken downgrade (`push_speech_disabled_note`) carries clean `content` + `SpeechDisabled`; both route through a shared `push_local_say_this`.
- `ui.rs` renders the marker ("Spoken: " / "(speech mode disabled) ") from `kind`, not a baked-in string.

## Interlock (land in order)
**desktop-assistant#473** → **voice#129** → **client-ui-common#13** → **this** (+ adele-gtk). Builds against all three.

379 lib tests green; clippy `-D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)