### PR TITLE
chore(deps): clear RUSTSEC-2026-0185/0194/0195 (quinn-proto, quick-xml)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1121,6 +1121,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chromiumoxide"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2181,11 +2192,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2195,10 +2204,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3714,9 +3726,9 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plist"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64",
  "indexmap",
@@ -3828,9 +3840,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -3857,15 +3869,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3934,6 +3947,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3969,6 +3993,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]


### PR DESCRIPTION
Refs #547

Advisory sweep: clears three high-severity RustSec advisories via a lockfile-only `cargo update` (no `Cargo.toml` changes).

## What changed

| Crate | Before | After | Kind |
|---|---|---|---|
| `quinn-proto` | 0.11.14 | 0.11.16 | semver-compatible |
| `quick-xml` | 0.39.2 | 0.41.0 | via `plist` bump |
| `plist` | 1.9.0 | 1.10.0 | semver-compatible |

`quick-xml` is a transitive dep (`syntect` -> `plist` -> `quick-xml`). The patched `quick-xml` (>=0.41.0) is only reachable by also updating its sole consumer `plist` to 1.10.0. Both moves stay inside their semver-compatible ranges, so `syntect`'s `"5"` pin is untouched and no `Cargo.toml` edit is needed. Transitive additions pulled in by the newer `quinn-proto` (`chacha20`, `rand` 0.10.x, `rand_core`, `rand_pcg`).

## Advisories cleared

- **RUSTSEC-2026-0185** (`quinn-proto`, 7.5 high) - remote memory exhaustion from unbounded out-of-order stream reassembly. Fixed >=0.11.15.
- **RUSTSEC-2026-0194** (`quick-xml`, 7.5 high) - quadratic run time checking a start tag for duplicate attribute names. Fixed >=0.41.0.
- **RUSTSEC-2026-0195** (`quick-xml`, 7.5 high) - unbounded namespace-declaration allocation in `NsReader` enabling memory-exhaustion DoS. Fixed >=0.41.0.

## cargo audit: before

```
error: 3 vulnerabilities found!
warning: 3 allowed warnings found

RUSTSEC-2026-0194  quick-xml 0.39.2   (high 7.5)  Solution: >=0.41.0
RUSTSEC-2026-0195  quick-xml 0.39.2   (high 7.5)  Solution: >=0.41.0
RUSTSEC-2026-0185  quinn-proto 0.11.14 (high 7.5) Solution: >=0.11.15
```

## cargo audit: after

```
0 vulnerabilities found (exit 0)
warning: 3 allowed warnings found
```

The 3 remaining are the pre-existing allow-listed non-blockers, unchanged by this PR:

- RUSTSEC-2025-0141 `bincode` 1.3.3 - unmaintained
- RUSTSEC-2024-0320 `yaml-rust` 0.4.5 - unmaintained
- RUSTSEC-2026-0190 `anyhow` 1.0.102 - `Error::downcast_mut()` unsoundness

## Verification

- `cargo audit` - 3 target advisories gone, exit 0.
- `just check` - fmt, clippy (warnings-as-errors), build, and full test suite (506 tests) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)