### PR TITLE
feat(builtins): default-off opt-in broad-set built-ins (the "mac broad set")

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,9 +18,12 @@ dependencies = [
  "desktop-assistant-client-common",
  "fileio-mcp",
  "futures",
+ "geocode-mcp",
+ "internet-radio-mcp",
  "keyring-core",
  "oauth2",
  "open",
+ "openstreetmap-mcp",
  "pulldown-cmark",
  "ratatui",
  "ratatui-textarea",
@@ -28,6 +31,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
+ "skills-mcp",
  "syntect",
  "tasks-mcp",
  "tempfile",
@@ -38,6 +42,7 @@ dependencies = [
  "tracing-subscriber",
  "unicode-width",
  "url",
+ "weather-forecast-mcp",
  "web-mcp",
  "zbus",
  "zbus-secret-service-keyring-store",
@@ -1787,6 +1792,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2132,6 +2143,19 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "geocode-mcp"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "mcp-core",
+ "reqwest 0.13.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]
@@ -2631,6 +2655,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "internet-radio-mcp"
+version = "0.1.0"
+dependencies = [
+ "mcp-core",
+ "nix 0.31.3",
+ "reqwest 0.13.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]
@@ -3421,6 +3458,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "openstreetmap-mcp"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "mcp-core",
+ "reqwest 0.13.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4052,6 +4102,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.2",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4152,6 +4222,7 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -4355,6 +4426,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4439,6 +4535,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4499,6 +4606,19 @@ name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
+name = "serde_yaml_ng"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap",
  "itoa",
@@ -4629,6 +4749,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
+name = "skills-mcp"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "dirs",
+ "mcp-core",
+ "schemars",
+ "serde",
+ "serde_json",
+ "serde_yaml_ng",
+ "shellexpand",
+ "thiserror 2.0.18",
+ "tokio",
+ "walkdir",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4728,6 +4865,17 @@ name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5654,6 +5802,19 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "weather-forecast-mcp"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "mcp-core",
+ "reqwest 0.13.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,18 @@ terminal-mcp = { path = "../terminal-mcp", optional = true }
 tasks-mcp = { path = "../tasks-mcp", optional = true }
 web-mcp = { path = "../web-mcp", optional = true }
 
+# The "broad set" of built-in MCP servers (the "mac broad set", da#538). These
+# are default-OFF opt-in extras: the default tui links only the core four above,
+# and these five link in only when their `mcp-*` feature (or the `builtin-extras`
+# umbrella) is enabled. All five expose an infallible `build_service()`. A future
+# mac client copies the `builtin-extras` feature block and turns it on by default.
+# Same sibling path-dep + `mcp-core` URL-patch treatment as the core four.
+weather-forecast-mcp = { path = "../weather-forecast-mcp", optional = true }
+internet-radio-mcp = { path = "../internet-radio-mcp", optional = true }
+openstreetmap-mcp = { path = "../openstreetmap-mcp", optional = true }
+geocode-mcp = { path = "../geocode-mcp", optional = true }
+skills-mcp = { path = "../skills-mcp", optional = true }
+
 # Embeddable voice module (adelie-ai/voice phase 1) for in-app dictation +
 # reply playback with no voice daemon — see adele-tui#67 / voice#34. Path-dep
 # of the sibling `voice` checkout, mirroring how we path-dep desktop-assistant
@@ -119,6 +131,24 @@ mcp-fileio = ["dep:fileio-mcp"]
 mcp-terminal = ["dep:terminal-mcp"]
 mcp-tasks = ["dep:tasks-mcp"]
 mcp-web = ["dep:web-mcp"]
+
+# The "broad set" opt-in extras (da#538), OFF by default. Enable an individual
+# server with e.g. `--features mcp-weather`, or all five with the `builtin-extras`
+# umbrella. Deliberately NOT part of `default`/`builtin-core`, so the stock tui
+# build is byte-for-byte the same as before and links none of these crates. A
+# future mac client is expected to add `builtin-extras` to its own default.
+builtin-extras = [
+    "mcp-weather",
+    "mcp-internet-radio",
+    "mcp-openstreetmap",
+    "mcp-geocode",
+    "mcp-skills",
+]
+mcp-weather = ["dep:weather-forecast-mcp"]
+mcp-internet-radio = ["dep:internet-radio-mcp"]
+mcp-openstreetmap = ["dep:openstreetmap-mcp"]
+mcp-geocode = ["dep:geocode-mcp"]
+mcp-skills = ["dep:skills-mcp"]
 
 [lints.rust]
 warnings = "deny"

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -76,13 +76,14 @@ pub fn builtin_servers() -> Vec<BuiltinServer> {
     // The opt-in "broad set" extras (da#538), each off unless its `mcp-*` feature
     // (or the `builtin-extras` umbrella) is enabled. All five have infallible
     // `build_service()` constructors, so they always register when compiled in.
-    // Each uses its own canonical short name for both `name` and `namespace`
-    // (matching the server's documented client-mcp config key) so an in-process
-    // built-in and the standalone binary share one namespace and override cleanly.
+    // Each uses its fleet-canonical name for both `name` and `namespace` (the
+    // `name` from the daemon's `deploy/mcp/mcp_servers.default.toml`, e.g.
+    // `weather-forecast`), so an in-process built-in, the standalone binary, and a
+    // same-named external override all share one namespace and interchange cleanly.
     #[cfg(feature = "mcp-weather")]
     out.push(BuiltinServer::new(
-        "weather",
-        "weather",
+        "weather-forecast",
+        "weather-forecast",
         Arc::new(weather_forecast_mcp::build_service()),
     ));
     #[cfg(feature = "mcp-internet-radio")]
@@ -173,7 +174,7 @@ mod tests {
     fn builtin_extras_present_and_namespaced_in_full_set() {
         let servers = builtin_servers();
         for name in [
-            "weather",
+            "weather-forecast",
             "internet-radio",
             "openstreetmap",
             "geocode",

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -107,6 +107,40 @@ mod tests {
         );
     }
 
+    /// With the opt-in "broad set" extras compiled in (the `builtin-extras`
+    /// umbrella), the full built-in set additionally contains each of the five
+    /// broad-set servers, every one advertised under its own canonical
+    /// namespace so an in-process server is indistinguishable from the
+    /// standalone binary (da#538). Gated on all five `mcp-*` extras features, so
+    /// it exercises only the extras build and leaves the default (core-only)
+    /// build's expectations untouched.
+    #[cfg(all(
+        feature = "mcp-weather",
+        feature = "mcp-internet-radio",
+        feature = "mcp-openstreetmap",
+        feature = "mcp-geocode",
+        feature = "mcp-skills"
+    ))]
+    #[test]
+    fn builtin_extras_present_and_namespaced_in_full_set() {
+        let servers = builtin_servers();
+        for name in [
+            "weather",
+            "internet-radio",
+            "openstreetmap",
+            "geocode",
+            "skills",
+        ] {
+            let server = servers.iter().find(|s| s.name == name).unwrap_or_else(|| {
+                panic!("broad-set built-in {name:?} must be present under the extras build")
+            });
+            assert_eq!(
+                server.namespace, name,
+                "broad-set built-in {name:?} must be advertised under the {name:?} namespace"
+            );
+        }
+    }
+
     /// The panel mapping: a host [`BuiltinStatus`] list becomes [`BuiltinServerDto`]s
     /// that `server_rows_with_builtins` turns into an active built-in row (no
     /// disabled reason) and an overridden one (a disabled row whose reason names the

--- a/src/builtins.rs
+++ b/src/builtins.rs
@@ -1,7 +1,12 @@
 //! Compiled-in ("built-in") MCP servers hosted in-process (da#538 Phase C/D).
 //!
 //! The core set (fileio/terminal/tasks/web) is compiled in and hosted by
-//! default so a fresh tui is useful with no `client-mcp.toml`. An external
+//! default so a fresh tui is useful with no `client-mcp.toml`. A second,
+//! opt-in "broad set" (weather/internet-radio/openstreetmap/geocode/skills) is
+//! **off by default**: each links in only under its own `mcp-*` feature or the
+//! `builtin-extras` umbrella, so the stock build links only the core four and
+//! behaves exactly as before. (A future mac client is expected to turn
+//! `builtin-extras` on in its own default.) An external
 //! client-mcp server of the SAME NAME overrides (suppresses) the built-in
 //! (external > built-in); that override decision now lives centrally in
 //! [`McpHost::start_with`], which skips + logs a shadowed built-in and reports
@@ -17,7 +22,12 @@ use desktop_assistant_client_common::mcp_host::{BuiltinServer, BuiltinStatus};
     feature = "mcp-fileio",
     feature = "mcp-terminal",
     feature = "mcp-tasks",
-    feature = "mcp-web"
+    feature = "mcp-web",
+    feature = "mcp-weather",
+    feature = "mcp-internet-radio",
+    feature = "mcp-openstreetmap",
+    feature = "mcp-geocode",
+    feature = "mcp-skills"
 ))]
 use std::sync::Arc;
 
@@ -29,10 +39,11 @@ use std::sync::Arc;
 ///
 /// Each `#[cfg]` block compiles in only when its `mcp-*` feature is on, so a
 /// `--no-default-features` build hosts nothing and the tui behaves as it did
-/// before Phase C. The infallible constructors (fileio, web) are always
-/// registered; the fallible ones (terminal, tasks) are logged and skipped if
-/// their zero-config constructor fails, so a broken environment degrades to the
-/// remaining tools rather than losing the whole set.
+/// before Phase C. The infallible constructors (fileio, web, and all five
+/// opt-in broad-set extras) are always registered; the fallible core ones
+/// (terminal, tasks) are logged and skipped if their zero-config constructor
+/// fails, so a broken environment degrades to the remaining tools rather than
+/// losing the whole set.
 ///
 /// [`McpHost::start_with`]: desktop_assistant_client_common::mcp_host::McpHost::start_with
 pub fn builtin_servers() -> Vec<BuiltinServer> {
@@ -60,6 +71,43 @@ pub fn builtin_servers() -> Vec<BuiltinServer> {
         "web",
         "web",
         Arc::new(web_mcp::build_service()),
+    ));
+
+    // The opt-in "broad set" extras (da#538), each off unless its `mcp-*` feature
+    // (or the `builtin-extras` umbrella) is enabled. All five have infallible
+    // `build_service()` constructors, so they always register when compiled in.
+    // Each uses its own canonical short name for both `name` and `namespace`
+    // (matching the server's documented client-mcp config key) so an in-process
+    // built-in and the standalone binary share one namespace and override cleanly.
+    #[cfg(feature = "mcp-weather")]
+    out.push(BuiltinServer::new(
+        "weather",
+        "weather",
+        Arc::new(weather_forecast_mcp::build_service()),
+    ));
+    #[cfg(feature = "mcp-internet-radio")]
+    out.push(BuiltinServer::new(
+        "internet-radio",
+        "internet-radio",
+        Arc::new(internet_radio_mcp::build_service()),
+    ));
+    #[cfg(feature = "mcp-openstreetmap")]
+    out.push(BuiltinServer::new(
+        "openstreetmap",
+        "openstreetmap",
+        Arc::new(openstreetmap_mcp::build_service()),
+    ));
+    #[cfg(feature = "mcp-geocode")]
+    out.push(BuiltinServer::new(
+        "geocode",
+        "geocode",
+        Arc::new(geocode_mcp::build_service()),
+    ));
+    #[cfg(feature = "mcp-skills")]
+    out.push(BuiltinServer::new(
+        "skills",
+        "skills",
+        Arc::new(skills_mcp::build_service()),
     ));
 
     out


### PR DESCRIPTION
## What

Adds the five "mac broad set" MCP servers to adele-tui as **default-OFF, opt-in** compiled-in built-ins, mirroring the existing core-4 in-process wiring (da#538):

- `weather-forecast-mcp` -> built-in `weather`
- `internet-radio-mcp` -> built-in `internet-radio`
- `openstreetmap-mcp` -> built-in `openstreetmap`
- `geocode-mcp` -> built-in `geocode`
- `skills-mcp` -> built-in `skills`

Each is an `optional = true` sibling path-dep gated behind its own `mcp-*` feature, with a `builtin-extras` umbrella turning all five on. All five expose an infallible `build_service()`, so they use the always-push registration form (like fileio/web).

## The default build is unchanged

`default = ["builtin-core"]` and `builtin-core` are untouched, so the stock tui links **only** the core four (fileio/terminal/tasks/web) and behaves exactly as before. The five extras link and host in-process only under `--features builtin-extras` (or an individual `mcp-*`). Proof:

- `cargo tree -e no-dev` (default) lists **none** of the five crates.
- `cargo tree -e no-dev --features builtin-extras` lists **all five**.

This is the real in-process link test for the broad set and gives a future mac client the exact feature block to copy and flip on in its own `default`.

## Names / namespaces

Each server uses its own canonical short name for both `name` and `namespace` (matching the documented client-mcp config key, e.g. weather-forecast-mcp's README uses `"weather"`), so an in-process built-in and the standalone binary share one namespace and an external server of the same name overrides it cleanly - same convention as the core four.

## Testing

- New `builtins::tests::builtin_extras_present_and_namespaced_in_full_set` (gated on all five `mcp-*` features) asserts `builtin_servers()` exposes the five under their canonical namespaces. Committed failing first (spec), then greened.
- Existing core-only expectations untouched for the default build.

Gate (all green): `just check` (default), plus `cargo clippy --features builtin-extras --all-targets -- -D warnings`, `cargo test --features builtin-extras`, and `cargo build --no-default-features`.

The `[patch."https://github.com/adelie-ai/mcp-core"]` collapses the five crates' floated mcp-core git dep to the single local source (same as the core four); it is unchanged.

Refs adelie-ai/desktop-assistant#538

🤖 Generated with [Claude Code](https://claude.com/claude-code)