### PR TITLE
feat(mcp): compile core MCP servers into the tui as in-process built-ins (da#538 Phase C)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,7 @@ dependencies = [
  "crossterm",
  "desktop-assistant-api-model",
  "desktop-assistant-client-common",
+ "fileio-mcp",
  "futures",
  "keyring-core",
  "oauth2",
@@ -28,12 +29,15 @@ dependencies = [
  "serde",
  "serde_json",
  "syntect",
+ "tasks-mcp",
+ "terminal-mcp",
  "tokio",
  "toml 0.9.12+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "unicode-width",
  "url",
+ "web-mcp",
  "zbus",
  "zbus-secret-service-keyring-store",
 ]
@@ -396,6 +400,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "async-tungstenite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc405d38be14342132609f06f02acaf825ddccfe76c4824a69281e0458ebd4"
+dependencies = [
+ "atomic-waker",
+ "futures-core",
+ "futures-io",
+ "futures-task",
+ "futures-util",
+ "log",
+ "pin-project-lite",
+ "tokio",
+ "tungstenite 0.28.0",
 ]
 
 [[package]]
@@ -990,6 +1011,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
+dependencies = [
+ "memchr",
+ "serde_core",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1012,6 +1043,9 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bytes-utils"
@@ -1079,6 +1113,71 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chromiumoxide"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26ed067eb6c1f660bdb87c05efb964421d2ca262bae0296cdfe38cf0cd949a3e"
+dependencies = [
+ "async-tungstenite",
+ "base64",
+ "bytes",
+ "chromiumoxide_cdp",
+ "chromiumoxide_types",
+ "dunce",
+ "fnv",
+ "futures",
+ "futures-timer",
+ "pin-project-lite",
+ "reqwest 0.13.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "which",
+ "windows-registry",
+]
+
+[[package]]
+name = "chromiumoxide_cdp"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68a6a03a7ebac4ea85308f285d6959a3e6b2ce32a0c9465dc7a7b1db0144eec7"
+dependencies = [
+ "chromiumoxide_pdl",
+ "chromiumoxide_types",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "chromiumoxide_pdl"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c602dea92337bc4d824668d78c5b79c3b4ddb29b40dd7218282bbe8fd3fc2091"
+dependencies = [
+ "chromiumoxide_types",
+ "either",
+ "heck",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "serde_json",
+]
+
+[[package]]
+name = "chromiumoxide_types"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678d5146e74f16fc4a41978b275af572cd913de1f10270d2b93b6c276bc57d80"
+dependencies = [
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "chrono"
@@ -1332,6 +1431,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1525,6 +1643,7 @@ dependencies = [
  "desktop-assistant-frame-codec",
  "desktop-assistant-mcp-client",
  "futures",
+ "mcp-core",
  "reqwest 0.13.1",
  "rustls",
  "rustls-pki-types",
@@ -1793,6 +1912,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "fileio-mcp"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "filetime",
+ "globset",
+ "ignore",
+ "mcp-core",
+ "nix 0.31.3",
+ "regex",
+ "serde",
+ "serde_json",
+ "shellexpand",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1953,6 +2101,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
+
+[[package]]
 name = "futures-util"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2024,6 +2178,19 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "globset"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
 
 [[package]]
 name = "gloo-timers"
@@ -2406,6 +2573,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b009b6744c1445efd7244084e25e498636412effb6760b55067553baa925cc7"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2736,7 +2919,7 @@ version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
 dependencies = [
- "nix",
+ "nix 0.29.0",
  "winapi",
 ]
 
@@ -2766,6 +2949,18 @@ checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
 dependencies = [
  "autocfg",
  "rawpointer",
+]
+
+[[package]]
+name = "mcp-core"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "clap",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]
@@ -2895,6 +3090,18 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -4287,6 +4494,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4326,6 +4546,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "shellexpand"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
+dependencies = [
+ "dirs",
 ]
 
 [[package]]
@@ -4567,6 +4796,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tasks-mcp"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "clap",
+ "mcp-core",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "shellexpand",
+ "thiserror 2.0.18",
+ "tokio",
+ "uuid",
+ "zbus",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4577,6 +4824,21 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "terminal-mcp"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "libc",
+ "mcp-core",
+ "serde",
+ "serde_json",
+ "shellexpand",
+ "thiserror 2.0.18",
+ "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -4618,7 +4880,7 @@ dependencies = [
  "libc",
  "log",
  "memmem",
- "nix",
+ "nix 0.29.0",
  "num-derive",
  "num-traits",
  "ordered-float",
@@ -4800,7 +5062,7 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tungstenite",
+ "tungstenite 0.29.0",
  "webpki-roots 0.26.11",
 ]
 
@@ -5016,6 +5278,23 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
@@ -5097,6 +5376,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "untrusted"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5156,6 +5441,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8-zero"
@@ -5365,6 +5656,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-mcp"
+version = "0.1.0"
+dependencies = [
+ "base64",
+ "chromiumoxide",
+ "clap",
+ "futures-util",
+ "mcp-core",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "url",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5481,6 +5788,15 @@ dependencies = [
  "lazy_static",
  "serde",
  "wezterm-dynamic",
+]
+
+[[package]]
+name = "which"
+version = "8.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f3ef584124b911bcc3875c2f1472e80f24361ceb789bd1c62b3e9a3df9ff43c"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,17 @@ desktop-assistant-api-model = { git = "https://github.com/adelie-ai/desktop-assi
 # The shared view-agnostic model+controller (CC-3, desktop-assistant#358).
 client-ui-common = { path = "../client-ui-common" }
 
+# Compiled-in ("built-in") MCP servers hosted in-process (da#538 Phase C). Each
+# core server lib exposes `build_service()`; the tui hosts them via
+# `McpHost::start_with` so a fresh client has core tools with no client-mcp.toml.
+# Optional + feature-gated (see `[features]`) so a `--no-default-features` build
+# links none of them and behaves exactly as before. Sibling path-deps, matching
+# how the desktop-assistant crates are path-patched below.
+fileio-mcp = { path = "../fileio-mcp", optional = true }
+terminal-mcp = { path = "../terminal-mcp", optional = true }
+tasks-mcp = { path = "../tasks-mcp", optional = true }
+web-mcp = { path = "../web-mcp", optional = true }
+
 # Embeddable voice module (adelie-ai/voice phase 1) for in-app dictation +
 # reply playback with no voice daemon — see adele-tui#67 / voice#34. Path-dep
 # of the sibling `voice` checkout, mirroring how we path-dep desktop-assistant
@@ -79,6 +90,30 @@ path = "../voice/crates/stt-whisper"
 desktop-assistant-client-common = { path = "../desktop-assistant/crates/client-common" }
 desktop-assistant-api-model = { path = "../desktop-assistant/crates/api-model" }
 
+# Collapse mcp-core to a SINGLE source. client-common pins it to a git rev while
+# the built-in server libs (fileio/terminal/tasks/web) float the git dep; two
+# git sources would split `mcp_core::McpService` into incompatible types (E0308)
+# when a built-in's `Arc<dyn McpService>` is handed to `BuiltinServer::new`.
+# Patching the URL to the local checkout resolves every consumer to one
+# mcp-core. `../mcp-core` is a superset of the pinned rev (only security/CLI
+# hardening + docs ahead; the `McpService` trait is byte-identical), so the API
+# client-common compiles against is unchanged.
+[patch."https://github.com/adelie-ai/mcp-core"]
+mcp-core = { path = "../mcp-core" }
+
+
+[features]
+# The core built-in MCP set is compiled in and hosted in-process by default, so
+# a fresh tui is useful with no client-mcp.toml (da#538 Phase C). Turn a server
+# off with e.g. `--no-default-features --features mcp-fileio,mcp-terminal`, or
+# drop them all with `--no-default-features` (the tui then behaves exactly as it
+# did before this feature — client-mcp.toml servers only).
+default = ["builtin-core"]
+builtin-core = ["mcp-fileio", "mcp-terminal", "mcp-tasks", "mcp-web"]
+mcp-fileio = ["dep:fileio-mcp"]
+mcp-terminal = ["dep:terminal-mcp"]
+mcp-tasks = ["dep:tasks-mcp"]
+mcp-web = ["dep:web-mcp"]
 
 [lints.rust]
 warnings = "deny"

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -1,0 +1,49 @@
+//! Compiled-in ("built-in") MCP servers hosted in-process (da#538 Phase C).
+//!
+//! The core set (fileio/terminal/tasks/web) is compiled in and hosted by
+//! default so a fresh tui is useful with no `client-mcp.toml`. An external
+//! client-mcp server of the SAME NAME overrides (suppresses) the built-in:
+//! external > built-in.
+
+use desktop_assistant_client_common::mcp_host::BuiltinServer;
+
+/// Build the enabled built-in servers, skipping any whose name is shadowed by a
+/// configured client-mcp server of the same name.
+pub fn builtin_servers(configured_names: &[String]) -> Vec<BuiltinServer> {
+    let _ = configured_names;
+    Vec::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// fileio's constructor is infallible, so with nothing shadowing it the
+    /// built-in set deterministically contains a server named "fileio",
+    /// advertised under the "fileio" namespace.
+    #[cfg(feature = "mcp-fileio")]
+    #[test]
+    fn fileio_builtin_present_and_namespaced_by_default() {
+        let servers = builtin_servers(&[]);
+        let fileio = servers
+            .iter()
+            .find(|s| s.name == "fileio")
+            .expect("fileio built-in must be present when nothing shadows it");
+        assert_eq!(
+            fileio.namespace, "fileio",
+            "fileio built-in must be advertised under the 'fileio' namespace"
+        );
+    }
+
+    /// A configured client-mcp server of the same name suppresses the built-in
+    /// (external > built-in), so the built-in set omits "fileio" entirely.
+    #[cfg(feature = "mcp-fileio")]
+    #[test]
+    fn external_same_name_shadows_builtin() {
+        let servers = builtin_servers(&["fileio".to_string()]);
+        assert!(
+            !servers.iter().any(|s| s.name == "fileio"),
+            "an external client-mcp server named 'fileio' must suppress the built-in"
+        );
+    }
+}

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -6,12 +6,71 @@
 //! external > built-in.
 
 use desktop_assistant_client_common::mcp_host::BuiltinServer;
+#[cfg(any(
+    feature = "mcp-fileio",
+    feature = "mcp-terminal",
+    feature = "mcp-tasks",
+    feature = "mcp-web"
+))]
+use std::sync::Arc;
 
 /// Build the enabled built-in servers, skipping any whose name is shadowed by a
-/// configured client-mcp server of the same name.
+/// configured client-mcp server of the same name (external override wins).
+///
+/// Each `#[cfg]` block compiles in only when its `mcp-*` feature is on, so a
+/// `--no-default-features` build hosts nothing and the tui behaves as it did
+/// before Phase C. The infallible constructors (fileio, web) are always
+/// registered; the fallible ones (terminal, tasks) are logged and skipped if
+/// their zero-config constructor fails, so a broken environment degrades to the
+/// remaining tools rather than losing the whole set.
 pub fn builtin_servers(configured_names: &[String]) -> Vec<BuiltinServer> {
-    let _ = configured_names;
-    Vec::new()
+    // Unused only when every mcp-* feature is off (`--no-default-features`),
+    // where no built-in is compiled in to consult it.
+    #[cfg_attr(
+        not(any(
+            feature = "mcp-fileio",
+            feature = "mcp-terminal",
+            feature = "mcp-tasks",
+            feature = "mcp-web"
+        )),
+        allow(unused_variables)
+    )]
+    let shadowed = |name: &str| configured_names.iter().any(|n| n == name);
+    #[allow(unused_mut)]
+    let mut out: Vec<BuiltinServer> = Vec::new();
+
+    #[cfg(feature = "mcp-fileio")]
+    if !shadowed("fileio") {
+        out.push(BuiltinServer::new(
+            "fileio",
+            "fileio",
+            Arc::new(fileio_mcp::build_service()),
+        ));
+    }
+    #[cfg(feature = "mcp-terminal")]
+    if !shadowed("terminal") {
+        match terminal_mcp::build_service() {
+            Ok(svc) => out.push(BuiltinServer::new("terminal", "terminal", Arc::new(svc))),
+            Err(e) => tracing::warn!("built-in terminal server unavailable: {e}"),
+        }
+    }
+    #[cfg(feature = "mcp-tasks")]
+    if !shadowed("tasks") {
+        match tasks_mcp::build_service() {
+            Ok(svc) => out.push(BuiltinServer::new("tasks", "tasks", Arc::new(svc))),
+            Err(e) => tracing::warn!("built-in tasks server unavailable: {e}"),
+        }
+    }
+    #[cfg(feature = "mcp-web")]
+    if !shadowed("web") {
+        out.push(BuiltinServer::new(
+            "web",
+            "web",
+            Arc::new(web_mcp::build_service()),
+        ));
+    }
+
+    out
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 //! independently of the binary entry point.
 
 pub mod app;
+pub mod builtins;
 pub mod client_tools;
 pub mod connections;
 pub mod credentials;

--- a/src/main.rs
+++ b/src/main.rs
@@ -323,10 +323,14 @@ async fn run_headless(config: &ConnectionConfig, prompt: String) -> Result<()> {
         .into_iter()
         .cloned()
         .collect();
-    let host = if servers.is_empty() {
+    // Compiled-in built-ins (da#538 Phase C): host the core MCP set in-process,
+    // minus any name a client-mcp.toml server already provides (external wins).
+    let configured: Vec<String> = servers.iter().map(|s| s.name.clone()).collect();
+    let mcp_builtins = adele::builtins::builtin_servers(&configured);
+    let host = if servers.is_empty() && mcp_builtins.is_empty() {
         None
     } else {
-        Some(McpHost::start(&servers).await)
+        Some(McpHost::start_with(&servers, mcp_builtins).await)
     };
     let host_tools = host.as_ref().map(|h| h.registrations()).unwrap_or_default();
     let builtins = vec![
@@ -514,8 +518,15 @@ async fn run(
         .into_iter()
         .cloned()
         .collect();
-    if !mcp_servers.is_empty() {
-        app.mcp_host = Some(Rc::new(McpHost::start(&mcp_servers).await));
+    // Compiled-in built-ins (da#538 Phase C): host the core MCP set in-process,
+    // suppressing any built-in whose name a configured client-mcp server already
+    // provides (external overrides built-in).
+    let configured: Vec<String> = mcp_servers.iter().map(|s| s.name.clone()).collect();
+    let mcp_builtins = adele::builtins::builtin_servers(&configured);
+    if !mcp_servers.is_empty() || !mcp_builtins.is_empty() {
+        app.mcp_host = Some(Rc::new(
+            McpHost::start_with(&mcp_servers, mcp_builtins).await,
+        ));
     }
 
     // The `Connector` owns the transport AND the signal stream, pumping every


### PR DESCRIPTION
## What / why

da#538 Phase C for the tui: compile the core MCP servers (**fileio / terminal / tasks / web**) into the `adele` binary and host them **in-process** by default, so a fresh tui exposes the core tool set with **no `client-mcp.toml`** and no subprocess to set up. Additive: with the feature off the tui behaves exactly as before.

Builds on Phase B (`McpHost::start_with` + `BuiltinServer` in `desktop-assistant-client-common`) and the lib-ified servers (each `*-mcp` exposes `build_service()`).

## Feature layout

`[features]` (the crate had none before):

- `default = ["builtin-core"]`
- `builtin-core = ["mcp-fileio", "mcp-terminal", "mcp-tasks", "mcp-web"]`
- `mcp-fileio = ["dep:fileio-mcp"]`, and likewise `mcp-terminal` / `mcp-tasks` / `mcp-web`

So the four servers link by default, `--no-default-features` links **none** (old path: `client-mcp.toml` servers only), and any single server can be turned off/on individually. The server crates are optional sibling path-deps.

## mcp-core unification (the one tricky bit -- please review)

`client-common` pins `mcp-core` to a **git rev** (`448b0e4`) while the four server libs **float** the `mcp-core` git dep. Two git sources would split `mcp_core::McpService` into incompatible types, so handing a built-in's `Arc<dyn McpService>` to `BuiltinServer::new` would `E0308`. Fix -- collapse to one source with a path patch (same shape as the existing `desktop-assistant` path-patch):

```toml
[patch."https://github.com/adelie-ai/mcp-core"]
mcp-core = { path = "../mcp-core" }
```

`../mcp-core` is only security/CLI-hardening + docs commits ahead of the pinned rev; the `McpService` trait is byte-identical between the two (verified: only a doc-comment change on the `shutdown` hook), so the API `client-common` compiles against is unchanged. `cargo tree` confirms a single `mcp-core` source (see proof below).

## Override-by-name behavior

`builtins::builtin_servers(configured_names)` builds the enabled set and **skips any name a configured `client-mcp.toml` server already provides** -- external overrides built-in (matches the epic's precedence: external-command > built-in). This composes with `McpHost::start_with`, which sets subprocess servers up first, so even a same-namespaced tool collision resolves in the external server's favor.

Infallible constructors (fileio, web) always register; the fallible ones (terminal, tasks) are logged via `tracing::warn!` and skipped if their zero-config constructor fails, so a broken environment degrades to the remaining tools rather than losing the whole set.

## Namespace choice

Each built-in is registered with `name == namespace == "<server>"` (`"fileio"`, `"terminal"`, `"tasks"`, `"web"`) -- the same bare namespace those servers use as subprocesses, so tool names (`fileio__...`, `web__...`) are identical whether a server is built-in or external, and the same name is what an external override shadows.

## Wiring (both `McpHost::start` sites in `src/main.rs`)

- **Headless `--prompt`** (`run_headless`) and **interactive** (`run`): after `servers`/`mcp_servers` is built, compute `configured` names, build `mcp_builtins`, and start the host **iff there is anything to host** (configured servers **or** built-ins). Switched `start` -> `start_with(&servers, mcp_builtins)`. The existing `say_this` / `request_voice` / `stop_voice` client-tool merge is untouched.

## cargo-tree proof (default features)

```
├── fileio-mcp v0.1.0 (../fileio-mcp)
│   ├── mcp-core v0.1.0 (../mcp-core)
├── tasks-mcp v0.1.0 (../tasks-mcp)
├── terminal-mcp v0.1.0 (../terminal-mcp)
├── web-mcp v0.1.0 (../web-mcp)
```

All four server crates link under `adele`, and `mcp-core` resolves to the single local **path** source (no git source in the tree) -- the patch unified it.

## Tests (TDD; failing tests committed first)

`src/builtins.rs` `#[cfg(test)]` (both gated `#[cfg(feature = "mcp-fileio")]`):

- `fileio_builtin_present_and_namespaced_by_default` -- `builtin_servers(&[])` contains a server named `fileio` under namespace `fileio` (fileio's ctor is infallible -> deterministic).
- `external_same_name_shadows_builtin` -- `builtin_servers(&["fileio".into()])` contains **no** `fileio` (external suppresses built-in).

The fallible ctors (terminal/tasks) are deliberately not asserted always-present.

## Gate (dev profile)

- `cargo fmt --check` clean
- `cargo clippy --all-targets -- -D warnings` (default features) -- Finished, 0 warnings
- `cargo test` (default features) -- 425 lib + 19 bin + 4 integration pass, 0 failed
- `cargo build --no-default-features` -- compiles clean (old path preserved)
- `cargo audit` -- no **new** advisories vs `origin/main` (identical pre-existing set)

## Binary size (default `release` profile: thin LTO + strip)

| build | `target/release/adele` |
|---|---|
| baseline (`origin/main`) | ~45.75 MB (47,971,440 B) |
| with all four built-ins (this PR, default features) | ~52.27 MB (54,808,976 B) |
| **delta** | **+6.52 MB (~+14%)** |

The `web` server's browser stack (`chromiumoxide`, a CDP client that drives an *external* Chromium -- not an embedded browser) is the largest single contributor but the total add for all four servers is modest. `--no-default-features` gives back the full delta.

## Note on module placement

The module lives at `src/builtins.rs` declared as `pub mod builtins;` in `src/lib.rs` (all 23 existing modules live in lib.rs) rather than `mod builtins;` in `main.rs`; the two wiring sites still land in `main.rs` as specified.

Refs adelie-ai/desktop-assistant#538

🤖 Generated with [Claude Code](https://claude.com/claude-code)
