### PR TITLE
feat(mcp): wire built-in enable/disable toggle (da#538 slice 4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ chat, tool calls, and background tasks.
   each purpose (chat, background, vector).
 - **MCP servers admin panel** (`F5`) — list, enable/disable, add, edit, and
   remove the daemon's Model Context Protocol servers (local stdio or remote
-  HTTP, with bearer-token or OAuth service-account auth).
+  HTTP, with bearer-token or OAuth service-account auth), and enable/disable the
+  client's compiled-in **built-in** servers (per-surface; applies on restart).
 - **OAuth2 + PKCE** authentication flow and credentials stored in the system
   keyring (libsecret / kwallet via the OS).
 - **Knowledge base browser/editor** for the daemon's built-in KB.
@@ -115,11 +116,34 @@ adele config mcp disable <NAME> [--surface tui]
 ```
 
 `config mcp list` also shows the compiled-in **built-in** servers (with tool
-counts), marking any that a same-named, surface-enabled client-MCP server
-overrides. Built-in enable/disable is not yet supported from the CLI (it needs
-the panel's built-in toggle); that case is reported clearly rather than silently
-ignored. Daemon-hosted MCP servers are out of scope here — manage those from the
-interactive `F5` panel.
+counts) and their status: `disabled (config)` when you turned the built-in off
+for the surface, `overridden by client-MCP '<name>'` when a same-named,
+surface-enabled client-MCP server shadows it, else `active`.
+
+**Enabling/disabling a built-in** is per-surface (the TUI uses the `tui`
+surface):
+
+```sh
+adele config mcp disable web            # turn the built-in `web` off for tui
+adele config mcp enable  web            # turn it back on
+adele config mcp disable web --surface gtk   # another surface, independently
+```
+
+`disable` adds the built-in to that surface's `disabled_builtins` list; `enable`
+removes it. The change is written to `client-mcp.toml` and takes effect on the
+**next client launch** (the running in-process host is not restarted). A name
+that is *both* a defined client-MCP server and a built-in resolves to the
+server (the server shadows the built-in), so `enable`/`disable` toggles the
+server, not the built-in.
+
+You can do the same from the interactive **`F5` panel**: the cursor moves over
+the built-in rows too, and `Space`/`t` toggles the selected built-in. The panel
+writes the same per-surface config and shows a green "(applies on restart)"
+note; a disabled built-in renders dimmed with its reason. Edit/remove/sign-in in
+the panel remain daemon-server operations.
+
+Daemon-hosted MCP servers are out of scope for the `config` CLI — manage those
+from the interactive `F5` panel.
 
 ### Global options
 

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -68,8 +68,9 @@ pub fn builtin_servers() -> Vec<BuiltinServer> {
 /// Map the host's per-built-in [`BuiltinStatus`] into the view-model
 /// [`BuiltinServerDto`]s the shared MCP-servers panel renders via
 /// `client_ui_common::server_rows_with_builtins`. The `usize` `tool_count`
-/// widens to the DTO's `u32`; `overridden_by` carries straight through so an
-/// overridden built-in renders as a disabled row.
+/// widens to the DTO's `u32`; `overridden_by` and `disabled_by_config` carry
+/// straight through so a built-in that is overridden or explicitly turned off in
+/// this client's config renders as a disabled row (da#538 slice 4).
 pub fn builtin_dtos(status: Vec<BuiltinStatus>) -> Vec<BuiltinServerDto> {
     status
         .into_iter()
@@ -78,6 +79,7 @@ pub fn builtin_dtos(status: Vec<BuiltinStatus>) -> Vec<BuiltinServerDto> {
             namespace: s.namespace,
             tool_count: s.tool_count as u32,
             overridden_by: s.overridden_by,
+            disabled_by_config: s.disabled_by_config,
         })
         .collect()
 }
@@ -117,12 +119,14 @@ mod tests {
                 namespace: "fileio".into(),
                 tool_count: 7,
                 overridden_by: None,
+                disabled_by_config: false,
             },
             BuiltinStatus {
                 name: "web".into(),
                 namespace: "web".into(),
                 tool_count: 3,
                 overridden_by: Some("web".into()),
+                disabled_by_config: false,
             },
         ];
 
@@ -168,6 +172,41 @@ mod tests {
         assert!(
             reason.contains("web"),
             "reason names the overriding server: {reason}"
+        );
+    }
+
+    /// A built-in explicitly turned off in this client's config maps to a DTO
+    /// carrying `disabled_by_config`, which `server_rows_with_builtins` renders
+    /// as a disabled row whose reason names the config off-switch (and takes
+    /// precedence over any override reason). This is the F5 panel's display path
+    /// for a config-disabled built-in (da#538 slice 4).
+    #[test]
+    fn config_disabled_builtin_maps_to_disabled_row() {
+        let status = vec![BuiltinStatus {
+            name: "web".into(),
+            namespace: "web".into(),
+            tool_count: 3,
+            // Both flags set at once: config-disable must win the display.
+            overridden_by: Some("web".into()),
+            disabled_by_config: true,
+        }];
+
+        let dtos = builtin_dtos(status);
+        assert!(
+            dtos[0].disabled_by_config,
+            "the config-disabled flag carries into the DTO"
+        );
+
+        let rows = server_rows_with_builtins(&[], &[], &dtos);
+        let web = rows.iter().find(|r| r.name == "web").expect("web row");
+        assert_eq!(web.kind, ServerKind::BuiltIn);
+        let reason = web
+            .disabled_reason
+            .as_deref()
+            .expect("a config-disabled built-in renders disabled with a reason");
+        assert!(
+            reason.contains("config"),
+            "the config-disable reason wins the display: {reason}"
         );
     }
 }

--- a/src/config_cmd.rs
+++ b/src/config_cmd.rs
@@ -500,22 +500,119 @@ mod tests {
     }
 
     #[test]
-    fn enable_builtin_only_name_is_declined_not_errored() {
+    fn disable_builtin_persists_to_config() {
         let (_dir, path) = temp_cfg();
         let builtins = [BuiltinInfo::new("fileio", 7)];
-        // "fileio" exists only as a built-in (no client-MCP definition).
-        let msg = out_string(|o| mcp_set_enabled(&path, "fileio", "tui", true, &builtins, o));
+        // "fileio" exists only as a built-in (no client-MCP definition). `on =
+        // false` disables it, so it is added to the surface's disabled_builtins.
+        let msg = out_string(|o| mcp_set_enabled(&path, "fileio", "tui", false, &builtins, o));
         assert!(
-            msg.contains("built-in") && msg.contains("not yet supported"),
-            "toggling a built-in-only name is declined with a clear message: {msg}"
+            msg.contains("fileio") && msg.contains("disabled") && msg.contains("tui"),
+            "disabling a built-in confirms name + state + surface: {msg}"
         );
-        // Nothing was written to the surface list.
+        assert_eq!(
+            ClientMcpConfig::load(&path).surface_disabled_builtins("tui"),
+            &["fileio"],
+            "disable writes the built-in to the surface's disabled_builtins list"
+        );
+    }
+
+    #[test]
+    fn enable_builtin_removes_from_disabled() {
+        let (_dir, path) = temp_cfg();
+        let builtins = [BuiltinInfo::new("web", 3)];
+        // Disable, then re-enable: the built-in returns to its default-on state.
+        mcp_set_enabled(&path, "web", "tui", false, &builtins, &mut Vec::new()).expect("disable");
+        assert_eq!(
+            ClientMcpConfig::load(&path).surface_disabled_builtins("tui"),
+            &["web"]
+        );
+
+        let msg = out_string(|o| mcp_set_enabled(&path, "web", "tui", true, &builtins, o));
         assert!(
-            !ClientMcpConfig::load(&path)
-                .surface_enabled_names("tui")
-                .iter()
-                .any(|n| n == "fileio"),
-            "a declined built-in toggle does not mutate the config"
+            msg.contains("web") && msg.contains("enabled"),
+            "re-enabling a built-in confirms it: {msg}"
+        );
+        assert!(
+            ClientMcpConfig::load(&path)
+                .surface_disabled_builtins("tui")
+                .is_empty(),
+            "enable removes the built-in from the surface's disabled_builtins list"
+        );
+    }
+
+    #[test]
+    fn disable_builtin_is_per_surface() {
+        let (_dir, path) = temp_cfg();
+        let builtins = [BuiltinInfo::new("terminal", 4)];
+        mcp_set_enabled(&path, "terminal", "tui", false, &builtins, &mut Vec::new())
+            .expect("disable");
+        let cfg = ClientMcpConfig::load(&path);
+        assert_eq!(cfg.surface_disabled_builtins("tui"), &["terminal"]);
+        assert!(
+            cfg.surface_disabled_builtins("gtk").is_empty(),
+            "disabling a built-in for one surface leaves the others on"
+        );
+    }
+
+    #[test]
+    fn list_marks_builtin_disabled_by_config() {
+        let (_dir, path) = temp_cfg();
+        let builtins = [BuiltinInfo::new("web", 3), BuiltinInfo::new("fileio", 7)];
+        mcp_set_enabled(&path, "web", "tui", false, &builtins, &mut Vec::new()).expect("disable");
+
+        let listed = out_string(|o| mcp_list(&path, &builtins, "tui", o));
+        // The config-disabled built-in is marked as such.
+        let web_line = listed
+            .lines()
+            .find(|l| l.contains("web"))
+            .expect("web built-in listed");
+        assert!(
+            web_line.contains("disabled (config)"),
+            "a config-disabled built-in is marked in list: {web_line}"
+        );
+        // A built-in that was not disabled still lists as active.
+        let fileio_line = listed
+            .lines()
+            .find(|l| l.contains("fileio"))
+            .expect("fileio built-in listed");
+        assert!(
+            fileio_line.contains("active"),
+            "an untouched built-in stays active: {fileio_line}"
+        );
+    }
+
+    #[test]
+    fn defined_server_named_like_builtin_takes_server_path() {
+        // A name that is BOTH a defined client-MCP server AND a built-in must
+        // resolve to the server (surface enable list), never the built-in
+        // disabled_builtins path — the precedence the interactive host applies.
+        let (_dir, path) = temp_cfg();
+        mcp_add_server(
+            &path,
+            "fileio",
+            "my-fileio",
+            &[],
+            None,
+            &["tui".to_string()],
+            true,
+            &mut Vec::new(),
+        )
+        .expect("add");
+        let builtins = [BuiltinInfo::new("fileio", 7)];
+
+        mcp_set_enabled(&path, "fileio", "tui", false, &builtins, &mut Vec::new())
+            .expect("disable");
+        let cfg = ClientMcpConfig::load(&path);
+        // The server was disabled for the surface (server path)...
+        assert!(
+            !cfg.surface_enabled_names("tui").iter().any(|n| n == "fileio"),
+            "the defined server is the one toggled off"
+        );
+        // ...and the built-in disabled list was NOT touched.
+        assert!(
+            cfg.surface_disabled_builtins("tui").is_empty(),
+            "a name matching a defined server never writes disabled_builtins"
         );
     }
 

--- a/src/config_cmd.rs
+++ b/src/config_cmd.rs
@@ -99,8 +99,9 @@ pub fn config_show(path: &Path, section: Option<&str>, out: &mut impl Write) -> 
 
 /// `config mcp list`: list the client-MCP servers for `surface` (with their
 /// command + whether they're enabled for that surface), then the compiled-in
-/// built-ins (with tool counts, marking any overridden by a same-named,
-/// surface-enabled client-MCP server).
+/// built-ins (with tool counts). A built-in is marked `disabled (config)` when
+/// it is explicitly turned off for the surface, else `overridden ...` when a
+/// same-named, surface-enabled client-MCP server shadows it, else `active`.
 pub fn mcp_list(
     path: &Path,
     builtins: &[BuiltinInfo],
@@ -118,6 +119,10 @@ pub fn mcp_list(
         .iter()
         .map(|s| s.name.as_str())
         .collect();
+    // Built-ins the user explicitly turned off for this surface (da#538 slice 4).
+    // A config-disable is the explicit off-switch, so it takes display precedence
+    // over an override — mirroring `server_rows_with_builtins`.
+    let disabled_builtins = cfg.surface_disabled_builtins(surface);
 
     // Column width for the name column, sized to the longest name shown.
     let name_w = defined
@@ -160,7 +165,9 @@ pub fn mcp_list(
     } else {
         writeln!(out, "  {:name_w$}  {:<5}  STATUS", "NAME", "TOOLS")?;
         for builtin in builtins {
-            let status = if overriding.iter().any(|n| *n == builtin.name) {
+            let status = if disabled_builtins.iter().any(|n| n == &builtin.name) {
+                "disabled (config)".to_string()
+            } else if overriding.iter().any(|n| *n == builtin.name) {
                 format!("overridden by client-MCP '{}'", builtin.name)
             } else {
                 "active".to_string()
@@ -249,10 +256,18 @@ pub fn mcp_remove_server(path: &Path, name: &str, out: &mut impl Write) -> Resul
     Ok(())
 }
 
-/// `config mcp enable`/`disable`: flip a client-MCP server's membership in one
-/// surface's enable list. A name that matches only a built-in is reported as
-/// not-yet-supported (a normal informational outcome, not an error); a name that
-/// matches neither is an error.
+/// `config mcp enable`/`disable`: turn a server or built-in on/off for one
+/// surface.
+///
+/// Precedence mirrors the interactive host: a name that matches a **defined**
+/// client-MCP server toggles that server's per-surface enable list, even if a
+/// built-in of the same name also exists (the server shadows the built-in). A
+/// name that matches only a **built-in** toggles that built-in's per-surface
+/// `disabled_builtins` list (`on = false` disables it, `on = true` re-enables
+/// it) — da#538 slice 4. A name that matches neither is an error.
+///
+/// A built-in toggled here takes effect on the next client launch (the running
+/// in-process host is not restarted), matching the F5 panel's behavior.
 pub fn mcp_set_enabled(
     path: &Path,
     name: &str,
@@ -273,13 +288,15 @@ pub fn mcp_set_enabled(
             if on { "Enabled" } else { "Disabled" }
         )?;
     } else if builtins.iter().any(|b| b.name == name) {
-        // A name that matches only a built-in: toggling built-ins needs the
-        // built-in disabled-state (da#538 slice 4), which doesn't exist yet.
-        // Report it as a normal informational decline, not an error, and make no
-        // change rather than writing a dangling surface entry.
+        // A name that matches only a built-in: record its per-surface off state.
+        // `on = false` disables (adds to `disabled_builtins`); `on = true`
+        // re-enables (removes it). Both are idempotent and per-surface.
+        cfg.set_builtin_disabled(surface, name, !on);
+        cfg.save(path).map_err(|e| anyhow!(e))?;
         writeln!(
             out,
-            "'{name}' is a built-in (in-process) server; enabling/disabling built-ins is not yet supported (coming with the panel toggle). No change made."
+            "{} built-in '{name}' for surface '{surface}' (applies on next launch).",
+            if on { "Enabled" } else { "Disabled" }
         )?;
     } else {
         bail!("no such client-MCP server: '{name}'");
@@ -506,8 +523,9 @@ mod tests {
         // "fileio" exists only as a built-in (no client-MCP definition). `on =
         // false` disables it, so it is added to the surface's disabled_builtins.
         let msg = out_string(|o| mcp_set_enabled(&path, "fileio", "tui", false, &builtins, o));
+        let lower = msg.to_lowercase();
         assert!(
-            msg.contains("fileio") && msg.contains("disabled") && msg.contains("tui"),
+            lower.contains("fileio") && lower.contains("disabled") && lower.contains("tui"),
             "disabling a built-in confirms name + state + surface: {msg}"
         );
         assert_eq!(
@@ -529,8 +547,9 @@ mod tests {
         );
 
         let msg = out_string(|o| mcp_set_enabled(&path, "web", "tui", true, &builtins, o));
+        let lower = msg.to_lowercase();
         assert!(
-            msg.contains("web") && msg.contains("enabled"),
+            lower.contains("web") && lower.contains("enabled"),
             "re-enabling a built-in confirms it: {msg}"
         );
         assert!(

--- a/src/config_cmd.rs
+++ b/src/config_cmd.rs
@@ -625,7 +625,9 @@ mod tests {
         let cfg = ClientMcpConfig::load(&path);
         // The server was disabled for the surface (server path)...
         assert!(
-            !cfg.surface_enabled_names("tui").iter().any(|n| n == "fileio"),
+            !cfg.surface_enabled_names("tui")
+                .iter()
+                .any(|n| n == "fileio"),
             "the defined server is the one toggled off"
         );
         // ...and the built-in disabled list was NOT touched.

--- a/src/main.rs
+++ b/src/main.rs
@@ -520,20 +520,31 @@ async fn run_headless(config: &ConnectionConfig, prompt: String) -> Result<()> {
 
     // Start the client-side MCP host for the `tui` surface and advertise its
     // tools (merged with the built-ins) so a headless prompt can trigger local
-    // tools exactly like the interactive client.
-    let servers: Vec<_> = ClientMcpConfig::load(&default_client_mcp_path())
+    // tools exactly like the interactive client. Keep the loaded config in scope
+    // so its per-surface disabled-built-in list can be consulted below.
+    let mcp_cfg = ClientMcpConfig::load(&default_client_mcp_path());
+    let servers: Vec<_> = mcp_cfg
         .resolved_servers("tui")
         .into_iter()
         .cloned()
         .collect();
     // Compiled-in built-ins (da#538 Phase C/D): host the full core MCP set
-    // in-process. `McpHost::start_with` centralizes the override, skipping (and
-    // logging) any built-in whose name a client-mcp.toml server already provides.
+    // in-process. `McpHost::start_with_disabled` centralizes the override,
+    // skipping (and logging) any built-in whose name a client-mcp.toml server
+    // already provides, plus any the user disabled for the `tui` surface in
+    // client config (da#538 slice 4).
     let mcp_builtins = adele::builtins::builtin_servers();
     let host = if servers.is_empty() && mcp_builtins.is_empty() {
         None
     } else {
-        Some(McpHost::start_with(&servers, mcp_builtins).await)
+        Some(
+            McpHost::start_with_disabled(
+                &servers,
+                mcp_builtins,
+                mcp_cfg.surface_disabled_builtins("tui"),
+            )
+            .await,
+        )
     };
     let host_tools = host.as_ref().map(|h| h.registrations()).unwrap_or_default();
     let builtins = vec![
@@ -722,13 +733,20 @@ async fn run(
         .cloned()
         .collect();
     // Compiled-in built-ins (da#538 Phase C/D): host the full core MCP set
-    // in-process. `McpHost::start_with` centralizes the override, skipping (and
-    // logging) any built-in whose name a configured client-mcp server already
-    // provides, and reports each built-in's status for the F5 panel.
+    // in-process. `McpHost::start_with_disabled` centralizes the override,
+    // skipping (and logging) any built-in whose name a configured client-mcp
+    // server already provides, plus any the user turned off for the `tui` surface
+    // in client config (da#538 slice 4); it reports each built-in's status
+    // (including `disabled_by_config`) for the F5 panel.
     let mcp_builtins = adele::builtins::builtin_servers();
     if !mcp_servers.is_empty() || !mcp_builtins.is_empty() {
         app.mcp_host = Some(Rc::new(
-            McpHost::start_with(&mcp_servers, mcp_builtins).await,
+            McpHost::start_with_disabled(
+                &mcp_servers,
+                mcp_builtins,
+                mcp_cfg.surface_disabled_builtins("tui"),
+            )
+            .await,
         ));
     }
 

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -32,13 +32,14 @@
 //! Keys
 //! ----
 //!
-//! List mode:
+//! List mode (the cursor spans the daemon servers then the built-ins):
 //! - `j`/`k` or arrows: navigate
-//! - `Enter` / `e`: edit selected
+//! - `Enter` / `e`: edit selected (daemon servers only)
 //! - `a`: add new
-//! - `Space` / `t`: enable/disable selected
+//! - `Space` / `t`: enable/disable selected — a daemon server via the daemon; a
+//!   built-in via this client's config (`disabled_builtins`), applied on restart
 //! - `c`: show the sign-in command for a server that needs OAuth sign-in
-//! - `d`: remove selected (with confirm)
+//! - `d`: remove selected (with confirm; daemon servers only)
 //! - `r`: refresh from daemon
 //! - `Esc` / `q`: close
 //!
@@ -55,12 +56,14 @@
 
 use std::collections::BTreeMap;
 use std::io;
+use std::path::PathBuf;
 
 use client_ui_common::{BuiltinServerDto, ServerRow, kind_label, server_rows_with_builtins};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use desktop_assistant_api_model::{
     Command, CommandResult, McpServerView, Secret, ServiceAccountView,
 };
+use desktop_assistant_client_common::mcp_host::{ClientMcpConfig, default_client_mcp_path};
 use desktop_assistant_client_common::{SignalEvent, TransportClient};
 use ratatui::{
     Frame, Terminal,
@@ -540,6 +543,49 @@ fn wrap_index(i: i32, len: usize) -> usize {
     (((i % len) + len) % len) as usize
 }
 
+/// The client surface this panel manages. The TUI hosts its client-MCP servers
+/// and built-ins under `"tui"`, so a built-in toggled here is written to that
+/// surface's `disabled_builtins` list (da#538 slice 4).
+const SURFACE: &str = "tui";
+
+/// What the list cursor currently points at. The panel's selectable rows are the
+/// daemon-managed servers followed by the in-process built-ins, so one flat
+/// cursor (`State::selected`) spans both sections; this names which side (and
+/// index) a given cursor position resolves to. Built-in rows were read-only
+/// before slice 4 — making them selectable is what enables the in-panel toggle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Sel {
+    /// The daemon server at this index into `State::servers`.
+    Daemon(usize),
+    /// The built-in at this index into `State::builtin_dtos`.
+    Builtin(usize),
+}
+
+/// The selectable targets in display order: every daemon server, then every
+/// built-in. Pure over the two counts so the cursor mapping is unit-testable
+/// without a terminal.
+fn selectable(servers: usize, builtins: usize) -> Vec<Sel> {
+    (0..servers)
+        .map(Sel::Daemon)
+        .chain((0..builtins).map(Sel::Builtin))
+        .collect()
+}
+
+/// The flat [`ListItem`] index a selectable target renders at, so the list
+/// highlight lands on the right row. The item layout is: the daemon rows (or a
+/// single placeholder item when there are none), then — when any built-ins are
+/// shown — one separator header, then the built-in rows. Kept pure (over the
+/// daemon-server count) so the highlight math is unit-testable.
+fn highlight_index(servers_len: usize, sel: Sel) -> usize {
+    // An empty daemon list still occupies one item (the "(no MCP servers)" hint).
+    let daemon_items = servers_len.max(1);
+    match sel {
+        Sel::Daemon(i) => i,
+        // +1 for the "── Built-in (in-process) ──" separator header.
+        Sel::Builtin(i) => daemon_items + 1 + i,
+    }
+}
+
 // ===========================================================================
 // TUI screen (mirrors `crate::connections`)
 // ===========================================================================
@@ -769,22 +815,38 @@ enum RpcOutcome {
 
 struct State {
     servers: Vec<McpServerView>,
-    /// Built-in (in-process) MCP servers, resolved once at open from the client's
-    /// `McpHost::builtin_status()` (da#538 Phase D). Rendered as a read-only
-    /// section below the daemon servers: they are hosted inside this client, not
-    /// managed by the daemon, so they are informational and not selectable /
-    /// editable. An overridden built-in carries a `disabled_reason` and renders
-    /// disabled. Empty when built-ins are compiled out or no host is running.
-    builtins: Vec<ServerRow>,
+    /// Built-in (in-process) MCP servers, resolved at open from the client's
+    /// `McpHost::builtin_status()` (da#538 Phase D) and kept as the source of
+    /// truth so an in-panel toggle can flip a built-in's `disabled_by_config`
+    /// and re-derive its row (slice 4). Rendered as a section below the daemon
+    /// servers; an overridden or config-disabled built-in renders disabled.
+    /// Empty when built-ins are compiled out or no host is running.
+    builtin_dtos: Vec<BuiltinServerDto>,
     /// OAuth service accounts (for the editor picker). Best-effort — a failure
     /// to list them leaves the picker empty rather than blocking the panel.
     accounts: Vec<ServiceAccountView>,
+    /// Flat cursor over the selectable rows ([`selectable`]): daemon servers
+    /// first, then built-ins.
     selected: usize,
     mode: Mode,
     form: FormState,
     error: Option<String>,
     busy: Option<String>,
+    /// A transient success/info line (e.g. after a built-in toggle), shown in the
+    /// status area when nothing is busy or errored.
+    notice: Option<String>,
+    /// The client-MCP config file a built-in toggle persists to. Injected so the
+    /// toggle path is testable against a tempfile.
+    config_path: PathBuf,
     closing: bool,
+}
+
+/// The selectable target the flat cursor currently points at, if any. `None`
+/// when there is nothing selectable (no daemon servers and no built-ins).
+fn current_sel(state: &State) -> Option<Sel> {
+    selectable(state.servers.len(), state.builtin_dtos.len())
+        .get(state.selected)
+        .copied()
 }
 
 /// The MCP-servers manager as a [`Screen`]: its [`State`] plus the borrowed
@@ -850,13 +912,15 @@ pub async fn run(
     let mut screen = McpScreen {
         state: State {
             servers: Vec::new(),
-            builtins: server_rows_with_builtins(&[], &[], builtins),
+            builtin_dtos: builtins.to_vec(),
             accounts: Vec::new(),
             selected: 0,
             mode: Mode::List,
             form: FormState::blank(),
             error: None,
             busy: Some("Loading MCP servers...".into()),
+            notice: None,
+            config_path: default_client_mcp_path(),
             closing: false,
         },
         client,
@@ -880,23 +944,33 @@ fn handle_list_key<'a>(
         (KeyCode::Esc | KeyCode::Char('q'), m) if m.is_empty() => state.closing = true,
         (KeyCode::Char('j') | KeyCode::Down, m) if m.is_empty() => advance_selection(state, 1),
         (KeyCode::Char('k') | KeyCode::Up, m) if m.is_empty() => advance_selection(state, -1),
+        // Edit is a daemon-server operation; built-ins aren't daemon-managed.
         (KeyCode::Enter | KeyCode::Char('e'), m) if m.is_empty() => {
-            if let Some(view) = state.servers.get(state.selected).cloned() {
+            if let Some(Sel::Daemon(i)) = current_sel(state)
+                && let Some(view) = state.servers.get(i).cloned()
+            {
+                state.notice = None;
                 state.form = FormState::from_pure(McpForm::from_view(&view));
                 state.error = None;
                 state.mode = Mode::Edit;
             }
         }
         (KeyCode::Char('a'), m) if m.is_empty() => {
+            state.notice = None;
             state.form = FormState::blank();
             state.error = None;
             state.mode = Mode::Edit;
         }
+        // Space/t toggles whatever is selected: a daemon server via the daemon,
+        // a built-in via the client's own config (slice 4).
         (KeyCode::Char(' ') | KeyCode::Char('t'), m) if m.is_empty() => {
-            do_toggle(state, pending, client)
+            toggle_selected(state, pending, client)
         }
         (KeyCode::Char('c'), m) if m.is_empty() => show_signin(state),
-        (KeyCode::Char('d'), m) if m.is_empty() && state.servers.get(state.selected).is_some() => {
+        // Remove is a daemon-server operation only.
+        (KeyCode::Char('d'), m)
+            if m.is_empty() && matches!(current_sel(state), Some(Sel::Daemon(_))) =>
+        {
             state.mode = Mode::RemoveConfirm;
         }
         (KeyCode::Char('r'), m) if m.is_empty() => refresh_all(state, pending, client),
@@ -998,8 +1072,12 @@ fn handle_remove_key<'a>(
 
 /// Show the OAuth sign-in command for the selected server (honest degradation):
 /// the TUI can't spawn the daemon-host browser, so it prints the command to run.
+/// Sign-in is a daemon-server concept; a selected built-in has none.
 fn show_signin(state: &mut State) {
-    let Some(server) = state.servers.get(state.selected) else {
+    let Some(Sel::Daemon(i)) = current_sel(state) else {
+        return;
+    };
+    let Some(server) = state.servers.get(i) else {
         return;
     };
     if server.configure_command.is_empty() {
@@ -1010,8 +1088,9 @@ fn show_signin(state: &mut State) {
     state.mode = Mode::SignInInfo;
 }
 
+/// Move the flat cursor across the combined daemon + built-in row list, wrapping.
 fn advance_selection(state: &mut State, delta: i32) {
-    let len = state.servers.len();
+    let len = state.servers.len() + state.builtin_dtos.len();
     if len == 0 {
         return;
     }
@@ -1083,16 +1162,32 @@ fn save_edit<'a>(
     });
 }
 
-fn do_toggle<'a>(
+/// Toggle whatever the cursor is on: a daemon server flips via the daemon
+/// (`SetMcpServerEnabled`), a built-in flips its per-surface config off-switch.
+fn toggle_selected<'a>(
     state: &mut State,
     pending: &mut InFlight<'a, RpcOutcome>,
     client: &'a TransportClient,
 ) {
-    let Some(server) = state.servers.get(state.selected) else {
+    match current_sel(state) {
+        Some(Sel::Daemon(i)) => do_toggle(state, pending, client, i),
+        Some(Sel::Builtin(i)) => toggle_builtin(state, i),
+        None => {}
+    }
+}
+
+fn do_toggle<'a>(
+    state: &mut State,
+    pending: &mut InFlight<'a, RpcOutcome>,
+    client: &'a TransportClient,
+    index: usize,
+) {
+    let Some(server) = state.servers.get(index) else {
         return;
     };
     let name = server.name.clone();
     let enabled = server.enabled;
+    state.notice = None;
     state.busy = Some(
         if enabled {
             "Disabling..."
@@ -1117,12 +1212,49 @@ fn do_toggle<'a>(
     });
 }
 
+/// Toggle a built-in's per-surface off state (da#538 slice 4). Unlike a daemon
+/// server this is a client-side config write, not an RPC: load the shared
+/// client-MCP config, flip `disabled_builtins` for `SURFACE`, persist, and flip
+/// the DTO so the row re-derives (disabled <-> active) on the next draw. The
+/// running in-process host is not restarted, so the change takes effect on the
+/// next client launch — surfaced in the confirmation note. Loading fresh (rather
+/// than trusting an in-memory copy) means a concurrent CLI edit isn't clobbered.
+fn toggle_builtin(state: &mut State, index: usize) {
+    let Some(dto) = state.builtin_dtos.get(index) else {
+        return;
+    };
+    let name = dto.name.clone();
+    let new_disabled = !dto.disabled_by_config;
+
+    let mut cfg = ClientMcpConfig::load(&state.config_path);
+    cfg.set_builtin_disabled(SURFACE, &name, new_disabled);
+    match cfg.save(&state.config_path) {
+        Ok(()) => {
+            state.builtin_dtos[index].disabled_by_config = new_disabled;
+            state.error = None;
+            state.busy = None;
+            state.notice = Some(format!(
+                "Built-in '{name}' {} for '{SURFACE}' (applies on restart)",
+                if new_disabled { "disabled" } else { "enabled" }
+            ));
+        }
+        Err(e) => {
+            state.notice = None;
+            state.error = Some(format!("Failed to save config: {e}"));
+        }
+    }
+}
+
 fn do_remove<'a>(
     state: &mut State,
     pending: &mut InFlight<'a, RpcOutcome>,
     client: &'a TransportClient,
 ) {
-    let Some(server) = state.servers.get(state.selected) else {
+    let server = match current_sel(state) {
+        Some(Sel::Daemon(i)) => state.servers.get(i),
+        _ => None,
+    };
+    let Some(server) = server else {
         state.mode = Mode::List;
         return;
     };
@@ -1151,8 +1283,11 @@ fn apply_outcome<'a>(
             match servers {
                 Ok(list) => {
                     state.servers = list;
-                    if state.selected >= state.servers.len() {
-                        state.selected = state.servers.len().saturating_sub(1);
+                    // Clamp the flat cursor to the combined daemon + built-in row
+                    // count so a shrunk server list can't strand it out of range.
+                    let selectable_len = state.servers.len() + state.builtin_dtos.len();
+                    if state.selected >= selectable_len {
+                        state.selected = selectable_len.saturating_sub(1);
                     }
                     state.error = None;
                 }
@@ -1261,17 +1396,19 @@ fn draw_list(f: &mut Frame, state: &State, area: Rect) {
         state.servers.iter().map(server_item).collect()
     };
 
-    // Built-in (in-process) servers render below the daemon list as a read-only
-    // section: they are hosted inside this client, so they are informational and
-    // never selectable / editable (selection stays bounded to `state.servers`).
-    if !state.builtins.is_empty() {
+    // Built-in (in-process) servers render below the daemon list, derived from
+    // the DTO source of truth so a toggle re-derives the row (active <-> disabled)
+    // on the next draw. They are selectable (for the built-in toggle) but not
+    // daemon-editable — edit/remove/sign-in stay daemon-only (slice 4).
+    let builtin_rows = server_rows_with_builtins(&[], &[], &state.builtin_dtos);
+    if !builtin_rows.is_empty() {
         items.push(ListItem::new(Line::from(Span::styled(
             "── Built-in (in-process) ──",
             Style::default()
                 .fg(theme().text_dim)
                 .add_modifier(Modifier::DIM),
         ))));
-        items.extend(state.builtins.iter().map(builtin_item));
+        items.extend(builtin_rows.iter().map(builtin_item));
     }
 
     let title = if state.servers.is_empty() {
@@ -1301,8 +1438,8 @@ fn draw_list(f: &mut Frame, state: &State, area: Rect) {
         .highlight_symbol("▸ ");
 
     let mut list_state = ListState::default();
-    if !state.servers.is_empty() {
-        list_state.select(Some(state.selected));
+    if let Some(sel) = current_sel(state) {
+        list_state.select(Some(highlight_index(state.servers.len(), sel)));
     }
     f.render_stateful_widget(list, area, &mut list_state);
 }
@@ -1676,11 +1813,12 @@ fn draw_account_line(f: &mut Frame, area: Rect, state: &State, focused: bool) {
 }
 
 fn draw_remove_overlay(f: &mut Frame, state: &State, area: Rect) {
-    let label = state
-        .servers
-        .get(state.selected)
-        .map(|s| sanitize(&s.name))
-        .unwrap_or_else(|| "this server".to_string());
+    let label = match current_sel(state) {
+        Some(Sel::Daemon(i)) => state.servers.get(i),
+        _ => None,
+    }
+    .map(|s| sanitize(&s.name))
+    .unwrap_or_else(|| "this server".to_string());
     let popup = centered_rect(64, 6, area);
     f.render_widget(Clear, popup);
     let block = Block::default()
@@ -1711,7 +1849,11 @@ fn draw_remove_overlay(f: &mut Frame, state: &State, area: Rect) {
 /// The read-only OAuth sign-in overlay: prints the exact command to run on the
 /// daemon host (honest degradation — the TUI can't spawn a remote browser).
 fn draw_signin_overlay(f: &mut Frame, state: &State, area: Rect) {
-    let Some(server) = state.servers.get(state.selected) else {
+    let server = match current_sel(state) {
+        Some(Sel::Daemon(i)) => state.servers.get(i),
+        _ => None,
+    };
+    let Some(server) = server else {
         return;
     };
     let command = server
@@ -1782,6 +1924,15 @@ fn draw_status(f: &mut Frame, state: &State, area: Rect) {
         // is sanitized like every other daemon string on the draw path.
         f.render_widget(
             Paragraph::new(Span::styled(format!(" • {}", sanitize(err)), style)),
+            area,
+        );
+    } else if let Some(notice) = &state.notice {
+        // A transient success/info line (e.g. a built-in toggle's "applies on
+        // restart" confirmation). Sanitized: it interpolates a config-sourced
+        // built-in name.
+        let style = Style::default().fg(theme().ok);
+        f.render_widget(
+            Paragraph::new(Span::styled(format!(" ✓ {}", sanitize(notice)), style)),
             area,
         );
     }
@@ -2331,14 +2482,34 @@ mod tests {
     fn state_with(servers: Vec<McpServerView>, accounts: Vec<ServiceAccountView>) -> State {
         State {
             servers,
-            builtins: Vec::new(),
+            builtin_dtos: Vec::new(),
             accounts,
             selected: 0,
             mode: Mode::List,
             form: FormState::blank(),
             error: None,
             busy: None,
+            notice: None,
+            config_path: PathBuf::from("/nonexistent/client-mcp.toml"),
             closing: false,
+        }
+    }
+
+    /// A [`BuiltinServerDto`] for the panel's built-in section. `overridden` names
+    /// an external server that shadows it (else active); `disabled_by_config`
+    /// marks it explicitly turned off in this client's config.
+    fn builtin_dto(
+        name: &str,
+        tool_count: u32,
+        overridden: Option<&str>,
+        disabled_by_config: bool,
+    ) -> BuiltinServerDto {
+        BuiltinServerDto {
+            name: name.into(),
+            namespace: name.into(),
+            tool_count,
+            overridden_by: overridden.map(Into::into),
+            disabled_by_config,
         }
     }
 
@@ -2413,9 +2584,9 @@ mod tests {
     #[test]
     fn draw_list_renders_builtin_section_with_override_reason() {
         let mut state = state_with(Vec::new(), Vec::new());
-        state.builtins = vec![
-            builtin_row("fileio", 7, None),
-            builtin_row("web", 3, Some("overridden by the external \"web\"")),
+        state.builtin_dtos = vec![
+            builtin_dto("fileio", 7, None, false),
+            builtin_dto("web", 3, Some("web"), false),
         ];
         let text = rendered(&state, 120, 20);
         assert!(
@@ -2430,6 +2601,154 @@ mod tests {
         assert!(
             text.contains("overridden"),
             "override reason missing: {text}"
+        );
+    }
+
+    #[test]
+    fn draw_list_renders_config_disabled_builtin_dimmed_with_reason() {
+        // A built-in turned off in this client's config renders in the built-in
+        // section as a disabled row whose reason names the config off-switch
+        // (da#538 slice 4) — the F5 panel's display path for a disabled built-in.
+        let mut state = state_with(Vec::new(), Vec::new());
+        state.builtin_dtos = vec![builtin_dto("web", 3, None, true)];
+        let text = rendered(&state, 120, 20);
+        assert!(text.contains("web"), "config-disabled built-in row missing");
+        assert!(
+            text.contains("config"),
+            "config-disable reason missing: {text}"
+        );
+    }
+
+    // --- selection model spanning daemon + built-in rows (slice 4) -----------
+
+    #[test]
+    fn selectable_lists_daemon_then_builtins() {
+        assert_eq!(
+            selectable(2, 3),
+            vec![
+                Sel::Daemon(0),
+                Sel::Daemon(1),
+                Sel::Builtin(0),
+                Sel::Builtin(1),
+                Sel::Builtin(2),
+            ]
+        );
+    }
+
+    #[test]
+    fn selectable_empty_when_no_rows() {
+        assert!(selectable(0, 0).is_empty());
+    }
+
+    #[test]
+    fn highlight_index_daemon_is_the_row_index() {
+        assert_eq!(highlight_index(3, Sel::Daemon(0)), 0);
+        assert_eq!(highlight_index(3, Sel::Daemon(2)), 2);
+    }
+
+    #[test]
+    fn highlight_index_builtin_skips_the_separator_header() {
+        // 3 daemon rows, then a separator, then built-ins: first built-in is #4.
+        assert_eq!(highlight_index(3, Sel::Builtin(0)), 4);
+        assert_eq!(highlight_index(3, Sel::Builtin(2)), 6);
+        // No daemon servers: the "(no MCP servers)" placeholder holds slot 0 and
+        // the separator slot 1, so the first built-in is #2.
+        assert_eq!(highlight_index(0, Sel::Builtin(0)), 2);
+    }
+
+    #[test]
+    fn current_sel_spans_daemon_then_builtins() {
+        let mut state = state_with(vec![view_named("alpha")], Vec::new());
+        state.builtin_dtos = vec![
+            builtin_dto("fileio", 7, None, false),
+            builtin_dto("web", 3, None, false),
+        ];
+        state.selected = 0;
+        assert_eq!(current_sel(&state), Some(Sel::Daemon(0)));
+        state.selected = 1;
+        assert_eq!(current_sel(&state), Some(Sel::Builtin(0)));
+        state.selected = 2;
+        assert_eq!(current_sel(&state), Some(Sel::Builtin(1)));
+        // Past the end resolves to nothing rather than panicking.
+        state.selected = 3;
+        assert_eq!(current_sel(&state), None);
+    }
+
+    #[test]
+    fn advance_selection_wraps_across_both_sections() {
+        let mut state = state_with(vec![view_named("alpha")], Vec::new());
+        state.builtin_dtos = vec![builtin_dto("web", 3, None, false)];
+        // Two selectable rows: daemon "alpha" then built-in "web".
+        assert_eq!(state.selected, 0);
+        advance_selection(&mut state, 1);
+        assert_eq!(current_sel(&state), Some(Sel::Builtin(0)));
+        advance_selection(&mut state, 1);
+        assert_eq!(
+            current_sel(&state),
+            Some(Sel::Daemon(0)),
+            "wraps back to top"
+        );
+        advance_selection(&mut state, -1);
+        assert_eq!(current_sel(&state), Some(Sel::Builtin(0)), "wraps backward");
+    }
+
+    // --- interactive built-in toggle persists to client config (slice 4) -----
+
+    #[test]
+    fn toggle_builtin_disables_persisting_and_flips_dto() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("client-mcp.toml");
+        let mut state = state_with(Vec::new(), Vec::new());
+        state.config_path = path.clone();
+        state.builtin_dtos = vec![builtin_dto("web", 3, None, false)];
+
+        toggle_builtin(&mut state, 0);
+
+        // Persisted to the tui surface's disabled_builtins.
+        assert_eq!(
+            ClientMcpConfig::load(&path).surface_disabled_builtins("tui"),
+            &["web"],
+            "toggle writes the built-in to the surface disabled list"
+        );
+        // The in-memory DTO flipped so the row re-derives disabled.
+        assert!(state.builtin_dtos[0].disabled_by_config);
+        // The confirmation note names the built-in and the restart caveat.
+        let notice = state.notice.as_deref().expect("a toggle sets a notice");
+        assert!(
+            notice.contains("web") && notice.contains("disabled") && notice.contains("restart"),
+            "notice explains the toggle + restart caveat: {notice}"
+        );
+        assert!(state.error.is_none(), "a successful toggle sets no error");
+    }
+
+    #[test]
+    fn toggle_builtin_reenable_removes_from_config() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("client-mcp.toml");
+        let mut state = state_with(Vec::new(), Vec::new());
+        state.config_path = path.clone();
+        // Start disabled, then toggle back on.
+        state.builtin_dtos = vec![builtin_dto("web", 3, None, true)];
+        // Seed the config so the re-enable has something to remove.
+        {
+            let mut cfg = ClientMcpConfig::load(&path);
+            cfg.set_builtin_disabled("tui", "web", true);
+            cfg.save(&path).expect("seed save");
+        }
+
+        toggle_builtin(&mut state, 0);
+
+        assert!(
+            ClientMcpConfig::load(&path)
+                .surface_disabled_builtins("tui")
+                .is_empty(),
+            "re-enabling removes the built-in from the disabled list"
+        );
+        assert!(!state.builtin_dtos[0].disabled_by_config);
+        let notice = state.notice.as_deref().expect("notice set");
+        assert!(
+            notice.contains("enabled"),
+            "notice reports re-enable: {notice}"
         );
     }
 


### PR DESCRIPTION
## Summary

Wires the built-in enable/disable toggle (da#538 slice 4) into adele-tui,
consuming the shared-crate halves (`ClientMcpConfig::set_builtin_disabled` /
`surface_disabled_builtins`, `McpHost::start_with_disabled`, and the
`disabled_by_config` field on `BuiltinStatus` / `BuiltinServerDto`).

- **Host start** (`main.rs`): both the interactive and headless MCP-host start
  sites now call `McpHost::start_with_disabled(.., surface_disabled_builtins("tui"))`,
  so a built-in the user turned off for the `tui` surface is not hosted (and is
  reported `disabled_by_config` for the panel).
- **`builtins.rs`**: `builtin_dtos` carries `disabled_by_config` through to the
  view-model DTO.
- **CLI** (`config_cmd.rs`): `adele config mcp disable/enable <name>` now toggles
  a built-in's per-surface `disabled_builtins` (replacing the old
  "not-yet-supported" decline), and `config mcp list` marks a config-disabled
  built-in `disabled (config)`. A name that is also a defined server keeps the
  server path (server shadows built-in).
- **F5 panel** (`mcp.rs`): full interactive toggle. The list cursor now spans the
  daemon servers and the built-in rows (a unified `Sel::Daemon`/`Sel::Builtin`
  model with pure, tested `selectable`/`highlight_index` mapping). `Space`/`t`
  on a built-in flips its per-surface config off-switch and re-derives the row
  (active <-> disabled) from the `BuiltinServerDto` source of truth, with a green
  "(applies on restart)" note since the running host is not restarted.
  Edit/remove/sign-in stay daemon-only.
- **README**: documents the working CLI + panel toggle and the precedence rules.

Per-surface + applies-on-next-launch throughout; config-disable is the explicit
off-switch and wins the display over an external override.

## Testing

`just check` green (fmt + `clippy --all-targets -D warnings` + build + test);
453 lib + 28 + 4 tests pass, no warnings. `--no-verify` was **not** used.

New/updated named tests:

- `config_cmd`: `disable_builtin_persists_to_config`,
  `enable_builtin_removes_from_disabled`, `disable_builtin_is_per_surface`,
  `list_marks_builtin_disabled_by_config`,
  `defined_server_named_like_builtin_takes_server_path` (replacing the old
  `enable_builtin_only_name_is_declined_not_errored`).
- `builtins`: `config_disabled_builtin_maps_to_disabled_row`; existing
  `BuiltinStatus` constructions updated for the new field.
- `mcp` panel: `selectable_lists_daemon_then_builtins`,
  `selectable_empty_when_no_rows`, `highlight_index_daemon_is_the_row_index`,
  `highlight_index_builtin_skips_the_separator_header`,
  `current_sel_spans_daemon_then_builtins`,
  `advance_selection_wraps_across_both_sections`,
  `toggle_builtin_disables_persisting_and_flips_dto`,
  `toggle_builtin_reenable_removes_from_config`,
  `draw_list_renders_config_disabled_builtin_dimmed_with_reason`.

Failing spec committed before the implementation (TDD).

## Interlock

Co-dependent -- must land with adelie-ai/desktop-assistant#545,
adelie-ai/client-ui-common#19, and the adele-gtk sibling.

Refs adelie-ai/desktop-assistant#538

🤖 Generated with [Claude Code](https://claude.com/claude-code)