### PR TITLE
feat: "Share device info with the assistant" off-switch (da#549 Phase 2b)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1624,6 +1624,7 @@ dependencies = [
 name = "desktop-assistant-api-model"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "desktop-assistant-protocol",
  "serde",
  "serde_json",
@@ -1649,6 +1650,8 @@ dependencies = [
  "desktop-assistant-frame-codec",
  "desktop-assistant-mcp-client",
  "futures",
+ "iana-time-zone",
+ "libc",
  "mcp-core",
  "reqwest 0.13.1",
  "rustls",

--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ chat, tool calls, and background tasks.
 - **Debug view toggle** for tool and system messages, **conversation rename**,
   **auto-reconnect** with backoff, and a **keybind hint toolbar** at the
   bottom of the window.
+- **Share device info toggle** (`Ctrl+O`, on by default) - controls whether the
+  client tells the assistant your name, username, home folder, hostname,
+  timezone, and OS at connect so it can personalize; off means nothing about
+  your device is sent. Persisted in `settings.json`; applies on the next
+  (re)connect. Scriptable via `adele config set share-client-context on|off`.
 - **Embedded voice** (optional, off by default) — `Ctrl+G` dictates a prompt
   (mic → speech-to-text) straight into the composer and sends it; replies can
   be spoken back. Runs in-process with **no voice daemon and no wake word**.
@@ -113,7 +118,15 @@ adele config mcp add-server <NAME> --command <CMD> [--arg <A>]... \
 adele config mcp remove-server <NAME>
 adele config mcp enable  <NAME> [--surface tui]
 adele config mcp disable <NAME> [--surface tui]
+adele config get share-client-context           # print the current value
+adele config set share-client-context on|off    # share device info (default on)
 ```
+
+**Share device info** (`share-client-context`) is the scriptable twin of the
+`Ctrl+O` toggle: it persists to `settings.json`, and `off` stops the client from
+sending your name, username, home folder, hostname, timezone, and OS to the
+assistant at connect. Values are lenient (`on`/`off`, `true`/`false`, `yes`/`no`,
+`1`/`0`); the change applies on the next (re)connect.
 
 `config mcp list` also shows the compiled-in **built-in** servers (with tool
 counts) and their status: `disabled (config)` when you turned the built-in off

--- a/src/app.rs
+++ b/src/app.rs
@@ -186,6 +186,12 @@ pub struct App {
     /// When true, render tool/system/empty-assistant messages dimly inline
     /// instead of filtering them out. Persisted via `settings.json`.
     pub show_debug: bool,
+    /// When true, share basic device context (name, username, home folder,
+    /// hostname, timezone, OS) with the assistant at connect so it can
+    /// personalize. On by default; toggled with `Ctrl+O` and persisted via
+    /// `settings.json` (da#549). Read into the `ConnectionConfig` when the
+    /// connection is built, so a toggle applies on the next (re)connect.
+    pub share_client_context: bool,
     /// Transient indicator from AssistantStatus events ("Searching knowledge
     /// base…", tool-call progress). Cleared when streaming completes or
     /// errors. Distinct from `status_message`, which is sticky user-facing
@@ -262,6 +268,7 @@ impl App {
             rename_textarea: new_textarea(),
             renaming_id: None,
             show_debug: false,
+            share_client_context: true,
             assistant_status: None,
             context_usage: None,
             show_sidebar: true,

--- a/src/config_cmd.rs
+++ b/src/config_cmd.rs
@@ -11,9 +11,12 @@
 //! unit-testable against a tempfile and an in-memory buffer with no real daemon,
 //! filesystem-global state, or terminal.
 //!
-//! Scope: this manages the **client-side** MCP config only. Daemon-hosted MCP
-//! servers are out of this first cut (they need a live connection + the typed
-//! command channel the `F5` panel uses); [`mcp_list`] says so in its output.
+//! Scope: this manages the **client-side** MCP config (`client-mcp.toml`) and,
+//! via [`config_set`] / [`config_get`], the client-local preferences in
+//! `settings.json` (currently the `share-client-context` device-info off-switch,
+//! da#549). Daemon-hosted MCP servers are out of this cut (they need a live
+//! connection + the typed command channel the `F5` panel uses); [`mcp_list`]
+//! says so in its output.
 //!
 //! [`default_client_mcp_path`]: desktop_assistant_client_common::mcp_host::default_client_mcp_path
 
@@ -23,6 +26,8 @@ use std::path::Path;
 
 use anyhow::{Result, anyhow, bail};
 use desktop_assistant_client_common::mcp_host::{ClientMcpConfig, McpServerConfig};
+
+use crate::settings::Settings;
 
 /// The default client surface the `config mcp` subcommands act on when none is
 /// given — the TUI's own surface. Mirrors the `"tui"` surface string the
@@ -302,6 +307,70 @@ pub fn mcp_set_enabled(
         bail!("no such client-MCP server: '{name}'");
     }
     Ok(())
+}
+
+/// The `config set`/`config get` key for the "Share device info with the
+/// assistant" preference ([`Settings::share_client_context`], da#549).
+pub const SHARE_CLIENT_CONTEXT_KEY: &str = "share-client-context";
+
+/// `config set <KEY> <VALUE>`: persist a client-local preference to the
+/// `settings.json` at `path`.
+///
+/// Only [`SHARE_CLIENT_CONTEXT_KEY`] is recognized today; any other key is a
+/// clear error naming the known key rather than a silent no-op. The value is
+/// parsed leniently (`on`/`off`, `true`/`false`, `yes`/`no`, `1`/`0`, any case)
+/// but strictly rejects anything else -- an unparseable value never touches the
+/// file. Other settings in the file are preserved (load, mutate one field,
+/// save).
+pub fn config_set(path: &Path, key: &str, value: &str, out: &mut impl Write) -> Result<()> {
+    match key {
+        SHARE_CLIENT_CONTEXT_KEY => {
+            // Parse BEFORE loading/saving so a bad value leaves the file untouched.
+            let on = parse_on_off(value)?;
+            let mut settings = Settings::load_from(path);
+            settings.share_client_context = on;
+            settings
+                .save_to(path)
+                .map_err(|e| anyhow!("saving settings to {}: {e}", path.display()))?;
+            writeln!(out, "{SHARE_CLIENT_CONTEXT_KEY} = {}", on_off(on))?;
+            Ok(())
+        }
+        other => bail!("unknown setting '{other}'; known keys: {SHARE_CLIENT_CONTEXT_KEY}"),
+    }
+}
+
+/// `config get <KEY>`: print a client-local preference's current value from the
+/// `settings.json` at `path` (an absent file reports the default). Unknown keys
+/// error the same way [`config_set`] does.
+pub fn config_get(path: &Path, key: &str, out: &mut impl Write) -> Result<()> {
+    match key {
+        SHARE_CLIENT_CONTEXT_KEY => {
+            let settings = Settings::load_from(path);
+            writeln!(
+                out,
+                "{SHARE_CLIENT_CONTEXT_KEY} = {}",
+                on_off(settings.share_client_context)
+            )?;
+            Ok(())
+        }
+        other => bail!("unknown setting '{other}'; known keys: {SHARE_CLIENT_CONTEXT_KEY}"),
+    }
+}
+
+/// Render a boolean preference as the `on`/`off` token the CLI reads and writes.
+fn on_off(value: bool) -> &'static str {
+    if value { "on" } else { "off" }
+}
+
+/// Parse a human on/off value. Lenient in encoding (accepts `on`/`off`,
+/// `true`/`false`, `yes`/`no`, `1`/`0`, any case, surrounding whitespace),
+/// strict in value (anything else is a clear error, never a silent default).
+fn parse_on_off(value: &str) -> Result<bool> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "on" | "true" | "yes" | "1" => Ok(true),
+        "off" | "false" | "no" | "0" => Ok(false),
+        other => bail!("invalid value '{other}'; use on/off (also true/false, yes/no, 1/0)"),
+    }
 }
 
 #[cfg(test)]
@@ -733,7 +802,10 @@ mod tests {
         .expect("seed");
         config_set(&path, SHARE_CLIENT_CONTEXT_KEY, "off", &mut Vec::new()).expect("set");
         let back = Settings::load_from(&path);
-        assert!(back.show_debug, "flipping one setting must not clobber another");
+        assert!(
+            back.show_debug,
+            "flipping one setting must not clobber another"
+        );
         assert!(!back.share_client_context);
     }
 
@@ -742,11 +814,17 @@ mod tests {
         let (_dir, path) = temp_settings();
         for on in ["on", "true", "yes", "1", "ON", "True"] {
             config_set(&path, SHARE_CLIENT_CONTEXT_KEY, on, &mut Vec::new()).expect("on-ish");
-            assert!(Settings::load_from(&path).share_client_context, "{on} => true");
+            assert!(
+                Settings::load_from(&path).share_client_context,
+                "{on} => true"
+            );
         }
         for off in ["off", "false", "no", "0", "OFF", "False"] {
             config_set(&path, SHARE_CLIENT_CONTEXT_KEY, off, &mut Vec::new()).expect("off-ish");
-            assert!(!Settings::load_from(&path).share_client_context, "{off} => false");
+            assert!(
+                !Settings::load_from(&path).share_client_context,
+                "{off} => false"
+            );
         }
     }
 
@@ -760,7 +838,10 @@ mod tests {
             "the error explains the accepted values: {err}"
         );
         // A rejected value must not have written the file.
-        assert!(!path.exists(), "a rejected set must not create the settings file");
+        assert!(
+            !path.exists(),
+            "a rejected set must not create the settings file"
+        );
     }
 
     #[test]
@@ -783,7 +864,10 @@ mod tests {
         assert!(on.contains("on"), "get reports the default (on): {on}");
         config_set(&path, SHARE_CLIENT_CONTEXT_KEY, "off", &mut Vec::new()).expect("off");
         let off = out_string(|o| config_get(&path, SHARE_CLIENT_CONTEXT_KEY, o));
-        assert!(off.contains("off"), "get reflects the persisted value: {off}");
+        assert!(
+            off.contains("off"),
+            "get reflects the persisted value: {off}"
+        );
     }
 
     #[test]

--- a/src/config_cmd.rs
+++ b/src/config_cmd.rs
@@ -691,4 +691,106 @@ mod tests {
             "path prints the config location: {printed}"
         );
     }
+
+    // --- Client preferences: share-client-context (da#549 Phase 2b) ---
+
+    /// A fresh tempdir + a settings.json path inside it (the file does not yet
+    /// exist, exercising the load-absent-as-default path).
+    fn temp_settings() -> (tempfile::TempDir, std::path::PathBuf) {
+        let dir = tempdir().expect("tempdir");
+        let path = dir.path().join("settings.json");
+        (dir, path)
+    }
+
+    #[test]
+    fn set_share_client_context_off_persists_and_reloads() {
+        let (_dir, path) = temp_settings();
+        let out = out_string(|o| config_set(&path, SHARE_CLIENT_CONTEXT_KEY, "off", o));
+        assert!(out.contains("off"), "set echoes the new value: {out}");
+        // The change survives a reload (and nothing else in the file matters).
+        assert!(!Settings::load_from(&path).share_client_context);
+    }
+
+    #[test]
+    fn set_share_client_context_on_persists_and_reloads() {
+        let (_dir, path) = temp_settings();
+        // Turn it off, then back on, to prove `on` actually writes true.
+        config_set(&path, SHARE_CLIENT_CONTEXT_KEY, "off", &mut Vec::new()).expect("off");
+        let out = out_string(|o| config_set(&path, SHARE_CLIENT_CONTEXT_KEY, "on", o));
+        assert!(out.contains("on"), "set echoes the new value: {out}");
+        assert!(Settings::load_from(&path).share_client_context);
+    }
+
+    #[test]
+    fn set_preserves_other_settings() {
+        let (_dir, path) = temp_settings();
+        // Seed a non-default show_debug, then flip share-client-context.
+        Settings {
+            show_debug: true,
+            share_client_context: true,
+        }
+        .save_to(&path)
+        .expect("seed");
+        config_set(&path, SHARE_CLIENT_CONTEXT_KEY, "off", &mut Vec::new()).expect("set");
+        let back = Settings::load_from(&path);
+        assert!(back.show_debug, "flipping one setting must not clobber another");
+        assert!(!back.share_client_context);
+    }
+
+    #[test]
+    fn set_accepts_true_false_yes_no_one_zero() {
+        let (_dir, path) = temp_settings();
+        for on in ["on", "true", "yes", "1", "ON", "True"] {
+            config_set(&path, SHARE_CLIENT_CONTEXT_KEY, on, &mut Vec::new()).expect("on-ish");
+            assert!(Settings::load_from(&path).share_client_context, "{on} => true");
+        }
+        for off in ["off", "false", "no", "0", "OFF", "False"] {
+            config_set(&path, SHARE_CLIENT_CONTEXT_KEY, off, &mut Vec::new()).expect("off-ish");
+            assert!(!Settings::load_from(&path).share_client_context, "{off} => false");
+        }
+    }
+
+    #[test]
+    fn set_rejects_invalid_value() {
+        let (_dir, path) = temp_settings();
+        let err = config_set(&path, SHARE_CLIENT_CONTEXT_KEY, "maybe", &mut Vec::new())
+            .expect_err("an unparseable value is rejected");
+        assert!(
+            err.to_string().contains("maybe") || err.to_string().contains("on/off"),
+            "the error explains the accepted values: {err}"
+        );
+        // A rejected value must not have written the file.
+        assert!(!path.exists(), "a rejected set must not create the settings file");
+    }
+
+    #[test]
+    fn set_rejects_unknown_key() {
+        let (_dir, path) = temp_settings();
+        let err = config_set(&path, "no-such-setting", "on", &mut Vec::new())
+            .expect_err("an unknown key is rejected");
+        assert!(
+            err.to_string().contains("no-such-setting")
+                || err.to_string().contains(SHARE_CLIENT_CONTEXT_KEY),
+            "the error names the offending/known key: {err}"
+        );
+    }
+
+    #[test]
+    fn get_reports_current_value() {
+        let (_dir, path) = temp_settings();
+        // Absent file => default on.
+        let on = out_string(|o| config_get(&path, SHARE_CLIENT_CONTEXT_KEY, o));
+        assert!(on.contains("on"), "get reports the default (on): {on}");
+        config_set(&path, SHARE_CLIENT_CONTEXT_KEY, "off", &mut Vec::new()).expect("off");
+        let off = out_string(|o| config_get(&path, SHARE_CLIENT_CONTEXT_KEY, o));
+        assert!(off.contains("off"), "get reflects the persisted value: {off}");
+    }
+
+    #[test]
+    fn get_rejects_unknown_key() {
+        let (_dir, path) = temp_settings();
+        let err = config_get(&path, "no-such-setting", &mut Vec::new())
+            .expect_err("an unknown key is rejected");
+        assert!(err.to_string().contains("no-such-setting") || err.to_string().contains("known"));
+    }
 }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -30,6 +30,11 @@ pub enum Action {
     SubmitRename,
     CancelRename,
     ToggleDebug,
+    /// Toggle the persisted "Share device info with the assistant" preference
+    /// (`Ctrl+O`, da#549 Phase 2b). Flips and saves
+    /// [`crate::settings::Settings::share_client_context`]; the new value shapes
+    /// the connect handshake on the next (re)connect.
+    ToggleShareClientContext,
     ToggleSidebar,
     SwitchConnection,
     OpenKnowledgeBase,
@@ -137,6 +142,10 @@ pub fn handle_key_event(
             KeyCode::Char('d') => Some(Action::ScrollDown),
             KeyCode::Char('e') => Some(Action::ScrollToBottom),
             KeyCode::Char('t') => Some(Action::ToggleDebug),
+            // Ctrl+O toggles the persisted "Share device info" preference
+            // (da#549). Like the other Ctrl toggles it shadows tui-textarea in
+            // Editing mode; Ctrl+O isn't a textarea binding, so nothing is lost.
+            KeyCode::Char('o') => Some(Action::ToggleShareClientContext),
             KeyCode::Char('b') => Some(Action::ToggleSidebar),
             KeyCode::Char('k') => Some(Action::OpenKnowledgeBase),
             KeyCode::Char('m') => Some(Action::OpenModelPicker),
@@ -289,6 +298,7 @@ pub fn help_sections() -> &'static [(&'static str, &'static [(&'static str, &'st
             &[
                 ("Ctrl+B", "toggle sidebar"),
                 ("Ctrl+T", "toggle debug messages"),
+                ("Ctrl+O", "share device info on/off"),
                 ("Ctrl+P", "tasks pane"),
             ],
         ),

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -745,6 +745,32 @@ mod tests {
         );
     }
 
+    // --- Share device info toggle (Ctrl+O, da#549 Phase 2b) ---
+
+    #[test]
+    fn ctrl_o_toggles_share_client_context_in_normal() {
+        assert_eq!(
+            handle_key_event(
+                key_with_mod(KeyCode::Char('o'), KeyModifiers::CONTROL),
+                &InputMode::Normal,
+                false
+            ),
+            Some(Action::ToggleShareClientContext)
+        );
+    }
+
+    #[test]
+    fn ctrl_o_toggles_share_client_context_in_editing() {
+        assert_eq!(
+            handle_key_event(
+                key_with_mod(KeyCode::Char('o'), KeyModifiers::CONTROL),
+                &InputMode::Editing,
+                false
+            ),
+            Some(Action::ToggleShareClientContext)
+        );
+    }
+
     // --- Sidebar toggle (Ctrl+B) ---
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ use adele::in_flight::InFlight;
 use adele::keys::{Action, handle_key_event};
 use adele::picker::PickerOutcome;
 use adele::profile::ProfileStore;
-use adele::settings::Settings;
+use adele::settings::{Settings, default_settings_path};
 use adele::voice::{VoiceConfig, VoiceSession};
 use adele::voice_client::VoiceController;
 use adele::{
@@ -178,6 +178,22 @@ enum ConfigCommand {
     },
     /// Manage client-hosted MCP servers.
     Mcp(McpArgs),
+    /// Set a client-local preference in `settings.json`.
+    ///
+    /// Currently the only key is `share-client-context` (the "Share device info
+    /// with the assistant" off-switch, da#549), e.g.
+    /// `adele config set share-client-context off`.
+    Set {
+        /// Setting key (e.g. `share-client-context`).
+        key: String,
+        /// New value: `on`/`off` (also `true`/`false`, `yes`/`no`, `1`/`0`).
+        value: String,
+    },
+    /// Print a client-local preference's current value from `settings.json`.
+    Get {
+        /// Setting key (e.g. `share-client-context`).
+        key: String,
+    },
 }
 
 /// `config mcp` subcommand group.
@@ -310,6 +326,18 @@ fn run_config(command: &ConfigCommand) -> Result<()> {
         ConfigCommand::Path => cc::config_path(&path, &mut out),
         ConfigCommand::Show { section } => cc::config_show(&path, section.as_deref(), &mut out),
         ConfigCommand::Mcp(mcp) => run_config_mcp(&path, &mcp.command, &mut out),
+        ConfigCommand::Set { key, value } => {
+            let settings_path = default_settings_path().ok_or_else(|| {
+                anyhow::anyhow!("could not resolve the settings path (set HOME or XDG_CONFIG_HOME)")
+            })?;
+            cc::config_set(&settings_path, key, value, &mut out)
+        }
+        ConfigCommand::Get { key } => {
+            let settings_path = default_settings_path().ok_or_else(|| {
+                anyhow::anyhow!("could not resolve the settings path (set HOME or XDG_CONFIG_HOME)")
+            })?;
+            cc::config_get(&settings_path, key, &mut out)
+        }
     }
 }
 
@@ -469,7 +497,10 @@ async fn main() -> Result<()> {
         _ => cli.global.prompt.clone(),
     };
     if let Some(prompt) = exec_prompt {
-        let config: ConnectionConfig = cli.global.into();
+        let mut config: ConnectionConfig = cli.global.into();
+        // Honor the persisted device-info off-switch in headless mode too, so a
+        // scripted `exec` shares (or withholds) the same context the TUI would.
+        Settings::load().apply_to_connection(&mut config);
         return run_headless(&config, prompt).await;
     }
 
@@ -695,6 +726,11 @@ async fn run_app(
             }
         }
     };
+    // Overlay the persisted client-local preferences (da#549: the device-info
+    // off-switch). `ConnectionConfig` defaults sharing on, so this only changes
+    // the handshake when the user opted out. Loaded fresh so a `config set` (or a
+    // prior session's `Ctrl+O`) is honored on this connect.
+    Settings::load().apply_to_connection(&mut config);
 
     loop {
         match run(terminal, &config).await? {
@@ -707,11 +743,25 @@ async fn run_app(
                 match picker::run(terminal, store).await?.0 {
                     PickerOutcome::Selected(profile) => {
                         config = profile.to_connection_config();
+                        // Re-apply on switch so a mid-session `Ctrl+O` toggle
+                        // takes effect on the newly selected connection.
+                        Settings::load().apply_to_connection(&mut config);
                     }
                     PickerOutcome::Cancelled => return Ok(()),
                 }
             }
         }
+    }
+}
+
+/// Snapshot the persisted preferences off live [`App`] state into a [`Settings`]
+/// for saving. Both preference toggles (`Ctrl+T` debug, `Ctrl+O` share-device-
+/// info) write through this so flipping one never clobbers another's on-disk
+/// value.
+fn settings_from_app(app: &App) -> Settings {
+    Settings {
+        show_debug: app.show_debug,
+        share_client_context: app.share_client_context,
     }
 }
 
@@ -722,6 +772,7 @@ async fn run(
     let mut app = App::new();
     let settings = Settings::load();
     app.show_debug = settings.show_debug;
+    app.share_client_context = settings.share_client_context;
 
     // Start any client-side MCP servers configured for the `tui` surface and hold
     // the host in `App` so its tools are advertised (register) and routed
@@ -2020,9 +2071,7 @@ async fn handle_action(
         Action::CancelRename => app.cancel_rename(),
         Action::ToggleDebug => {
             app.show_debug = !app.show_debug;
-            let settings = Settings {
-                show_debug: app.show_debug,
-            };
+            let settings = settings_from_app(app);
             if let Err(e) = settings.save() {
                 app.status_message = format!("Settings save failed: {e}");
             } else {
@@ -2030,6 +2079,26 @@ async fn handle_action(
                     "Debug view ON (showing tool/system messages)".into()
                 } else {
                     "Debug view OFF".into()
+                };
+            }
+        }
+        Action::ToggleShareClientContext => {
+            app.share_client_context = !app.share_client_context;
+            let settings = settings_from_app(app);
+            if let Err(e) = settings.save() {
+                app.status_message = format!("Settings save failed: {e}");
+            } else {
+                // "Share device info with the assistant": name, username, home
+                // folder, hostname, timezone, OS. Off = nothing about your
+                // device is sent. Applies on the next (re)connect.
+                app.status_message = if app.share_client_context {
+                    "Share device info: ON - name, username, home folder, hostname, \
+                     timezone, OS (applies on next reconnect)"
+                        .into()
+                } else {
+                    "Share device info: OFF - nothing about your device is sent \
+                     (applies on next reconnect)"
+                        .into()
                 };
             }
         }
@@ -2904,9 +2973,8 @@ mod tests {
 
     #[test]
     fn config_set_share_client_context_parses() {
-        let cli =
-            CliArgs::try_parse_from(args(&["config", "set", "share-client-context", "off"]))
-                .unwrap();
+        let cli = CliArgs::try_parse_from(args(&["config", "set", "share-client-context", "off"]))
+            .unwrap();
         match cli.command {
             Some(Command::Config(ConfigArgs {
                 command: ConfigCommand::Set { key, value },

--- a/src/main.rs
+++ b/src/main.rs
@@ -2902,6 +2902,34 @@ mod tests {
         }
     }
 
+    #[test]
+    fn config_set_share_client_context_parses() {
+        let cli =
+            CliArgs::try_parse_from(args(&["config", "set", "share-client-context", "off"]))
+                .unwrap();
+        match cli.command {
+            Some(Command::Config(ConfigArgs {
+                command: ConfigCommand::Set { key, value },
+            })) => {
+                assert_eq!(key, "share-client-context");
+                assert_eq!(value, "off");
+            }
+            other => panic!("expected config set, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn config_get_share_client_context_parses() {
+        let cli =
+            CliArgs::try_parse_from(args(&["config", "get", "share-client-context"])).unwrap();
+        match cli.command {
+            Some(Command::Config(ConfigArgs {
+                command: ConfigCommand::Get { key },
+            })) => assert_eq!(key, "share-client-context"),
+            other => panic!("expected config get, got {other:?}"),
+        }
+    }
+
     // --- Panic hook (TUI-1) ---
 
     #[test]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -87,4 +87,94 @@ mod tests {
         let s: Settings = serde_json::from_str(json).unwrap();
         assert!(!s.show_debug);
     }
+
+    // --- Share device info (da#549 Phase 2b) ---
+
+    #[test]
+    fn share_client_context_defaults_true() {
+        assert!(Settings::default().share_client_context);
+    }
+
+    #[test]
+    fn missing_share_client_context_defaults_to_true() {
+        // Back-compat: a settings.json written before the field existed keeps
+        // sharing ON (the daemon-side default), so upgrading never silently
+        // opts a user out.
+        let json = r#"{"show_debug":true}"#;
+        let s: Settings = serde_json::from_str(json).unwrap();
+        assert!(s.share_client_context);
+        assert!(s.show_debug);
+    }
+
+    #[test]
+    fn empty_object_defaults_share_client_context_true() {
+        let s: Settings = serde_json::from_str("{}").unwrap();
+        assert!(s.share_client_context);
+    }
+
+    #[test]
+    fn round_trip_serializes_share_client_context() {
+        let s = Settings {
+            show_debug: false,
+            share_client_context: false,
+        };
+        let json = serde_json::to_string(&s).unwrap();
+        assert!(json.contains("\"share_client_context\":false"));
+        let back: Settings = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, s);
+    }
+
+    #[test]
+    fn apply_to_connection_off_disables_sharing() {
+        let s = Settings {
+            show_debug: false,
+            share_client_context: false,
+        };
+        let mut cfg = ConnectionConfig::default();
+        assert!(
+            cfg.share_client_context,
+            "daemon-side default must be on before we apply the opt-out"
+        );
+        s.apply_to_connection(&mut cfg);
+        assert!(!cfg.share_client_context);
+    }
+
+    #[test]
+    fn apply_to_connection_on_keeps_sharing() {
+        let mut cfg = ConnectionConfig::default();
+        Settings::default().apply_to_connection(&mut cfg);
+        assert!(cfg.share_client_context);
+    }
+
+    #[test]
+    fn load_from_missing_file_defaults_share_on() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("does-not-exist.json");
+        let s = Settings::load_from(&path);
+        assert!(s.share_client_context);
+        assert!(!s.show_debug);
+    }
+
+    #[test]
+    fn save_to_then_load_from_round_trips_both_fields() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("settings.json");
+        let s = Settings {
+            show_debug: true,
+            share_client_context: false,
+        };
+        s.save_to(&path).expect("save");
+        let back = Settings::load_from(&path);
+        assert_eq!(back, s);
+    }
+
+    #[test]
+    fn load_from_corrupt_file_yields_defaults() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("settings.json");
+        std::fs::write(&path, b"not json at all").expect("write");
+        let s = Settings::load_from(&path);
+        assert_eq!(s, Settings::default());
+        assert!(s.share_client_context);
+    }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,32 +1,83 @@
-use std::{env, fs, io, path::PathBuf};
+use std::{
+    env, fs, io,
+    path::{Path, PathBuf},
+};
 
+use desktop_assistant_client_common::ConnectionConfig;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+/// Persisted, client-local user preferences for the TUI.
+///
+/// Stored as JSON at `$XDG_CONFIG_HOME/adele-tui/settings.json` (or
+/// `~/.config/adele-tui/settings.json`). Loading is tolerant: a missing or
+/// corrupt file yields [`Settings::default`], and any field a file omits falls
+/// back to that field's `#[serde(default)]`, so upgrading past a new field never
+/// breaks an older config.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct Settings {
+    /// Render tool/system/empty-assistant messages dimly inline instead of
+    /// filtering them out. Off by default.
     #[serde(default)]
     pub show_debug: bool,
+    /// Share basic device context (real name, username, home folder, hostname,
+    /// timezone, OS) with the assistant so it can personalize replies. **On by
+    /// default** -- the daemon-side default is also on, so this is the user's
+    /// off-switch (da#549). When off, the client attaches no device context to
+    /// the connect handshake. A settings.json predating this field parses as on.
+    #[serde(default = "default_share_client_context")]
+    pub share_client_context: bool,
+}
+
+/// The default for [`Settings::share_client_context`]: **on**. A standalone
+/// function (rather than `bool::default`, which is `false`) so a config missing
+/// the key deserializes to on, matching the daemon-side default.
+fn default_share_client_context() -> bool {
+    true
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self {
+            show_debug: false,
+            share_client_context: default_share_client_context(),
+        }
+    }
 }
 
 impl Settings {
-    /// Load settings from disk, returning defaults if the file doesn't exist
-    /// or fails to parse. We never hard-fail on settings — a corrupted file
-    /// just means the user gets defaults until they toggle something and
-    /// save overwrites the bad file.
+    /// Load settings from the default path, returning [`Settings::default`] if
+    /// the file doesn't exist or fails to parse. We never hard-fail on settings
+    /// -- a corrupted file just means the user gets defaults until they toggle
+    /// something and save overwrites the bad file.
     pub fn load() -> Self {
-        let Some(path) = settings_path() else {
-            return Self::default();
-        };
-        let Ok(bytes) = fs::read(&path) else {
+        match default_settings_path() {
+            Some(path) => Self::load_from(&path),
+            None => Self::default(),
+        }
+    }
+
+    /// Load settings from an explicit path, returning [`Settings::default`] when
+    /// the file is absent or unparseable. Injecting the path keeps the loader
+    /// unit-testable and lets the `config` CLI act on the file without a TUI.
+    pub fn load_from(path: &Path) -> Self {
+        let Ok(bytes) = fs::read(path) else {
             return Self::default();
         };
         serde_json::from_slice(&bytes).unwrap_or_default()
     }
 
+    /// Save settings to the default path, creating parent directories as needed.
     pub fn save(&self) -> io::Result<()> {
-        let Some(path) = settings_path() else {
+        let Some(path) = default_settings_path() else {
             return Err(io::Error::other("could not resolve settings path"));
         };
+        self.save_to(&path)
+    }
+
+    /// Save settings to an explicit path, creating parent directories as needed.
+    /// The injectable twin of [`Settings::save`], used by the `config` CLI and
+    /// the unit tests.
+    pub fn save_to(&self, path: &Path) -> io::Result<()> {
         if let Some(parent) = path.parent() {
             fs::create_dir_all(parent)?;
         }
@@ -34,9 +85,25 @@ impl Settings {
             .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
         fs::write(path, bytes)
     }
+
+    /// Apply the persisted client-local preferences that shape an outgoing
+    /// [`ConnectionConfig`] before we dial the daemon.
+    ///
+    /// Currently that is only [`Settings::share_client_context`] (da#549): the
+    /// daemon and [`ConnectionConfig::default`] both default sharing on, so this
+    /// carries the user's opt-out through to the connect handshake. Applied when
+    /// the connection is built, so a mid-session toggle takes effect on the next
+    /// (re)connect.
+    pub fn apply_to_connection(&self, config: &mut ConnectionConfig) {
+        config.share_client_context = self.share_client_context;
+    }
 }
 
-fn settings_path() -> Option<PathBuf> {
+/// The default settings file path: `$XDG_CONFIG_HOME/adele-tui/settings.json`,
+/// falling back to `~/.config/adele-tui/settings.json`. `None` when neither
+/// `XDG_CONFIG_HOME` nor `HOME` is set (no sensible location), in which case the
+/// caller degrades to in-memory defaults rather than failing.
+pub fn default_settings_path() -> Option<PathBuf> {
     let base = if let Ok(xdg) = env::var("XDG_CONFIG_HOME")
         && !xdg.is_empty()
     {
@@ -59,15 +126,18 @@ mod tests {
 
     #[test]
     fn missing_xdg_home_var_falls_back_to_home() {
-        // Smoke: settings_path is Some when HOME is set (true in test env).
+        // Smoke: default_settings_path is Some when HOME is set (true in test env).
         if env::var("HOME").is_ok() {
-            assert!(settings_path().is_some());
+            assert!(default_settings_path().is_some());
         }
     }
 
     #[test]
     fn round_trip_serializes_show_debug() {
-        let s = Settings { show_debug: true };
+        let s = Settings {
+            show_debug: true,
+            share_client_context: true,
+        };
         let json = serde_json::to_string(&s).unwrap();
         assert!(json.contains("\"show_debug\":true"));
         let back: Settings = serde_json::from_str(&json).unwrap();


### PR DESCRIPTION
## Summary

Adds the user-facing, **default-on** opt-out that drives `ConnectionConfig.share_client_context` (client-common Phase 2a). With it on (the default, matching the daemon), the client sends six device-context fields at connect - real name, username, home folder, hostname, timezone, OS - so Adele can personalize. Off means nothing about the device is sent. This is the off-switch; default-on preserves the existing behavior.

## How it works

- **Persistence** uses the TUI's own `settings.json` store: a new `Settings.share_client_context` field, default on via a serde field-default so a config written before this field parses as on (never silently opts a user out).
- `ConnectionConfig` is `Deserialize`-only and carries secrets, so the preference is overlaid onto it at connect time via `Settings::apply_to_connection(&mut config)` - on the initial connect, on connection switch (`F2`), and in headless `exec`. Effect is on the next (re)connect.

## Surfaces

- **Settings toggle:** `Ctrl+O` flips and persists it, with a status line spelling out what is / isn't shared; listed in the `F1`/`?` help overlay. (The TUI has no separate settings panel; persisted preference toggles are keybindings - this mirrors the existing `Ctrl+T` debug toggle.)
- **Config CLI** (scriptable parity, like the `config mcp` commands): `adele config set share-client-context on|off` and `adele config get share-client-context`, acting on `settings.json` with lenient `on/off/true/false/yes/no/1/0` parsing (strict rejection of anything else; a bad value never writes the file).

`Settings` gains path-injectable `load_from`/`save_to` twins so the config handlers stay pure over an injected path and unit-testable against a tempfile.

## Tests (spec committed before implementation)

- `settings.rs`: `share_client_context_defaults_true`, `missing_share_client_context_defaults_to_true`, `empty_object_defaults_share_client_context_true`, `round_trip_serializes_share_client_context`, `apply_to_connection_off_disables_sharing`, `apply_to_connection_on_keeps_sharing`, `load_from_missing_file_defaults_share_on`, `save_to_then_load_from_round_trips_both_fields`, `load_from_corrupt_file_yields_defaults`.
- `keys.rs`: `ctrl_o_toggles_share_client_context_in_normal` / `_in_editing`.
- `config_cmd.rs`: `set_share_client_context_off_persists_and_reloads`, `..._on_...`, `set_preserves_other_settings`, `set_accepts_true_false_yes_no_one_zero`, `set_rejects_invalid_value`, `set_rejects_unknown_key`, `get_reports_current_value`, `get_rejects_unknown_key`.
- `main.rs`: `config_set_share_client_context_parses`, `config_get_share_client_context_parses`.

Gate green on pinned 1.96.0: `just check` (fmt, clippy `-D warnings`, build, test) - 472 lib + 30 bin + 4 integration tests pass.

## Notes

- `Cargo.lock` picks up client-common Phase 2a's transitive deps (`iana-time-zone`, `libc`, `base64`) used for device-context resolution. No new direct dependencies.
- `cargo audit` reports 3 pre-existing high advisories (`quick-xml`, `quinn-proto`) in unrelated transitive deps - present on `main` independent of this change, not introduced by the lockfile delta. Recommend a separate tracked dependency-bump follow-up.

Refs adelie-ai/desktop-assistant#549

🤖 Generated with [Claude Code](https://claude.com/claude-code)