### PR TITLE
feat: add -v/--verbose stderr logging for headless/scriptable debugging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,7 @@ dependencies = [
  "tokio",
  "toml 0.9.12+spec-1.1.0",
  "tracing",
+ "tracing-subscriber",
  "unicode-width",
  "url",
  "zbus",
@@ -1534,6 +1535,7 @@ dependencies = [
  "toml 1.1.2+spec-1.1.0",
  "tracing",
  "uuid",
+ "webpki-roots 1.0.7",
  "zbus",
 ]
 
@@ -2748,6 +2750,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matrixmultiply"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2894,6 +2905,15 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4300,6 +4320,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4654,6 +4683,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4928,6 +4966,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -5119,6 +5187,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ rustls = { version = "0.23", default-features = false, features = ["ring"] }
 url = "2"
 toml = "0.9"
 tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # Direct zbus client for the standalone voice daemon (`org.desktopAssistant.Voice`),
 # a separate D-Bus service from the orchestrator transport. Used by
 # `voice_client::VoiceController` to route narration through the daemon's warm

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,6 +114,11 @@ struct CliArgs {
     /// land in shell history / the process list.
     #[arg(long = "ws-login-password", env = "DESKTOP_ASSISTANT_TUI_WS_PASSWORD")]
     ws_login_password: Option<String>,
+    /// Enable verbose logging (`-v` info, `-vv` debug, `-vvv` trace). Logs go to
+    /// stderr so a headless `--prompt` run pipes cleanly to a file for scripting
+    /// and debugging. `RUST_LOG`, when set, overrides the level entirely.
+    #[arg(short = 'v', long, action = clap::ArgAction::Count)]
+    verbose: u8,
 }
 
 impl From<CliArgs> for ConnectionConfig {
@@ -201,6 +206,44 @@ fn install_panic_hook() {
     }));
 }
 
+/// Build the tracing `EnvFilter` directive for a `-v` count. `RUST_LOG`, when
+/// set, takes precedence and this is not consulted. Higher counts widen the
+/// level for our own crates while keeping third-party noise at `warn`.
+fn log_filter(verbose: u8) -> String {
+    let level = match verbose {
+        0 => "warn",
+        1 => "info",
+        2 => "debug",
+        _ => "trace",
+    };
+    format!(
+        "warn,adele={level},desktop_assistant_client_common={level},\
+         desktop_assistant_mcp_client={level},client_ui_common={level}"
+    )
+}
+
+/// Install a stderr tracing subscriber when `-v`/`--verbose` is given or
+/// `RUST_LOG` is set; otherwise stay silent so normal output is clean. Logging
+/// to stderr keeps a headless `--prompt` run's reply (stdout) separable from
+/// diagnostics. Best-effort: an already-installed global subscriber is a no-op.
+fn init_logging(verbose: u8) {
+    use tracing_subscriber::EnvFilter;
+    let has_rust_log = std::env::var_os("RUST_LOG").is_some();
+    if verbose == 0 && !has_rust_log {
+        return;
+    }
+    let filter = if has_rust_log {
+        EnvFilter::from_default_env()
+    } else {
+        EnvFilter::new(log_filter(verbose))
+    };
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_writer(std::io::stderr)
+        .with_target(true)
+        .try_init();
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Both `ring` and `aws-lc-rs` end up enabled in rustls because reqwest 0.12
@@ -215,6 +258,10 @@ async fn main() -> Result<()> {
     let matches = CliArgs::command().get_matches();
     let cli = CliArgs::from_arg_matches(&matches)?;
     let cli_explicit = any_explicit_connection_arg(&matches);
+
+    // Install logging first so connection/registration/streaming diagnostics are
+    // captured for the headless path too (verbose or RUST_LOG; silent otherwise).
+    init_logging(cli.verbose);
 
     // Headless one-shot: `--prompt "…"` connects, prints the reply, and exits
     // without ever entering the TUI. Runs before any terminal setup.
@@ -2350,6 +2397,25 @@ mod tests {
         let mut out = vec!["adele".to_string()];
         out.extend(parts.iter().map(|value| value.to_string()));
         out
+    }
+
+    #[test]
+    fn log_filter_scales_level_with_verbosity_and_quiets_third_party() {
+        assert!(
+            log_filter(0).contains("adele=warn"),
+            "no -v => our crates stay at warn"
+        );
+        assert!(log_filter(1).contains("adele=info"), "one -v => info");
+        assert!(log_filter(2).contains("adele=debug"), "two -v => debug");
+        assert!(log_filter(3).contains("adele=trace"), "three -v => trace");
+        assert!(log_filter(9).contains("adele=trace"), "saturates at trace");
+        // Our client crates track the same level so streaming/registration is visible.
+        assert!(log_filter(2).contains("desktop_assistant_client_common=debug"));
+        // Third-party noise stays at warn regardless of verbosity.
+        assert!(
+            log_filter(3).starts_with("warn,"),
+            "base directive keeps third-party at warn"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Add a `-v/--verbose` clap `Count` flag that installs a stderr `tracing` subscriber:

- `-v` -> `info`, `-vv` -> `debug`, `-vvv`+ -> `trace` (saturates)
- Scales the level for our own crates (`adele`, `desktop_assistant_client_common`, `desktop_assistant_mcp_client`, `client_ui_common`) while keeping third-party output pinned at `warn`.
- `RUST_LOG`, when set, overrides the computed level entirely.
- With no `-v` and no `RUST_LOG`, no subscriber is installed, so normal output stays clean.

Logging is initialized in `main()` **before** the headless/interactive split, so it covers both paths.

## Why

Enables piping headless `--prompt` one-shot runs to a log file for scripting and debugging: diagnostics go to **stderr** while the assistant's reply stays on **stdout**, so the two are cleanly separable (`adele --prompt "..." -vv 2>run.log`). This supports client-tooling debugging of connection, registration, and streaming behavior in scriptable, non-interactive runs.

No filed issue exists for this; it is a debugging/ergonomics addition for the client tooling.

## Tests

- New unit test `log_filter_scales_level_with_verbosity_and_quiets_third_party` asserts the level scales with `-v` count, saturates at `trace`, tracks our client crates, and keeps the base directive at `warn` for third-party noise.
- Full gate green locally and via the pre-push `just check` hook: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo build`, `cargo test` (424 lib + 19 bin + 4 integration tests pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)