### PR TITLE
CLI: exec + config subcommands (scriptable config/MCP management)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,7 @@ dependencies = [
  "serde_json",
  "syntect",
  "tasks-mcp",
+ "tempfile",
  "terminal-mcp",
  "tokio",
  "toml 0.9.12+spec-1.1.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,6 +102,11 @@ desktop-assistant-api-model = { path = "../desktop-assistant/crates/api-model" }
 mcp-core = { path = "../mcp-core" }
 
 
+[dev-dependencies]
+# Tempfile config paths for the `config_cmd` unit tests, so they mutate/save
+# `ClientMcpConfig` against a throwaway file instead of the user's real config.
+tempfile = "3"
+
 [features]
 # The core built-in MCP set is compiled in and hosted in-process by default, so
 # a fresh tui is useful with no client-mcp.toml (da#538 Phase C). Turn a server

--- a/README.md
+++ b/README.md
@@ -82,20 +82,60 @@ cargo install --path .   # installs `adele` to ~/.cargo/bin
 ## Run
 
 ```sh
-adele
+adele                       # interactive TUI (default)
+adele exec "summarize X"    # one-shot: send a prompt, print the reply, exit
+adele config mcp list       # scriptable config, no daemon needed
 ```
 
-### CLI options
+`adele` with no subcommand launches the interactive TUI (the global options
+below still apply). The subcommands are:
+
+### `exec <PROMPT>` (alias: `prompt`)
+
+Send a single prompt non-interactively, stream the reply to stdout, and exit —
+no TUI. Client-hosted MCP tools (`client-mcp.toml`) still work, so this can
+drive a local or remote (k8s) brain end to end. This replaces the old
+`--prompt <TEXT>` flag, which still works (hidden, deprecated) for back-compat.
+
+### `config` — scriptable config management
+
+The non-interactive twin of the `F5` MCP-servers panel. It loads, mutates, and
+saves the shared client-MCP config (`$XDG_CONFIG_HOME/adele/client-mcp.toml`)
+directly, with no daemon connection:
+
+```sh
+adele config path                     # print the config file location
+adele config show [--section mcp]     # print the effective config as TOML
+adele config mcp list                 # list client-MCP servers + built-ins
+adele config mcp add-server <NAME> --command <CMD> [--arg <A>]... \
+    [--namespace <NS>] [--surface <S>]... [--enabled]
+adele config mcp remove-server <NAME>
+adele config mcp enable  <NAME> [--surface tui]
+adele config mcp disable <NAME> [--surface tui]
+```
+
+`config mcp list` also shows the compiled-in **built-in** servers (with tool
+counts), marking any that a same-named, surface-enabled client-MCP server
+overrides. Built-in enable/disable is not yet supported from the CLI (it needs
+the panel's built-in toggle); that case is reported clearly rather than silently
+ignored. Daemon-hosted MCP servers are out of scope here — manage those from the
+interactive `F5` panel.
+
+### Global options
+
+Given before any subcommand (they apply to the TUI and `exec` alike):
 
 | Flag | Env var | Default | Description |
 |------|---------|---------|-------------|
-| `--transport` | `DESKTOP_ASSISTANT_TUI_TRANSPORT` | `ws` | Transport: `ws` or `dbus` |
-| `--ws-url` | `DESKTOP_ASSISTANT_TUI_WS_URL` | `ws://127.0.0.1:11339/ws` | WebSocket URL |
+| `--transport` | `DESKTOP_ASSISTANT_TUI_TRANSPORT` | `local` | Transport: `local` (UDS), `ws`, or `dbus` |
+| `--socket [PATH]` | | | Connect over the local Unix socket (optional path override) |
+| `--ws [URL]` | | | Connect over WebSocket (optional URL override) |
+| `--ws-url` | `DESKTOP_ASSISTANT_TUI_WS_URL` | `wss://127.0.0.1:11339/ws` | WebSocket URL |
 | `--ws-jwt` | `DESKTOP_ASSISTANT_TUI_WS_JWT` | | Direct JWT token |
-| `--ws-login-username` | `DESKTOP_ASSISTANT_TUI_WS_LOGIN_USERNAME` | | Login username |
-| `--ws-login-password` | `DESKTOP_ASSISTANT_TUI_WS_LOGIN_PASSWORD` | | Login password |
+| `--ws-login-username` | `DESKTOP_ASSISTANT_TUI_WS_USERNAME` | | Login username |
+| `--ws-login-password` | `DESKTOP_ASSISTANT_TUI_WS_PASSWORD` | | Login password |
 | `--ws-subject` | `DESKTOP_ASSISTANT_TUI_WS_SUBJECT` | `desktop-tui` | JWT subject |
-| `--dbus-service` | `DESKTOP_ASSISTANT_DBUS_SERVICE` | `org.desktopAssistant` | D-Bus service name |
+| `-v`, `--verbose` | | | Verbose logging to stderr (`-v`/`-vv`/`-vvv`) |
 
 ## Test
 

--- a/src/config_cmd.rs
+++ b/src/config_cmd.rs
@@ -1,0 +1,401 @@
+//! Non-interactive `config` subcommand handlers (adele-tui#122).
+//!
+//! The scriptable twin of the interactive `F5` MCP-servers panel and the
+//! connection/config screens: `adele config …` loads, mutates, and saves the
+//! shared client-MCP config ([`ClientMcpConfig`], `client-mcp.toml`) without ever
+//! standing up a TUI or a daemon connection, so it composes in shell scripts.
+//!
+//! Every handler here is **pure over an injected config path** — the caller
+//! resolves [`default_client_mcp_path`] and passes it in — and writes its
+//! human-facing output to an injected [`Write`] sink, so the whole surface is
+//! unit-testable against a tempfile and an in-memory buffer with no real daemon,
+//! filesystem-global state, or terminal.
+//!
+//! Scope: this manages the **client-side** MCP config only. Daemon-hosted MCP
+//! servers are out of this first cut (they need a live connection + the typed
+//! command channel the `F5` panel uses); [`mcp_list`] says so in its output.
+//!
+//! [`default_client_mcp_path`]: desktop_assistant_client_common::mcp_host::default_client_mcp_path
+
+use std::io::Write;
+use std::path::Path;
+
+use anyhow::{Result, bail};
+
+/// The default client surface the `config mcp` subcommands act on when none is
+/// given — the TUI's own surface. Mirrors the `"tui"` surface string the
+/// interactive client hosts its client-MCP servers under.
+pub const DEFAULT_SURFACE: &str = "tui";
+
+/// A compiled-in built-in server, reduced to what [`mcp_list`] renders: its name
+/// and advertised tool count. The caller resolves these from
+/// `crate::builtins::builtin_servers()` (`name` + `service.tools().len()`) and
+/// passes them in, so this module stays free of the feature-gated built-in
+/// server deps and is testable with synthetic built-ins.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BuiltinInfo {
+    /// The built-in's name (also its default tool-namespace prefix).
+    pub name: String,
+    /// The number of tools the built-in advertises (`service.tools().len()`).
+    pub tool_count: usize,
+}
+
+impl BuiltinInfo {
+    /// Convenience constructor.
+    pub fn new(name: impl Into<String>, tool_count: usize) -> Self {
+        Self {
+            name: name.into(),
+            tool_count,
+        }
+    }
+}
+
+/// `config path`: print the resolved client-MCP config file location.
+pub fn config_path(path: &Path, out: &mut impl Write) -> Result<()> {
+    let _ = (path, out);
+    bail!("config_path not yet implemented")
+}
+
+/// `config show [--section mcp]`: print the effective client-MCP config as TOML.
+///
+/// `section` restricts the output; only `mcp` (the default) is supported today,
+/// and any other value is a clear error rather than an empty print.
+pub fn config_show(path: &Path, section: Option<&str>, out: &mut impl Write) -> Result<()> {
+    let _ = (path, section, out);
+    bail!("config_show not yet implemented")
+}
+
+/// `config mcp list`: list the client-MCP servers for `surface` (with their
+/// command + whether they're enabled for that surface), then the compiled-in
+/// built-ins (with tool counts, marking any overridden by a same-named,
+/// surface-enabled client-MCP server).
+pub fn mcp_list(
+    path: &Path,
+    builtins: &[BuiltinInfo],
+    surface: &str,
+    out: &mut impl Write,
+) -> Result<()> {
+    let _ = (path, builtins, surface, out);
+    bail!("mcp_list not yet implemented")
+}
+
+/// `config mcp add-server`: define (or replace) a stdio client-MCP server, and
+/// — when `enabled` — turn it on for each of `surfaces`.
+#[allow(clippy::too_many_arguments)]
+pub fn mcp_add_server(
+    path: &Path,
+    name: &str,
+    command: &str,
+    args: &[String],
+    namespace: Option<&str>,
+    surfaces: &[String],
+    enabled: bool,
+    out: &mut impl Write,
+) -> Result<()> {
+    let _ = (path, name, command, args, namespace, surfaces, enabled, out);
+    bail!("mcp_add_server not yet implemented")
+}
+
+/// `config mcp remove-server`: delete a client-MCP server definition (and prune
+/// it from every surface). Errors if no server by that name is defined.
+pub fn mcp_remove_server(path: &Path, name: &str, out: &mut impl Write) -> Result<()> {
+    let _ = (path, name, out);
+    bail!("mcp_remove_server not yet implemented")
+}
+
+/// `config mcp enable`/`disable`: flip a client-MCP server's membership in one
+/// surface's enable list. A name that matches only a built-in is reported as
+/// not-yet-supported (a normal informational outcome, not an error); a name that
+/// matches neither is an error.
+pub fn mcp_set_enabled(
+    path: &Path,
+    name: &str,
+    surface: &str,
+    on: bool,
+    builtins: &[BuiltinInfo],
+    out: &mut impl Write,
+) -> Result<()> {
+    let _ = (path, name, surface, on, builtins, out);
+    bail!("mcp_set_enabled not yet implemented")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use desktop_assistant_client_common::mcp_host::ClientMcpConfig;
+    use tempfile::tempdir;
+
+    /// A fresh tempdir + the config path inside it (the file itself does not yet
+    /// exist, exercising the load-absent-as-default path).
+    fn temp_cfg() -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("client-mcp.toml");
+        (dir, path)
+    }
+
+    fn out_string(f: impl FnOnce(&mut Vec<u8>) -> Result<()>) -> String {
+        let mut buf = Vec::new();
+        f(&mut buf).expect("handler ok");
+        String::from_utf8(buf).expect("utf8 output")
+    }
+
+    #[test]
+    fn add_server_then_list_includes_it() {
+        let (_dir, path) = temp_cfg();
+
+        mcp_add_server(
+            &path,
+            "notes",
+            "notes-mcp",
+            &["serve".to_string()],
+            Some("nt"),
+            &["tui".to_string()],
+            true,
+            &mut Vec::new(),
+        )
+        .expect("add");
+
+        // The definition was written and reloads.
+        let cfg = ClientMcpConfig::load(&path);
+        let server = cfg
+            .list_defined_servers()
+            .iter()
+            .find(|s| s.name == "notes")
+            .expect("notes server defined after add");
+        assert_eq!(server.command, "notes-mcp");
+        assert_eq!(server.args, vec!["serve".to_string()]);
+        assert_eq!(server.namespace.as_deref(), Some("nt"));
+
+        // And `list` reflects it, with its command and enabled status.
+        let listed = out_string(|o| mcp_list(&path, &[], "tui", o));
+        assert!(listed.contains("notes"), "list names the server: {listed}");
+        assert!(
+            listed.contains("notes-mcp"),
+            "list shows the command: {listed}"
+        );
+        assert!(
+            listed.contains("enabled"),
+            "an added+enabled server lists as enabled: {listed}"
+        );
+    }
+
+    #[test]
+    fn add_server_without_enabled_leaves_surface_off() {
+        let (_dir, path) = temp_cfg();
+        mcp_add_server(
+            &path,
+            "notes",
+            "notes-mcp",
+            &[],
+            None,
+            &["tui".to_string()],
+            false,
+            &mut Vec::new(),
+        )
+        .expect("add");
+
+        let cfg = ClientMcpConfig::load(&path);
+        assert!(
+            cfg.list_defined_servers().iter().any(|s| s.name == "notes"),
+            "server is defined"
+        );
+        assert!(
+            !cfg.surface_enabled_names("tui").iter().any(|n| n == "notes"),
+            "without --enabled the server is not turned on for the surface"
+        );
+    }
+
+    #[test]
+    fn enable_disable_toggles_surface() {
+        let (_dir, path) = temp_cfg();
+        mcp_add_server(
+            &path,
+            "notes",
+            "notes-mcp",
+            &[],
+            None,
+            &["tui".to_string()],
+            false,
+            &mut Vec::new(),
+        )
+        .expect("add");
+
+        mcp_set_enabled(&path, "notes", "tui", true, &[], &mut Vec::new()).expect("enable");
+        assert!(
+            ClientMcpConfig::load(&path)
+                .surface_enabled_names("tui")
+                .iter()
+                .any(|n| n == "notes"),
+            "enable adds the server to the tui surface"
+        );
+
+        mcp_set_enabled(&path, "notes", "tui", false, &[], &mut Vec::new()).expect("disable");
+        assert!(
+            !ClientMcpConfig::load(&path)
+                .surface_enabled_names("tui")
+                .iter()
+                .any(|n| n == "notes"),
+            "disable removes the server from the tui surface"
+        );
+    }
+
+    #[test]
+    fn remove_server_removes_it() {
+        let (_dir, path) = temp_cfg();
+        mcp_add_server(
+            &path,
+            "notes",
+            "notes-mcp",
+            &[],
+            None,
+            &["tui".to_string()],
+            true,
+            &mut Vec::new(),
+        )
+        .expect("add");
+        assert!(
+            ClientMcpConfig::load(&path)
+                .list_defined_servers()
+                .iter()
+                .any(|s| s.name == "notes")
+        );
+
+        mcp_remove_server(&path, "notes", &mut Vec::new()).expect("remove");
+        let cfg = ClientMcpConfig::load(&path);
+        assert!(
+            !cfg.list_defined_servers().iter().any(|s| s.name == "notes"),
+            "the definition is gone after remove"
+        );
+        assert!(
+            !cfg.surface_enabled_names("tui").iter().any(|n| n == "notes"),
+            "remove prunes the surface enable entry too"
+        );
+    }
+
+    #[test]
+    fn remove_absent_server_errors() {
+        let (_dir, path) = temp_cfg();
+        let err = mcp_remove_server(&path, "ghost", &mut Vec::new())
+            .expect_err("removing an undefined server errors");
+        assert!(
+            err.to_string().contains("ghost"),
+            "the error names the missing server: {err}"
+        );
+    }
+
+    #[test]
+    fn list_marks_builtin_overridden_when_same_name_enabled() {
+        let (_dir, path) = temp_cfg();
+        // A client-MCP server named "fileio", enabled for tui, shadows the
+        // built-in of the same name (external > built-in).
+        mcp_add_server(
+            &path,
+            "fileio",
+            "my-fileio",
+            &[],
+            None,
+            &["tui".to_string()],
+            true,
+            &mut Vec::new(),
+        )
+        .expect("add");
+
+        let builtins = [BuiltinInfo::new("fileio", 7), BuiltinInfo::new("terminal", 4)];
+        let listed = out_string(|o| mcp_list(&path, &builtins, "tui", o));
+
+        // The overriding built-in renders as overridden; the untouched one does not.
+        assert!(
+            listed.contains("fileio") && listed.contains("overridden"),
+            "an overridden built-in is marked overridden: {listed}"
+        );
+        // The built-in section shows tool counts.
+        assert!(
+            listed.contains('7') && listed.contains('4'),
+            "built-in tool counts are shown: {listed}"
+        );
+        // "terminal" is not overridden (no same-named client-MCP server).
+        let terminal_line = listed
+            .lines()
+            .find(|l| l.contains("terminal"))
+            .expect("terminal built-in listed");
+        assert!(
+            !terminal_line.contains("overridden"),
+            "a non-shadowed built-in is not marked overridden: {terminal_line}"
+        );
+    }
+
+    #[test]
+    fn enable_builtin_only_name_is_declined_not_errored() {
+        let (_dir, path) = temp_cfg();
+        let builtins = [BuiltinInfo::new("fileio", 7)];
+        // "fileio" exists only as a built-in (no client-MCP definition).
+        let msg = out_string(|o| mcp_set_enabled(&path, "fileio", "tui", true, &builtins, o));
+        assert!(
+            msg.contains("built-in") && msg.contains("not yet supported"),
+            "toggling a built-in-only name is declined with a clear message: {msg}"
+        );
+        // Nothing was written to the surface list.
+        assert!(
+            !ClientMcpConfig::load(&path)
+                .surface_enabled_names("tui")
+                .iter()
+                .any(|n| n == "fileio"),
+            "a declined built-in toggle does not mutate the config"
+        );
+    }
+
+    #[test]
+    fn enable_unknown_name_errors() {
+        let (_dir, path) = temp_cfg();
+        let err = mcp_set_enabled(&path, "ghost", "tui", true, &[], &mut Vec::new())
+            .expect_err("enabling an unknown, non-built-in name errors");
+        assert!(
+            err.to_string().contains("ghost"),
+            "the error names the unknown server: {err}"
+        );
+    }
+
+    #[test]
+    fn show_reports_added_server_and_path() {
+        let (_dir, path) = temp_cfg();
+        mcp_add_server(
+            &path,
+            "notes",
+            "notes-mcp",
+            &[],
+            None,
+            &["tui".to_string()],
+            true,
+            &mut Vec::new(),
+        )
+        .expect("add");
+
+        let shown = out_string(|o| config_show(&path, None, o));
+        assert!(shown.contains("notes"), "show renders the server: {shown}");
+        assert!(
+            shown.contains("client-mcp.toml"),
+            "show names the config path: {shown}"
+        );
+    }
+
+    #[test]
+    fn show_rejects_unknown_section() {
+        let (_dir, path) = temp_cfg();
+        let err = config_show(&path, Some("bogus"), &mut Vec::new())
+            .expect_err("an unknown --section is rejected");
+        assert!(
+            err.to_string().contains("bogus") || err.to_string().contains("mcp"),
+            "the error explains only mcp is supported: {err}"
+        );
+    }
+
+    #[test]
+    fn path_prints_config_location() {
+        let (_dir, path) = temp_cfg();
+        let printed = out_string(|o| config_path(&path, o));
+        assert!(
+            printed.contains("client-mcp.toml"),
+            "path prints the config location: {printed}"
+        );
+    }
+}

--- a/src/config_cmd.rs
+++ b/src/config_cmd.rs
@@ -130,7 +130,10 @@ pub fn mcp_list(
 
     writeln!(out, "Client-hosted MCP servers (surface: {surface})")?;
     if defined.is_empty() {
-        writeln!(out, "  (none defined — add one with `config mcp add-server`)")?;
+        writeln!(
+            out,
+            "  (none defined — add one with `config mcp add-server`)"
+        )?;
     } else {
         writeln!(out, "  {:name_w$}  {:<9}  COMMAND", "NAME", "STATUS")?;
         for server in defined {
@@ -365,7 +368,9 @@ mod tests {
             "server is defined"
         );
         assert!(
-            !cfg.surface_enabled_names("tui").iter().any(|n| n == "notes"),
+            !cfg.surface_enabled_names("tui")
+                .iter()
+                .any(|n| n == "notes"),
             "without --enabled the server is not turned on for the surface"
         );
     }
@@ -432,7 +437,9 @@ mod tests {
             "the definition is gone after remove"
         );
         assert!(
-            !cfg.surface_enabled_names("tui").iter().any(|n| n == "notes"),
+            !cfg.surface_enabled_names("tui")
+                .iter()
+                .any(|n| n == "notes"),
             "remove prunes the surface enable entry too"
         );
     }
@@ -465,7 +472,10 @@ mod tests {
         )
         .expect("add");
 
-        let builtins = [BuiltinInfo::new("fileio", 7), BuiltinInfo::new("terminal", 4)];
+        let builtins = [
+            BuiltinInfo::new("fileio", 7),
+            BuiltinInfo::new("terminal", 4),
+        ];
         let listed = out_string(|o| mcp_list(&path, &builtins, "tui", o));
 
         // The overriding built-in renders as overridden; the untouched one does not.

--- a/src/config_cmd.rs
+++ b/src/config_cmd.rs
@@ -17,10 +17,12 @@
 //!
 //! [`default_client_mcp_path`]: desktop_assistant_client_common::mcp_host::default_client_mcp_path
 
+use std::collections::HashMap;
 use std::io::Write;
 use std::path::Path;
 
-use anyhow::{Result, bail};
+use anyhow::{Result, anyhow, bail};
+use desktop_assistant_client_common::mcp_host::{ClientMcpConfig, McpServerConfig};
 
 /// The default client surface the `config mcp` subcommands act on when none is
 /// given — the TUI's own surface. Mirrors the `"tui"` surface string the
@@ -51,9 +53,17 @@ impl BuiltinInfo {
 }
 
 /// `config path`: print the resolved client-MCP config file location.
+///
+/// This file is shared per machine across every Adele client (each surface
+/// selects its own subset), so the path is the same one the interactive TUI,
+/// GTK, and KDE clients read.
 pub fn config_path(path: &Path, out: &mut impl Write) -> Result<()> {
-    let _ = (path, out);
-    bail!("config_path not yet implemented")
+    writeln!(out, "Client-MCP config: {}", path.display())?;
+    writeln!(
+        out,
+        "  (shared per machine; each client surface selects its own subset)"
+    )?;
+    Ok(())
 }
 
 /// `config show [--section mcp]`: print the effective client-MCP config as TOML.
@@ -61,8 +71,30 @@ pub fn config_path(path: &Path, out: &mut impl Write) -> Result<()> {
 /// `section` restricts the output; only `mcp` (the default) is supported today,
 /// and any other value is a clear error rather than an empty print.
 pub fn config_show(path: &Path, section: Option<&str>, out: &mut impl Write) -> Result<()> {
-    let _ = (path, section, out);
-    bail!("config_show not yet implemented")
+    match section {
+        None | Some("mcp") => {}
+        Some(other) => bail!("unknown config section '{other}'; only 'mcp' is supported"),
+    }
+
+    writeln!(out, "Client-MCP config: {}", path.display())?;
+    if !path.exists() {
+        writeln!(
+            out,
+            "  (file does not exist — no client-hosted MCP servers configured)"
+        )?;
+        return Ok(());
+    }
+
+    // Load (tolerant of a malformed file, which parses to an empty config with a
+    // warning) and re-serialize the *effective* config, so `show` reflects what
+    // the clients actually see rather than echoing raw bytes.
+    let cfg = ClientMcpConfig::load(path);
+    if cfg.list_defined_servers().is_empty() {
+        writeln!(out, "  (no client-MCP servers defined)")?;
+    }
+    let toml = toml::to_string_pretty(&cfg).map_err(|e| anyhow!("serialize config: {e}"))?;
+    write!(out, "{toml}")?;
+    Ok(())
 }
 
 /// `config mcp list`: list the client-MCP servers for `surface` (with their
@@ -75,8 +107,79 @@ pub fn mcp_list(
     surface: &str,
     out: &mut impl Write,
 ) -> Result<()> {
-    let _ = (path, builtins, surface, out);
-    bail!("mcp_list not yet implemented")
+    let cfg = ClientMcpConfig::load(path);
+    let defined = cfg.list_defined_servers();
+    let enabled_names = cfg.surface_enabled_names(surface);
+    // A built-in is overridden when a same-named client-MCP server actually
+    // resolves for this surface (defined + enabled + surface-listed) — exactly
+    // the shadowing rule `McpHost::start_with` applies.
+    let overriding: Vec<&str> = cfg
+        .resolved_servers(surface)
+        .iter()
+        .map(|s| s.name.as_str())
+        .collect();
+
+    // Column width for the name column, sized to the longest name shown.
+    let name_w = defined
+        .iter()
+        .map(|s| s.name.len())
+        .chain(builtins.iter().map(|b| b.name.len()))
+        .max()
+        .unwrap_or(4)
+        .max(4);
+
+    writeln!(out, "Client-hosted MCP servers (surface: {surface})")?;
+    if defined.is_empty() {
+        writeln!(out, "  (none defined — add one with `config mcp add-server`)")?;
+    } else {
+        writeln!(out, "  {:name_w$}  {:<9}  COMMAND", "NAME", "STATUS")?;
+        for server in defined {
+            let status = if enabled_names.iter().any(|n| n == &server.name) {
+                "enabled"
+            } else {
+                "disabled"
+            };
+            let target = if server.command.is_empty() {
+                "(remote/http)".to_string()
+            } else if server.args.is_empty() {
+                server.command.clone()
+            } else {
+                format!("{} {}", server.command, server.args.join(" "))
+            };
+            writeln!(out, "  {:name_w$}  {status:<9}  {target}", server.name)?;
+        }
+    }
+
+    writeln!(out)?;
+    writeln!(out, "Built-in (in-process) servers")?;
+    if builtins.is_empty() {
+        writeln!(out, "  (none compiled in)")?;
+    } else {
+        writeln!(out, "  {:name_w$}  {:<5}  STATUS", "NAME", "TOOLS")?;
+        for builtin in builtins {
+            let status = if overriding.iter().any(|n| *n == builtin.name) {
+                format!("overridden by client-MCP '{}'", builtin.name)
+            } else {
+                "active".to_string()
+            };
+            writeln!(
+                out,
+                "  {:name_w$}  {:<5}  {status}",
+                builtin.name, builtin.tool_count
+            )?;
+        }
+    }
+
+    writeln!(out)?;
+    writeln!(
+        out,
+        "Note: daemon-hosted MCP servers are not shown here (client-side config only)."
+    )?;
+    writeln!(
+        out,
+        "      Manage those from the interactive `adele` F5 panel."
+    )?;
+    Ok(())
 }
 
 /// `config mcp add-server`: define (or replace) a stdio client-MCP server, and
@@ -92,15 +195,55 @@ pub fn mcp_add_server(
     enabled: bool,
     out: &mut impl Write,
 ) -> Result<()> {
-    let _ = (path, name, command, args, namespace, surfaces, enabled, out);
-    bail!("mcp_add_server not yet implemented")
+    let mut cfg = ClientMcpConfig::load(path);
+    let existed = cfg.list_defined_servers().iter().any(|s| s.name == name);
+
+    // The definition is always enabled at the definition level (the surface
+    // enable list is the on/off switch the `enable`/`disable` subcommands drive);
+    // `--enabled` decides whether it is turned on for the given surface(s) now.
+    let server = McpServerConfig {
+        name: name.to_string(),
+        command: command.to_string(),
+        args: args.to_vec(),
+        namespace: namespace.map(str::to_string),
+        enabled: true,
+        env: HashMap::new(),
+        env_secrets: HashMap::new(),
+        http: None,
+        description: None,
+    };
+    cfg.upsert_server(server);
+    if enabled {
+        for surface in surfaces {
+            cfg.set_surface_enabled(surface, name, true);
+        }
+    }
+    cfg.save(path).map_err(|e| anyhow!(e))?;
+
+    writeln!(
+        out,
+        "{} client-MCP server '{name}' (command: {command}).",
+        if existed { "Updated" } else { "Added" }
+    )?;
+    if enabled && !surfaces.is_empty() {
+        writeln!(out, "Enabled for surface(s): {}.", surfaces.join(", "))?;
+    } else {
+        writeln!(
+            out,
+            "Defined but not enabled for any surface; run `adele config mcp enable {name}` to turn it on."
+        )?;
+    }
+    Ok(())
 }
 
 /// `config mcp remove-server`: delete a client-MCP server definition (and prune
 /// it from every surface). Errors if no server by that name is defined.
 pub fn mcp_remove_server(path: &Path, name: &str, out: &mut impl Write) -> Result<()> {
-    let _ = (path, name, out);
-    bail!("mcp_remove_server not yet implemented")
+    let mut cfg = ClientMcpConfig::load(path);
+    cfg.remove_server(name).map_err(|e| anyhow!(e))?;
+    cfg.save(path).map_err(|e| anyhow!(e))?;
+    writeln!(out, "Removed client-MCP server '{name}'.")?;
+    Ok(())
 }
 
 /// `config mcp enable`/`disable`: flip a client-MCP server's membership in one
@@ -115,8 +258,30 @@ pub fn mcp_set_enabled(
     builtins: &[BuiltinInfo],
     out: &mut impl Write,
 ) -> Result<()> {
-    let _ = (path, name, surface, on, builtins, out);
-    bail!("mcp_set_enabled not yet implemented")
+    let mut cfg = ClientMcpConfig::load(path);
+    let is_defined = cfg.list_defined_servers().iter().any(|s| s.name == name);
+
+    if is_defined {
+        cfg.set_surface_enabled(surface, name, on);
+        cfg.save(path).map_err(|e| anyhow!(e))?;
+        writeln!(
+            out,
+            "{} client-MCP server '{name}' for surface '{surface}'.",
+            if on { "Enabled" } else { "Disabled" }
+        )?;
+    } else if builtins.iter().any(|b| b.name == name) {
+        // A name that matches only a built-in: toggling built-ins needs the
+        // built-in disabled-state (da#538 slice 4), which doesn't exist yet.
+        // Report it as a normal informational decline, not an error, and make no
+        // change rather than writing a dangling surface entry.
+        writeln!(
+            out,
+            "'{name}' is a built-in (in-process) server; enabling/disabling built-ins is not yet supported (coming with the panel toggle). No change made."
+        )?;
+    } else {
+        bail!("no such client-MCP server: '{name}'");
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 pub mod app;
 pub mod builtins;
 pub mod client_tools;
+pub mod config_cmd;
 pub mod connections;
 pub mod credentials;
 pub mod in_flight;

--- a/src/main.rs
+++ b/src/main.rs
@@ -67,9 +67,29 @@ enum CliTransportMode {
     Dbus,
 }
 
+/// The `adele` command line: global connection/verbosity options (flattened,
+/// parsed at the top level so they apply to the interactive TUI and the `exec`
+/// one-shot alike) plus an optional subcommand.
+///
+/// No subcommand -> the interactive TUI (unchanged). `exec <PROMPT>` -> a
+/// one-shot headless turn (the preferred replacement for the deprecated
+/// `--prompt` flag). `config …` -> scriptable, daemon-free management of the
+/// shared client-MCP config, the non-interactive twin of the `F5` panel.
 #[derive(Debug, Parser)]
 #[command(name = "adele")]
 struct CliArgs {
+    #[command(flatten)]
+    global: Global,
+    #[command(subcommand)]
+    command: Option<Command>,
+}
+
+/// Connection, credential, and verbosity options shared by the interactive and
+/// `exec` paths. Flattened into [`CliArgs`], so they are given before any
+/// subcommand (`adele --ws exec "hi"`) and read the same way whether or not a
+/// subcommand is present.
+#[derive(Debug, clap::Args)]
+struct Global {
     /// Transport used when neither --socket nor --ws is given. Defaults to
     /// the daemon's local Unix socket.
     #[arg(
@@ -99,10 +119,10 @@ struct CliArgs {
         default_value = DEFAULT_WS_SUBJECT
     )]
     ws_subject: String,
-    /// Send a single prompt non-interactively, print the reply to stdout, and
-    /// exit — no TUI. Client-hosted MCP tools (client-mcp.toml) still work, so
-    /// this can drive a local or remote (k8s) brain end to end.
-    #[arg(long, value_name = "TEXT")]
+    /// Deprecated: use the `exec <TEXT>` subcommand instead. Send a single
+    /// prompt non-interactively, print the reply to stdout, and exit — no TUI.
+    /// Kept as a hidden back-compat alias; `exec` is the preferred form.
+    #[arg(long, value_name = "TEXT", hide = true)]
     prompt: Option<String>,
     /// Bearer (JWT) for the WebSocket transport, skipping interactive login.
     #[arg(long = "ws-jwt", env = "DESKTOP_ASSISTANT_TUI_WS_JWT")]
@@ -115,16 +135,116 @@ struct CliArgs {
     #[arg(long = "ws-login-password", env = "DESKTOP_ASSISTANT_TUI_WS_PASSWORD")]
     ws_login_password: Option<String>,
     /// Enable verbose logging (`-v` info, `-vv` debug, `-vvv` trace). Logs go to
-    /// stderr so a headless `--prompt` run pipes cleanly to a file for scripting
+    /// stderr so a headless `exec` run pipes cleanly to a file for scripting
     /// and debugging. `RUST_LOG`, when set, overrides the level entirely.
     #[arg(short = 'v', long, action = clap::ArgAction::Count)]
     verbose: u8,
 }
 
-impl From<CliArgs> for ConnectionConfig {
-    fn from(cli: CliArgs) -> Self {
+/// Top-level subcommands. Absent -> the interactive TUI.
+#[derive(Debug, clap::Subcommand)]
+enum Command {
+    /// Send a single prompt non-interactively, print the reply, and exit — no
+    /// TUI. Client-hosted MCP tools (client-mcp.toml) still work, so this can
+    /// drive a local or remote (k8s) brain end to end. The preferred form of
+    /// the old `--prompt` flag.
+    #[command(alias = "prompt")]
+    Exec {
+        /// The prompt text to send.
+        prompt: String,
+    },
+    /// Scriptable, daemon-free management of the shared client-MCP config — the
+    /// non-interactive twin of the interactive `F5` panel.
+    Config(ConfigArgs),
+}
+
+/// `config` subcommand group.
+#[derive(Debug, clap::Args)]
+struct ConfigArgs {
+    #[command(subcommand)]
+    command: ConfigCommand,
+}
+
+/// `config <…>` operations.
+#[derive(Debug, clap::Subcommand)]
+enum ConfigCommand {
+    /// Print the client-MCP config file location.
+    Path,
+    /// Print the effective config (currently the client-MCP config).
+    Show {
+        /// Restrict to a section. Only `mcp` is supported today (the default).
+        #[arg(long)]
+        section: Option<String>,
+    },
+    /// Manage client-hosted MCP servers.
+    Mcp(McpArgs),
+}
+
+/// `config mcp` subcommand group.
+#[derive(Debug, clap::Args)]
+struct McpArgs {
+    #[command(subcommand)]
+    command: McpCommand,
+}
+
+/// `config mcp <…>` operations. These act on the client-side `client-mcp.toml`
+/// only; daemon-hosted MCP servers are out of scope for this non-interactive
+/// surface (manage those from the interactive `F5` panel).
+#[derive(Debug, clap::Subcommand)]
+enum McpCommand {
+    /// List client-MCP servers (for the tui surface) and the compiled-in
+    /// built-ins, with status.
+    List,
+    /// Define (or replace) a stdio client-MCP server.
+    AddServer {
+        /// Server name (also the default tool-namespace prefix).
+        name: String,
+        /// Command to spawn (stdio transport).
+        #[arg(long)]
+        command: String,
+        /// A launch argument; repeat the flag for multiple. Hyphen-leading
+        /// values are accepted (e.g. `--arg --root=/data`), since MCP server
+        /// arguments commonly start with `--`.
+        #[arg(long = "arg", value_name = "A", allow_hyphen_values = true)]
+        arg: Vec<String>,
+        /// Optional tool-namespace prefix.
+        #[arg(long)]
+        namespace: Option<String>,
+        /// Surface(s) to enable it for when --enabled is given (default: tui).
+        /// Repeat the flag for multiple.
+        #[arg(long)]
+        surface: Vec<String>,
+        /// Also enable the server for the given surface(s) now.
+        #[arg(long)]
+        enabled: bool,
+    },
+    /// Remove a client-MCP server definition.
+    RemoveServer {
+        /// Server name.
+        name: String,
+    },
+    /// Enable a client-MCP server for a surface.
+    Enable {
+        /// Server name.
+        name: String,
+        /// Surface to enable it for.
+        #[arg(long, default_value = "tui")]
+        surface: String,
+    },
+    /// Disable a client-MCP server for a surface.
+    Disable {
+        /// Server name.
+        name: String,
+        /// Surface to disable it for.
+        #[arg(long, default_value = "tui")]
+        surface: String,
+    },
+}
+
+impl From<Global> for ConnectionConfig {
+    fn from(global: Global) -> Self {
         let ws_url = {
-            let trimmed = cli.ws_url.trim();
+            let trimmed = global.ws_url.trim();
             if trimmed.is_empty() {
                 DEFAULT_WS_URL.to_string()
             } else {
@@ -133,7 +253,7 @@ impl From<CliArgs> for ConnectionConfig {
         };
 
         let ws_subject = {
-            let trimmed = cli.ws_subject.trim();
+            let trimmed = global.ws_subject.trim();
             if trimmed.is_empty() {
                 DEFAULT_WS_SUBJECT.to_string()
             } else {
@@ -144,16 +264,16 @@ impl From<CliArgs> for ConnectionConfig {
         // `--socket` and `--ws` are explicit selectors that override the
         // (always-defaulted) `--transport`. clap makes them mutually
         // exclusive, so at most one is `Some` here.
-        let (transport_mode, socket_path, ws_url) = if let Some(path) = cli.socket {
+        let (transport_mode, socket_path, ws_url) = if let Some(path) = global.socket {
             (TransportMode::Uds, path, ws_url)
-        } else if let Some(url) = cli.ws {
+        } else if let Some(url) = global.ws {
             let resolved = match url {
                 Some(u) if !u.trim().is_empty() => u.trim().to_string(),
                 _ => ws_url,
             };
             (TransportMode::Ws, None, resolved)
         } else {
-            let mode = match cli.transport {
+            let mode = match global.transport {
                 CliTransportMode::Local => TransportMode::Uds,
                 CliTransportMode::Ws => TransportMode::Ws,
                 CliTransportMode::Dbus => TransportMode::Dbus,
@@ -164,9 +284,9 @@ impl From<CliArgs> for ConnectionConfig {
         Self {
             transport_mode,
             ws_url,
-            ws_jwt: cli.ws_jwt,
-            ws_login_username: cli.ws_login_username,
-            ws_login_password: cli.ws_login_password,
+            ws_jwt: global.ws_jwt,
+            ws_login_username: global.ws_login_username,
+            ws_login_password: global.ws_login_password,
             ws_subject,
             socket_path,
             // Local UDS authenticates by kernel peer-cred (desktop-assistant#407):
@@ -174,6 +294,77 @@ impl From<CliArgs> for ConnectionConfig {
             ..Default::default()
         }
     }
+}
+
+/// Dispatch a `config` subcommand: pure, daemon-free config management that
+/// loads/mutates/saves the shared `client-mcp.toml` and prints to stdout. Runs
+/// before any TUI/terminal or daemon connection setup. Built-in server info
+/// (name + advertised tool count) is resolved from the compiled-in set so
+/// `mcp list`/`enable`/`disable` can report built-ins without a daemon.
+fn run_config(command: &ConfigCommand) -> Result<()> {
+    use adele::config_cmd as cc;
+
+    let path = default_client_mcp_path();
+    let mut out = io::stdout().lock();
+    match command {
+        ConfigCommand::Path => cc::config_path(&path, &mut out),
+        ConfigCommand::Show { section } => cc::config_show(&path, section.as_deref(), &mut out),
+        ConfigCommand::Mcp(mcp) => run_config_mcp(&path, &mcp.command, &mut out),
+    }
+}
+
+/// Dispatch a `config mcp` subcommand against the client-MCP config at `path`.
+fn run_config_mcp(
+    path: &std::path::Path,
+    command: &McpCommand,
+    out: &mut impl std::io::Write,
+) -> Result<()> {
+    use adele::config_cmd as cc;
+
+    match command {
+        McpCommand::List => cc::mcp_list(path, &builtin_infos(), cc::DEFAULT_SURFACE, out),
+        McpCommand::AddServer {
+            name,
+            command,
+            arg,
+            namespace,
+            surface,
+            enabled,
+        } => {
+            let surfaces = if surface.is_empty() {
+                vec![cc::DEFAULT_SURFACE.to_string()]
+            } else {
+                surface.clone()
+            };
+            cc::mcp_add_server(
+                path,
+                name,
+                command,
+                arg,
+                namespace.as_deref(),
+                &surfaces,
+                *enabled,
+                out,
+            )
+        }
+        McpCommand::RemoveServer { name } => cc::mcp_remove_server(path, name, out),
+        McpCommand::Enable { name, surface } => {
+            cc::mcp_set_enabled(path, name, surface, true, &builtin_infos(), out)
+        }
+        McpCommand::Disable { name, surface } => {
+            cc::mcp_set_enabled(path, name, surface, false, &builtin_infos(), out)
+        }
+    }
+}
+
+/// Resolve the compiled-in built-in MCP servers to the `(name, tool_count)`
+/// pairs the `config mcp` handlers render — the same set the interactive client
+/// hosts in-process. Empty when built-ins are compiled out.
+fn builtin_infos() -> Vec<adele::config_cmd::BuiltinInfo> {
+    adele::builtins::builtin_servers()
+        .iter()
+        .map(|s| adele::config_cmd::BuiltinInfo::new(s.name.clone(), s.service.tools().len()))
+        .collect()
 }
 
 /// Best-effort terminal restoration (TUI-1): undo everything `main`'s setup
@@ -261,12 +452,24 @@ async fn main() -> Result<()> {
 
     // Install logging first so connection/registration/streaming diagnostics are
     // captured for the headless path too (verbose or RUST_LOG; silent otherwise).
-    init_logging(cli.verbose);
+    init_logging(cli.global.verbose);
 
-    // Headless one-shot: `--prompt "…"` connects, prints the reply, and exits
-    // without ever entering the TUI. Runs before any terminal setup.
-    if let Some(prompt) = cli.prompt.clone() {
-        let config: ConnectionConfig = cli.into();
+    // `config …`: pure, daemon-free config management. Dispatch and return
+    // before any terminal setup or daemon connection.
+    if let Some(Command::Config(cfg)) = &cli.command {
+        return run_config(&cfg.command);
+    }
+
+    // Headless one-shot: `exec <PROMPT>` (preferred) or the deprecated
+    // `--prompt` flag connects, prints the reply, and exits without ever
+    // entering the TUI. Runs before any terminal setup.
+    let exec_prompt = match &cli.command {
+        Some(Command::Exec { prompt }) => Some(prompt.clone()),
+        // `config` already returned above; only `None` remains here.
+        _ => cli.global.prompt.clone(),
+    };
+    if let Some(prompt) = exec_prompt {
+        let config: ConnectionConfig = cli.global.into();
         return run_headless(&config, prompt).await;
     }
 
@@ -294,7 +497,7 @@ async fn main() -> Result<()> {
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
-    let result = run_app(&mut terminal, cli, cli_explicit).await;
+    let result = run_app(&mut terminal, cli.global, cli_explicit).await;
 
     // Restore terminal (same best-effort path the panic hook uses).
     restore_terminal();
@@ -463,17 +666,17 @@ enum RunOutcome {
 /// connection switch.
 async fn run_app(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
-    cli: CliArgs,
+    global: Global,
     cli_explicit: bool,
 ) -> Result<()> {
     // First connection: respect explicit CLI/env args; otherwise picker if
     // we have profiles, else fall back to CLI defaults.
     let mut config = if cli_explicit {
-        ConnectionConfig::from(cli)
+        ConnectionConfig::from(global)
     } else {
         let store = ProfileStore::load();
         if store.profiles.is_empty() {
-            ConnectionConfig::from(cli)
+            ConnectionConfig::from(global)
         } else {
             match picker::run(terminal, store).await?.0 {
                 PickerOutcome::Selected(profile) => profile.to_connection_config(),
@@ -2455,15 +2658,17 @@ mod tests {
         ]))
         .unwrap();
 
-        assert_eq!(parsed.transport, CliTransportMode::Dbus);
-        assert_eq!(parsed.ws_url, "wss://example/ws");
-        assert_eq!(parsed.ws_subject, "custom-client");
+        assert_eq!(parsed.global.transport, CliTransportMode::Dbus);
+        assert_eq!(parsed.global.ws_url, "wss://example/ws");
+        assert_eq!(parsed.global.ws_subject, "custom-client");
     }
 
     #[test]
     fn clap_default_with_no_flags_is_local_uds() {
         let cli = CliArgs::try_parse_from(args(&[])).unwrap();
-        let config = ConnectionConfig::from(cli);
+        // No subcommand => interactive TUI.
+        assert!(cli.command.is_none());
+        let config = ConnectionConfig::from(cli.global);
         // UDS is now the default connector.
         assert_eq!(config.transport_mode, TransportMode::Uds);
         assert_eq!(config.socket_path, None); // None => daemon default socket
@@ -2476,7 +2681,7 @@ mod tests {
     #[test]
     fn socket_flag_without_value_selects_uds_default_path() {
         let cli = CliArgs::try_parse_from(args(&["--socket"])).unwrap();
-        let config = ConnectionConfig::from(cli);
+        let config = ConnectionConfig::from(cli.global);
         assert_eq!(config.transport_mode, TransportMode::Uds);
         assert_eq!(config.socket_path, None);
     }
@@ -2484,7 +2689,7 @@ mod tests {
     #[test]
     fn socket_flag_with_path_sets_socket_path() {
         let cli = CliArgs::try_parse_from(args(&["--socket=/tmp/custom.sock"])).unwrap();
-        let config = ConnectionConfig::from(cli);
+        let config = ConnectionConfig::from(cli.global);
         assert_eq!(config.transport_mode, TransportMode::Uds);
         assert_eq!(config.socket_path, Some(PathBuf::from("/tmp/custom.sock")));
     }
@@ -2492,7 +2697,7 @@ mod tests {
     #[test]
     fn ws_flag_with_url_selects_websocket() {
         let cli = CliArgs::try_parse_from(args(&["--ws=wss://host/ws"])).unwrap();
-        let config = ConnectionConfig::from(cli);
+        let config = ConnectionConfig::from(cli.global);
         assert_eq!(config.transport_mode, TransportMode::Ws);
         assert_eq!(config.ws_url, "wss://host/ws");
         assert_eq!(config.socket_path, None);
@@ -2501,7 +2706,7 @@ mod tests {
     #[test]
     fn ws_flag_without_value_falls_back_to_default_ws_url() {
         let cli = CliArgs::try_parse_from(args(&["--ws"])).unwrap();
-        let config = ConnectionConfig::from(cli);
+        let config = ConnectionConfig::from(cli.global);
         assert_eq!(config.transport_mode, TransportMode::Ws);
         assert_eq!(config.ws_url, DEFAULT_WS_URL);
     }
@@ -2517,7 +2722,7 @@ mod tests {
     fn dbus_transport_still_selectable() {
         // No regression: --transport dbus continues to map to D-Bus.
         let cli = CliArgs::try_parse_from(args(&["--transport", "dbus"])).unwrap();
-        let config = ConnectionConfig::from(cli);
+        let config = ConnectionConfig::from(cli.global);
         assert_eq!(config.transport_mode, TransportMode::Dbus);
     }
 
@@ -2526,7 +2731,7 @@ mod tests {
         // No regression: the explicit ws transport + --ws-url path.
         let cli = CliArgs::try_parse_from(args(&["--transport", "ws", "--ws-url", "wss://h/ws"]))
             .unwrap();
-        let config = ConnectionConfig::from(cli);
+        let config = ConnectionConfig::from(cli.global);
         assert_eq!(config.transport_mode, TransportMode::Ws);
         assert_eq!(config.ws_url, "wss://h/ws");
     }
@@ -2538,6 +2743,145 @@ mod tests {
         let rendered = error.to_string();
         assert!(rendered.contains("ws"));
         assert!(rendered.contains("dbus"));
+    }
+
+    // --- Subcommand structure (adele-tui#122) ---
+
+    #[test]
+    fn bare_args_have_no_subcommand() {
+        // Back-compat: `adele` (with only global flags) still means the
+        // interactive TUI — no subcommand.
+        let cli = CliArgs::try_parse_from(args(&["--socket"])).unwrap();
+        assert!(cli.command.is_none(), "bare adele has no subcommand");
+    }
+
+    #[test]
+    fn exec_subcommand_parses_prompt() {
+        let cli = CliArgs::try_parse_from(args(&["exec", "hello there"])).unwrap();
+        match cli.command {
+            Some(Command::Exec { prompt }) => assert_eq!(prompt, "hello there"),
+            other => panic!("expected Exec, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn prompt_alias_maps_to_exec() {
+        // `prompt` is a subcommand alias of `exec`.
+        let cli = CliArgs::try_parse_from(args(&["prompt", "hi"])).unwrap();
+        assert!(matches!(cli.command, Some(Command::Exec { prompt }) if prompt == "hi"));
+    }
+
+    #[test]
+    fn legacy_prompt_flag_still_parses() {
+        // Back-compat: the deprecated `--prompt <TEXT>` global flag still parses
+        // (no subcommand) and carries the prompt for the headless path.
+        let cli = CliArgs::try_parse_from(args(&["--prompt", "legacy"])).unwrap();
+        assert!(cli.command.is_none());
+        assert_eq!(cli.global.prompt.as_deref(), Some("legacy"));
+    }
+
+    #[test]
+    fn exec_accepts_global_flags_before_it() {
+        // Globals are parsed at the top level, so they precede the subcommand.
+        let cli = CliArgs::try_parse_from(args(&["--ws=wss://h/ws", "exec", "hi"])).unwrap();
+        assert!(matches!(&cli.command, Some(Command::Exec { prompt }) if prompt == "hi"));
+        let config = ConnectionConfig::from(cli.global);
+        assert_eq!(config.transport_mode, TransportMode::Ws);
+    }
+
+    #[test]
+    fn config_mcp_list_parses() {
+        let cli = CliArgs::try_parse_from(args(&["config", "mcp", "list"])).unwrap();
+        assert!(matches!(
+            cli.command,
+            Some(Command::Config(ConfigArgs {
+                command: ConfigCommand::Mcp(McpArgs {
+                    command: McpCommand::List
+                })
+            }))
+        ));
+    }
+
+    #[test]
+    fn config_path_and_show_parse() {
+        let path = CliArgs::try_parse_from(args(&["config", "path"])).unwrap();
+        assert!(matches!(
+            path.command,
+            Some(Command::Config(ConfigArgs {
+                command: ConfigCommand::Path
+            }))
+        ));
+
+        let show = CliArgs::try_parse_from(args(&["config", "show", "--section", "mcp"])).unwrap();
+        match show.command {
+            Some(Command::Config(ConfigArgs {
+                command: ConfigCommand::Show { section },
+            })) => assert_eq!(section.as_deref(), Some("mcp")),
+            other => panic!("expected config show, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn config_mcp_add_server_parses_flags() {
+        let cli = CliArgs::try_parse_from(args(&[
+            "config",
+            "mcp",
+            "add-server",
+            "notes",
+            "--command",
+            "notes-mcp",
+            "--arg",
+            "serve",
+            "--arg",
+            "--root=/x",
+            "--namespace",
+            "nt",
+            "--surface",
+            "tui",
+            "--enabled",
+        ]))
+        .unwrap();
+        match cli.command {
+            Some(Command::Config(ConfigArgs {
+                command:
+                    ConfigCommand::Mcp(McpArgs {
+                        command:
+                            McpCommand::AddServer {
+                                name,
+                                command,
+                                arg,
+                                namespace,
+                                surface,
+                                enabled,
+                            },
+                    }),
+            })) => {
+                assert_eq!(name, "notes");
+                assert_eq!(command, "notes-mcp");
+                assert_eq!(arg, vec!["serve".to_string(), "--root=/x".to_string()]);
+                assert_eq!(namespace.as_deref(), Some("nt"));
+                assert_eq!(surface, vec!["tui".to_string()]);
+                assert!(enabled);
+            }
+            other => panic!("expected add-server, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn config_mcp_enable_defaults_surface_to_tui() {
+        let cli = CliArgs::try_parse_from(args(&["config", "mcp", "enable", "notes"])).unwrap();
+        match cli.command {
+            Some(Command::Config(ConfigArgs {
+                command:
+                    ConfigCommand::Mcp(McpArgs {
+                        command: McpCommand::Enable { name, surface },
+                    }),
+            })) => {
+                assert_eq!(name, "notes");
+                assert_eq!(surface, "tui", "surface defaults to tui");
+            }
+            other => panic!("expected enable, got {other:?}"),
+        }
     }
 
     // --- Panic hook (TUI-1) ---


### PR DESCRIPTION
Restructure the flat `adele` CLI into subcommands while keeping the bare interactive TUI and every existing flag working. This is the non-interactive twin of the `F5` MCP panel; the `config mcp` part complements da#538.

## Subcommand structure
```
adele [GLOBAL]                         # no subcommand -> interactive TUI (unchanged)
adele exec <PROMPT> [GLOBAL]           # one-shot headless (alias: prompt); replaces --prompt
adele config path                      # print the client-mcp.toml location
adele config show [--section mcp]      # print the effective config as TOML
adele config mcp list                  # client-mcp servers (tui surface) + built-ins, with status
adele config mcp add-server <NAME> --command <CMD> [--arg <A>]... [--namespace <NS>] [--surface <S>]... [--enabled]
adele config mcp remove-server <NAME>
adele config mcp enable  <NAME> [--surface tui]
adele config mcp disable <NAME> [--surface tui]
```
The connection/creds/verbose flags moved into a flattened `Global` struct shared by the interactive and `exec` paths; a top-level `Option<Command>` selects the subcommand.

## Back-compat
- Bare `adele` (with only global flags) still launches the interactive TUI.
- The old `--prompt <TEXT>` flag still works: it is kept as a hidden, deprecated global alias routing to the same headless path as `exec`. `exec <PROMPT>` (alias `prompt`) is the preferred form.
- All prior global flags and their env vars are unchanged.

## config mcp handlers reuse ClientMcpConfig
The `config` subcommands are pure and daemon-free: `main` dispatches them before any terminal/connection setup. Handlers live in a testable `src/config_cmd.rs` module, each taking an injected config path + output sink (so they unit-test against a tempfile + in-memory buffer). They reuse the existing `ClientMcpConfig` edit ops (`load`/`save`/`upsert_server`/`remove_server`/`set_surface_enabled`/`surface_enabled_names`/`resolved_servers`) — the same ops the `F5` panel uses. `enable`/`disable` target client-mcp servers (default surface `tui`).

## Built-in list is read-only (this first cut)
`config mcp list` also shows the compiled-in built-ins (name + `service.tools().len()`), marking any overridden by a same-named, surface-enabled client-mcp server (the exact `McpHost::start_with` shadowing rule). Enabling/disabling a **built-in** needs the built-in disabled-state (da#538 slice 4) which doesn't exist yet, so a name matching only a built-in is reported clearly ("not yet supported") rather than silently ignored. Daemon-hosted MCP servers are out of scope here (noted in the output).

## Tests (TDD)
Failing spec committed first, then the implementation. `src/config_cmd.rs` unit tests cover add->list, enable/disable toggle, remove (+ absent error), built-in override marking, the built-in-only decline, unknown-name error, and show/path. `src/main.rs` clap parse tests cover: bare args -> no subcommand; `exec hi`/`prompt hi` -> `Exec`; `config mcp {list,add-server,enable}` -> the right variants; legacy `--prompt hi` still parses; globals-before-subcommand.

## Gate (dev profile)
`cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` all green (439 + 28 lib/bin + 4 tests). The only lockfile change promotes the already-present `tempfile` crate to a direct dev-dependency (no new crate in the graph).

## Note / minor deviation
Global flags are parsed at the top level, so they precede the subcommand (git-style: `adele --ws exec "hi"`). `--arg` accepts hyphen-leading values (`--arg --root=/data`) since MCP server args commonly start with `--`. The README's global-options table was corrected in passing (transport default `local`, WS login env-var names, removed the non-existent `--dbus-service` row).

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)
