### PR TITLE
feat(mcp): built-in servers in F5 panel + full-set override (da#538 Phase D, slice 3)

### DIFF
--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -1,11 +1,18 @@
-//! Compiled-in ("built-in") MCP servers hosted in-process (da#538 Phase C).
+//! Compiled-in ("built-in") MCP servers hosted in-process (da#538 Phase C/D).
 //!
 //! The core set (fileio/terminal/tasks/web) is compiled in and hosted by
 //! default so a fresh tui is useful with no `client-mcp.toml`. An external
-//! client-mcp server of the SAME NAME overrides (suppresses) the built-in:
-//! external > built-in.
+//! client-mcp server of the SAME NAME overrides (suppresses) the built-in
+//! (external > built-in); that override decision now lives centrally in
+//! [`McpHost::start_with`], which skips + logs a shadowed built-in and reports
+//! it via [`McpHost::builtin_status`]. This module just enumerates the full
+//! compiled-in set and maps that status into the panel's view-model DTO.
+//!
+//! [`McpHost::start_with`]: desktop_assistant_client_common::mcp_host::McpHost::start_with
+//! [`McpHost::builtin_status`]: desktop_assistant_client_common::mcp_host::McpHost::builtin_status
 
-use desktop_assistant_client_common::mcp_host::BuiltinServer;
+use client_ui_common::BuiltinServerDto;
+use desktop_assistant_client_common::mcp_host::{BuiltinServer, BuiltinStatus};
 #[cfg(any(
     feature = "mcp-fileio",
     feature = "mcp-terminal",
@@ -14,8 +21,11 @@ use desktop_assistant_client_common::mcp_host::BuiltinServer;
 ))]
 use std::sync::Arc;
 
-/// Build the enabled built-in servers, skipping any whose name is shadowed by a
-/// configured client-mcp server of the same name (external override wins).
+/// Build every enabled built-in server as the full compiled-in set.
+///
+/// The override (skipping a built-in whose name matches a configured client-mcp
+/// server) is owned by [`McpHost::start_with`], so this returns the complete set
+/// and lets the host make and log the shadowing decision.
 ///
 /// Each `#[cfg]` block compiles in only when its `mcp-*` feature is on, so a
 /// `--no-default-features` build hosts nothing and the tui behaves as it did
@@ -23,61 +33,59 @@ use std::sync::Arc;
 /// registered; the fallible ones (terminal, tasks) are logged and skipped if
 /// their zero-config constructor fails, so a broken environment degrades to the
 /// remaining tools rather than losing the whole set.
-pub fn builtin_servers(configured_names: &[String]) -> Vec<BuiltinServer> {
-    // Unused only when every mcp-* feature is off (`--no-default-features`),
-    // where no built-in is compiled in to consult it.
-    #[cfg_attr(
-        not(any(
-            feature = "mcp-fileio",
-            feature = "mcp-terminal",
-            feature = "mcp-tasks",
-            feature = "mcp-web"
-        )),
-        allow(unused_variables)
-    )]
-    let shadowed = |name: &str| configured_names.iter().any(|n| n == name);
+///
+/// [`McpHost::start_with`]: desktop_assistant_client_common::mcp_host::McpHost::start_with
+pub fn builtin_servers() -> Vec<BuiltinServer> {
     #[allow(unused_mut)]
     let mut out: Vec<BuiltinServer> = Vec::new();
 
     #[cfg(feature = "mcp-fileio")]
-    if !shadowed("fileio") {
-        out.push(BuiltinServer::new(
-            "fileio",
-            "fileio",
-            Arc::new(fileio_mcp::build_service()),
-        ));
-    }
+    out.push(BuiltinServer::new(
+        "fileio",
+        "fileio",
+        Arc::new(fileio_mcp::build_service()),
+    ));
     #[cfg(feature = "mcp-terminal")]
-    if !shadowed("terminal") {
-        match terminal_mcp::build_service() {
-            Ok(svc) => out.push(BuiltinServer::new("terminal", "terminal", Arc::new(svc))),
-            Err(e) => tracing::warn!("built-in terminal server unavailable: {e}"),
-        }
+    match terminal_mcp::build_service() {
+        Ok(svc) => out.push(BuiltinServer::new("terminal", "terminal", Arc::new(svc))),
+        Err(e) => tracing::warn!("built-in terminal server unavailable: {e}"),
     }
     #[cfg(feature = "mcp-tasks")]
-    if !shadowed("tasks") {
-        match tasks_mcp::build_service() {
-            Ok(svc) => out.push(BuiltinServer::new("tasks", "tasks", Arc::new(svc))),
-            Err(e) => tracing::warn!("built-in tasks server unavailable: {e}"),
-        }
+    match tasks_mcp::build_service() {
+        Ok(svc) => out.push(BuiltinServer::new("tasks", "tasks", Arc::new(svc))),
+        Err(e) => tracing::warn!("built-in tasks server unavailable: {e}"),
     }
     #[cfg(feature = "mcp-web")]
-    if !shadowed("web") {
-        out.push(BuiltinServer::new(
-            "web",
-            "web",
-            Arc::new(web_mcp::build_service()),
-        ));
-    }
+    out.push(BuiltinServer::new(
+        "web",
+        "web",
+        Arc::new(web_mcp::build_service()),
+    ));
 
     out
+}
+
+/// Map the host's per-built-in [`BuiltinStatus`] into the view-model
+/// [`BuiltinServerDto`]s the shared MCP-servers panel renders via
+/// `client_ui_common::server_rows_with_builtins`. The `usize` `tool_count`
+/// widens to the DTO's `u32`; `overridden_by` carries straight through so an
+/// overridden built-in renders as a disabled row.
+pub fn builtin_dtos(status: Vec<BuiltinStatus>) -> Vec<BuiltinServerDto> {
+    status
+        .into_iter()
+        .map(|s| BuiltinServerDto {
+            name: s.name,
+            namespace: s.namespace,
+            tool_count: s.tool_count as u32,
+            overridden_by: s.overridden_by,
+        })
+        .collect()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use client_ui_common::{ServerKind, kind_label, server_rows_with_builtins};
-    use desktop_assistant_client_common::mcp_host::BuiltinStatus;
 
     /// fileio's constructor is infallible, so the compiled-in set deterministically
     /// contains a server named "fileio", advertised under the "fileio" namespace.

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -76,33 +76,90 @@ pub fn builtin_servers(configured_names: &[String]) -> Vec<BuiltinServer> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use client_ui_common::{ServerKind, kind_label, server_rows_with_builtins};
+    use desktop_assistant_client_common::mcp_host::BuiltinStatus;
 
-    /// fileio's constructor is infallible, so with nothing shadowing it the
-    /// built-in set deterministically contains a server named "fileio",
-    /// advertised under the "fileio" namespace.
+    /// fileio's constructor is infallible, so the compiled-in set deterministically
+    /// contains a server named "fileio", advertised under the "fileio" namespace.
+    /// The override (skipping a shadowed built-in) now lives centrally in
+    /// [`McpHost::start_with`], so `builtin_servers()` always returns the full set.
     #[cfg(feature = "mcp-fileio")]
     #[test]
-    fn fileio_builtin_present_and_namespaced_by_default() {
-        let servers = builtin_servers(&[]);
+    fn fileio_builtin_present_and_namespaced_in_full_set() {
+        let servers = builtin_servers();
         let fileio = servers
             .iter()
             .find(|s| s.name == "fileio")
-            .expect("fileio built-in must be present when nothing shadows it");
+            .expect("fileio built-in must be present in the compiled set");
         assert_eq!(
             fileio.namespace, "fileio",
             "fileio built-in must be advertised under the 'fileio' namespace"
         );
     }
 
-    /// A configured client-mcp server of the same name suppresses the built-in
-    /// (external > built-in), so the built-in set omits "fileio" entirely.
-    #[cfg(feature = "mcp-fileio")]
+    /// The panel mapping: a host [`BuiltinStatus`] list becomes [`BuiltinServerDto`]s
+    /// that `server_rows_with_builtins` turns into an active built-in row (no
+    /// disabled reason) and an overridden one (a disabled row whose reason names the
+    /// external server). This is the exact path the F5 MCP panel renders.
     #[test]
-    fn external_same_name_shadows_builtin() {
-        let servers = builtin_servers(&["fileio".to_string()]);
+    fn builtin_dtos_map_to_active_and_overridden_rows() {
+        let status = vec![
+            BuiltinStatus {
+                name: "fileio".into(),
+                namespace: "fileio".into(),
+                tool_count: 7,
+                overridden_by: None,
+            },
+            BuiltinStatus {
+                name: "web".into(),
+                namespace: "web".into(),
+                tool_count: 3,
+                overridden_by: Some("web".into()),
+            },
+        ];
+
+        let dtos = builtin_dtos(status);
+        assert_eq!(dtos.len(), 2, "each status maps to exactly one dto");
+        let fileio_dto = dtos
+            .iter()
+            .find(|d| d.name == "fileio")
+            .expect("fileio dto present");
+        assert_eq!(fileio_dto.tool_count, 7, "usize tool_count widens to u32");
+        assert_eq!(fileio_dto.overridden_by, None);
+
+        let rows = server_rows_with_builtins(&[], &[], &dtos);
+
+        let fileio = rows
+            .iter()
+            .find(|r| r.name == "fileio")
+            .expect("fileio row present");
+        assert_eq!(
+            fileio.kind,
+            ServerKind::BuiltIn,
+            "built-in rows carry the BuiltIn kind"
+        );
+        assert_eq!(
+            fileio.disabled_reason, None,
+            "an active built-in is not disabled"
+        );
+        assert_eq!(kind_label(fileio.kind), "built-in");
+
+        let web = rows
+            .iter()
+            .find(|r| r.name == "web")
+            .expect("web row present");
+        assert_eq!(web.kind, ServerKind::BuiltIn);
+        let reason = web
+            .disabled_reason
+            .as_deref()
+            .expect("an overridden built-in must render disabled with a reason");
         assert!(
-            !servers.iter().any(|s| s.name == "fileio"),
-            "an external client-mcp server named 'fileio' must suppress the built-in"
+            reason.contains("overridden"),
+            "reason explains the override: {reason}"
+        );
+        assert!(
+            reason.contains("web"),
+            "reason names the overriding server: {reason}"
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -323,10 +323,10 @@ async fn run_headless(config: &ConnectionConfig, prompt: String) -> Result<()> {
         .into_iter()
         .cloned()
         .collect();
-    // Compiled-in built-ins (da#538 Phase C): host the core MCP set in-process,
-    // minus any name a client-mcp.toml server already provides (external wins).
-    let configured: Vec<String> = servers.iter().map(|s| s.name.clone()).collect();
-    let mcp_builtins = adele::builtins::builtin_servers(&configured);
+    // Compiled-in built-ins (da#538 Phase C/D): host the full core MCP set
+    // in-process. `McpHost::start_with` centralizes the override, skipping (and
+    // logging) any built-in whose name a client-mcp.toml server already provides.
+    let mcp_builtins = adele::builtins::builtin_servers();
     let host = if servers.is_empty() && mcp_builtins.is_empty() {
         None
     } else {
@@ -518,11 +518,11 @@ async fn run(
         .into_iter()
         .cloned()
         .collect();
-    // Compiled-in built-ins (da#538 Phase C): host the core MCP set in-process,
-    // suppressing any built-in whose name a configured client-mcp server already
-    // provides (external overrides built-in).
-    let configured: Vec<String> = mcp_servers.iter().map(|s| s.name.clone()).collect();
-    let mcp_builtins = adele::builtins::builtin_servers(&configured);
+    // Compiled-in built-ins (da#538 Phase C/D): host the full core MCP set
+    // in-process. `McpHost::start_with` centralizes the override, skipping (and
+    // logging) any built-in whose name a configured client-mcp server already
+    // provides, and reports each built-in's status for the F5 panel.
+    let mcp_builtins = adele::builtins::builtin_servers();
     if !mcp_servers.is_empty() || !mcp_builtins.is_empty() {
         app.mcp_host = Some(Rc::new(
             McpHost::start_with(&mcp_servers, mcp_builtins).await,
@@ -707,6 +707,14 @@ async fn run(
                 }
                 ScreenRequest::McpServers => {
                     if let Some(conn) = connector.clone() {
+                        // Resolve the client's in-process built-ins for the panel's
+                        // read-only section (da#538 Phase D). Computed before the
+                        // sink borrows `app` mutably; empty when no host is running.
+                        let mcp_builtins = app
+                            .mcp_host
+                            .as_ref()
+                            .map(|h| adele::builtins::builtin_dtos(h.builtin_status()))
+                            .unwrap_or_default();
                         let mut sink = SubScreenSink {
                             app: &mut app,
                             connector: &connector,
@@ -715,8 +723,14 @@ async fn run(
                             narration_tx: &narration_tx,
                             disconnect: &mut disconnect,
                         };
-                        if let Err(e) =
-                            mcp::run(terminal, conn.client(), &mut signal_rx, &mut sink).await
+                        if let Err(e) = mcp::run(
+                            terminal,
+                            conn.client(),
+                            &mcp_builtins,
+                            &mut signal_rx,
+                            &mut sink,
+                        )
+                        .await
                         {
                             sink.app.status_message = format!("MCP servers error: {e}");
                         }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -56,6 +56,7 @@
 use std::collections::BTreeMap;
 use std::io;
 
+use client_ui_common::{BuiltinServerDto, ServerRow, kind_label, server_rows_with_builtins};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use desktop_assistant_api_model::{
     Command, CommandResult, McpServerView, Secret, ServiceAccountView,
@@ -768,6 +769,13 @@ enum RpcOutcome {
 
 struct State {
     servers: Vec<McpServerView>,
+    /// Built-in (in-process) MCP servers, resolved once at open from the client's
+    /// `McpHost::builtin_status()` (da#538 Phase D). Rendered as a read-only
+    /// section below the daemon servers: they are hosted inside this client, not
+    /// managed by the daemon, so they are informational and not selectable /
+    /// editable. An overridden built-in carries a `disabled_reason` and renders
+    /// disabled. Empty when built-ins are compiled out or no host is running.
+    builtins: Vec<ServerRow>,
     /// OAuth service accounts (for the editor picker). Best-effort — a failure
     /// to list them leaves the picker empty rather than blocking the panel.
     accounts: Vec<ServiceAccountView>,
@@ -826,15 +834,23 @@ impl Screen for McpScreen<'_> {
 }
 
 /// Run the MCP-servers screen. Returns when the user closes it.
+///
+/// `builtins` are the client's compiled-in (in-process) MCP servers, resolved by
+/// the caller from `McpHost::builtin_status()` and mapped to
+/// [`BuiltinServerDto`]s. They are merged into read-only [`ServerRow`]s (via
+/// `server_rows_with_builtins` with no daemon/external client rows) and shown as
+/// a separate informational section; pass an empty slice when none are hosted.
 pub async fn run(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
     client: &TransportClient,
+    builtins: &[BuiltinServerDto],
     signal_rx: &mut tokio::sync::mpsc::UnboundedReceiver<SignalEvent>,
     sink: &mut impl crate::screen::SignalSink,
 ) -> anyhow::Result<()> {
     let mut screen = McpScreen {
         state: State {
             servers: Vec::new(),
+            builtins: server_rows_with_builtins(&[], &[], builtins),
             accounts: Vec::new(),
             selected: 0,
             mode: Mode::List,
@@ -1236,7 +1252,7 @@ fn draw_header(f: &mut Frame, area: Rect) {
 }
 
 fn draw_list(f: &mut Frame, state: &State, area: Rect) {
-    let items: Vec<ListItem> = if state.servers.is_empty() {
+    let mut items: Vec<ListItem> = if state.servers.is_empty() {
         vec![ListItem::new(Line::from(Span::styled(
             "(no MCP servers — press 'a' to add one)",
             Style::default().fg(theme().text_dim),
@@ -1244,6 +1260,19 @@ fn draw_list(f: &mut Frame, state: &State, area: Rect) {
     } else {
         state.servers.iter().map(server_item).collect()
     };
+
+    // Built-in (in-process) servers render below the daemon list as a read-only
+    // section: they are hosted inside this client, so they are informational and
+    // never selectable / editable (selection stays bounded to `state.servers`).
+    if !state.builtins.is_empty() {
+        items.push(ListItem::new(Line::from(Span::styled(
+            "── Built-in (in-process) ──",
+            Style::default()
+                .fg(theme().text_dim)
+                .add_modifier(Modifier::DIM),
+        ))));
+        items.extend(state.builtins.iter().map(builtin_item));
+    }
 
     let title = if state.servers.is_empty() {
         "Servers".to_string()
@@ -1327,6 +1356,71 @@ fn server_item(server: &McpServerView) -> ListItem<'static> {
         lines.push(Line::from(Span::styled(
             "    Sign-in required — press 'c' for the command to run on the daemon host",
             Style::default().fg(theme().warn),
+        )));
+    }
+    ListItem::new(lines)
+}
+
+/// Pure display model for one built-in [`ServerRow`]: the head-line text (name +
+/// kind chip + tool count), the optional override reason, and whether the row
+/// should render disabled/dimmed. Kept pure — free of `ratatui` styling — so the
+/// overridden/disabled rendering is unit-testable without a terminal. All text
+/// is [`sanitize`]d (the overriding name is config-sourced) as elsewhere here.
+struct BuiltinRowDisplay {
+    head: String,
+    reason: Option<String>,
+    disabled: bool,
+}
+
+/// Build the display model for a built-in row. An overridden built-in
+/// (`disabled_reason == Some`) is marked `disabled` and carries its reason.
+fn builtin_row_display(row: &ServerRow) -> BuiltinRowDisplay {
+    let chip = kind_label(row.kind);
+    let n = row.tool_count;
+    let head = format!(
+        "{}  [{chip}]  {n} tool{}",
+        sanitize(&row.name),
+        if n == 1 { "" } else { "s" },
+    );
+    BuiltinRowDisplay {
+        head,
+        reason: row.disabled_reason.as_deref().map(sanitize),
+        disabled: row.disabled_reason.is_some(),
+    }
+}
+
+/// One built-in server row: a head line (name + `[built-in]` chip + tool count)
+/// plus, when the built-in is overridden by an external server of the same name,
+/// a dim disabled detail line surfacing the reason. Overridden rows render dim
+/// throughout to read as inactive.
+fn builtin_item(row: &ServerRow) -> ListItem<'static> {
+    let display = builtin_row_display(row);
+    let head_style = if display.disabled {
+        Style::default()
+            .fg(theme().text_dim)
+            .add_modifier(Modifier::DIM)
+    } else {
+        Style::default().fg(theme().text_dim)
+    };
+
+    let mut lines = vec![Line::from(vec![
+        Span::styled(
+            "○",
+            Style::default().fg(if display.disabled {
+                theme().text_dim
+            } else {
+                theme().ok
+            }),
+        ),
+        Span::raw(" "),
+        Span::styled(display.head, head_style),
+    ])];
+    if let Some(reason) = display.reason {
+        lines.push(Line::from(Span::styled(
+            format!("    {reason}"),
+            Style::default()
+                .fg(theme().text_dim)
+                .add_modifier(Modifier::ITALIC | Modifier::DIM),
         )));
     }
     ListItem::new(lines)
@@ -2253,12 +2347,21 @@ mod tests {
     /// A built-in [`ServerRow`] as produced by `server_rows_with_builtins`: an
     /// in-process, client-run server whose `disabled_reason` is `Some` iff an
     /// external server of the same name overrides it.
-    fn builtin_row(name: &str, tool_count: u32, reason: Option<&str>) -> client_ui_common::ServerRow {
+    fn builtin_row(
+        name: &str,
+        tool_count: u32,
+        reason: Option<&str>,
+    ) -> client_ui_common::ServerRow {
         client_ui_common::ServerRow {
             name: name.into(),
             runner: client_ui_common::Runner::Client,
             transport: "builtin".into(),
-            status: if reason.is_some() { "disabled" } else { "running" }.into(),
+            status: if reason.is_some() {
+                "disabled"
+            } else {
+                "running"
+            }
+            .into(),
             tool_count,
             detail: None,
             kind: client_ui_common::ServerKind::BuiltIn,
@@ -2270,8 +2373,15 @@ mod tests {
     fn builtin_row_display_active_has_no_reason() {
         let d = builtin_row_display(&builtin_row("fileio", 7, None));
         assert!(!d.disabled, "an active built-in must not render disabled");
-        assert!(d.reason.is_none(), "an active built-in has no override reason");
-        assert!(d.head.contains("fileio"), "head names the server: {}", d.head);
+        assert!(
+            d.reason.is_none(),
+            "an active built-in has no override reason"
+        );
+        assert!(
+            d.head.contains("fileio"),
+            "head names the server: {}",
+            d.head
+        );
         assert!(
             d.head.contains("built-in"),
             "head carries the kind chip: {}",
@@ -2312,7 +2422,10 @@ mod tests {
             text.contains("in-process"),
             "built-in section header missing: {text}"
         );
-        assert!(text.contains("fileio"), "active built-in row missing: {text}");
+        assert!(
+            text.contains("fileio"),
+            "active built-in row missing: {text}"
+        );
         assert!(text.contains("built-in"), "kind chip missing: {text}");
         assert!(
             text.contains("overridden"),

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -2237,6 +2237,7 @@ mod tests {
     fn state_with(servers: Vec<McpServerView>, accounts: Vec<ServiceAccountView>) -> State {
         State {
             servers,
+            builtins: Vec::new(),
             accounts,
             selected: 0,
             mode: Mode::List,
@@ -2245,6 +2246,78 @@ mod tests {
             busy: None,
             closing: false,
         }
+    }
+
+    // --- built-in rows (da#538 Phase D, slice 3) -----------------------------
+
+    /// A built-in [`ServerRow`] as produced by `server_rows_with_builtins`: an
+    /// in-process, client-run server whose `disabled_reason` is `Some` iff an
+    /// external server of the same name overrides it.
+    fn builtin_row(name: &str, tool_count: u32, reason: Option<&str>) -> client_ui_common::ServerRow {
+        client_ui_common::ServerRow {
+            name: name.into(),
+            runner: client_ui_common::Runner::Client,
+            transport: "builtin".into(),
+            status: if reason.is_some() { "disabled" } else { "running" }.into(),
+            tool_count,
+            detail: None,
+            kind: client_ui_common::ServerKind::BuiltIn,
+            disabled_reason: reason.map(Into::into),
+        }
+    }
+
+    #[test]
+    fn builtin_row_display_active_has_no_reason() {
+        let d = builtin_row_display(&builtin_row("fileio", 7, None));
+        assert!(!d.disabled, "an active built-in must not render disabled");
+        assert!(d.reason.is_none(), "an active built-in has no override reason");
+        assert!(d.head.contains("fileio"), "head names the server: {}", d.head);
+        assert!(
+            d.head.contains("built-in"),
+            "head carries the kind chip: {}",
+            d.head
+        );
+    }
+
+    #[test]
+    fn builtin_row_display_overridden_dims_and_shows_reason() {
+        let d = builtin_row_display(&builtin_row(
+            "web",
+            3,
+            Some("overridden by the external \"web\""),
+        ));
+        assert!(
+            d.disabled,
+            "an overridden built-in must render disabled/dimmed"
+        );
+        let reason = d
+            .reason
+            .as_deref()
+            .expect("an overridden built-in must surface a reason");
+        assert!(
+            reason.contains("overridden"),
+            "reason explains the override: {reason}"
+        );
+    }
+
+    #[test]
+    fn draw_list_renders_builtin_section_with_override_reason() {
+        let mut state = state_with(Vec::new(), Vec::new());
+        state.builtins = vec![
+            builtin_row("fileio", 7, None),
+            builtin_row("web", 3, Some("overridden by the external \"web\"")),
+        ];
+        let text = rendered(&state, 120, 20);
+        assert!(
+            text.contains("in-process"),
+            "built-in section header missing: {text}"
+        );
+        assert!(text.contains("fileio"), "active built-in row missing: {text}");
+        assert!(text.contains("built-in"), "kind chip missing: {text}");
+        assert!(
+            text.contains("overridden"),
+            "override reason missing: {text}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Slice 3 of da#538 Phase D for adele-tui: activate the centralized built-in override (from slice 2) and render built-in servers in the F5 MCP panel.

## What changed

- **Activate the central override.** `builtin_servers()` (was `builtin_servers(configured_names)`) now returns the FULL compiled-in set. The override -- skipping and logging a built-in whose name matches a configured client-mcp server -- now lives centrally in `McpHost::start_with`, so the tui passes the full list at both `start_with` sites (headless + interactive) in `main.rs`. The old `external_same_name_shadows_builtin` test moved to client-common; the presence test now asserts against the full set.
- **Plumb `builtin_status()` to the panel.** New `builtins::builtin_dtos()` maps the host's `BuiltinStatus` -> `client_ui_common::BuiltinServerDto` (widening `tool_count`, carrying `overridden_by`). The `McpServers` screen handler resolves `app.mcp_host.builtin_status()` into DTOs and passes them to `mcp::run`.
- **Render built-in rows.** The panel builds them via `server_rows_with_builtins(&[], &[], &dtos)` and draws a read-only "Built-in (in-process)" section below the daemon servers. Rows show the `kind_label` chip ("built-in") and tool count. An overridden built-in renders **dimmed/disabled** with its reason (`overridden by the external "<name>"`). The interactive daemon-server model is untouched; built-in rows are informational and not selectable/editable.

## Deviation

The tui F5 panel never called `client_ui_common::server_rows` -- it renders daemon `McpServerView`s directly in a fully-interactive selectable list (edit/toggle/remove index into `state.servers`). Rather than migrate that interactive model to `ServerRow`, built-ins are rendered as a separate read-only section computed via `server_rows_with_builtins(&[], &[], &dtos)`, reusing the shared override-message + `kind_label` logic. Selection stays bounded to the daemon servers, so no interactive coupling is broken.

## Gate (dev profile) -- all green

- `cargo fmt` / `--check` clean
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo test` -- all pass (5 new built-in tests)
- `cargo build --no-default-features` compiles (built-ins off -> panel shows no built-in rows, `builtin_servers()` empty)

TDD: failing spec committed first (25bcc57), then implementation (b1f5055).

**Do not merge -- pending review.**

Refs adelie-ai/desktop-assistant#538

🤖 Generated with [Claude Code](https://claude.com/claude-code)