### PR TITLE
feat: queue prompts sent while streaming — editable, flushed as one turn

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1927,6 +1927,70 @@ mod tests {
         );
     }
 
+    #[test]
+    fn in_view_stream_complete_flush_preserves_a_fresh_composer_draft() {
+        // AC9: a reply completing while the conversation is in view flushes the
+        // queued backlog as ONE combined send, but a fresh, not-yet-Entered draft
+        // the user has since typed into the live composer must survive untouched.
+        // The flush drains only the committed queue; it must never emit a
+        // `SetComposerText("")` that clears the in-progress composer.
+        let mut app = app_streaming_on_c1();
+        submit(&mut app, "q1"); // queued while busy; composer clears
+        app.set_composer("half-typed"); // user starts a fresh draft mid-stream
+
+        let effects = app.apply_core(UiMessage::StreamComplete {
+            request_id: "srv-1".into(),
+            full_response: "reply".into(),
+        });
+
+        assert_eq!(
+            sent_prompt(&effects).as_deref(),
+            Some("q1"),
+            "the in-view completion flushes the queued backlog as a send"
+        );
+        assert_eq!(
+            app.textarea_content(),
+            "half-typed",
+            "the fresh composer draft must survive the flush, not be cleared"
+        );
+    }
+
+    #[test]
+    fn stream_complete_while_editing_a_recalled_message_defers_the_flush() {
+        // AC8: if a reply completes while the user has a queued message checked
+        // out for editing, the flush is DEFERRED — flushing the partial queue now
+        // would send a stale burst and orphan the checked-out edit. No send fires;
+        // the edit and the remaining queue stay intact until the user finishes (or
+        // cancels) the edit.
+        let mut app = app_streaming_on_c1();
+        submit(&mut app, "a");
+        submit(&mut app, "b");
+        app.recall_prev_queued(); // check out "b" (index 1) into the composer
+        assert_eq!(app.editing_queued_index(), Some(1));
+        assert_eq!(app.textarea_content(), "b");
+        assert_eq!(app.queued_messages_for_view(), &["a".to_string()]);
+
+        let effects = app.apply_core(UiMessage::StreamComplete {
+            request_id: "srv-1".into(),
+            full_response: "reply".into(),
+        });
+
+        assert!(
+            sent_prompt(&effects).is_none(),
+            "the flush must be deferred while a queued item is checked out: {effects:?}"
+        );
+        assert_eq!(
+            app.editing_queued_index(),
+            Some(1),
+            "the checked-out edit is preserved across the deferred flush"
+        );
+        assert_eq!(
+            app.queued_messages_for_view(),
+            &["a".to_string()],
+            "the remaining queue stays intact — nothing sent, nothing orphaned"
+        );
+    }
+
     // --- Bracketed paste (TUI-3) ---
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -991,7 +991,21 @@ impl App {
         }
     }
 
-    pub fn load_conversation(&mut self, detail: ConversationDetail) {
+    /// Open (or switch to) `detail`'s conversation, returning any controller-level
+    /// effects the caller must run — today the switch-back queue flush: when the
+    /// now-open conversation has messages the user queued while its reply streamed
+    /// in the background and that reply has since finished, they flush as ONE
+    /// combined [`Effect::SendPrompt`]. Empty on the common path (idle+empty
+    /// queue, still streaming, or mid-edit). The caller runs the returned effects
+    /// through `run_controller_effects` (the same executor a StreamComplete flush
+    /// uses), since the actual send RPC needs the connector this method doesn't
+    /// hold. Seeding detail directly via `open_conversation` bypasses the reducer's
+    /// `ConversationLoaded` switch-back flush, so this method re-supplies it.
+    ///
+    /// Not `#[must_use]`: many call sites (tests, and the reconnect resync where
+    /// the connector isn't yet live) legitimately have no backlog to flush and
+    /// drop the empty vec. The three real switch paths in `main` run it.
+    pub fn load_conversation(&mut self, detail: ConversationDetail) -> Vec<Effect> {
         let incoming_id = detail.id.clone();
         let outgoing_id = self.core.current_conversation().map(|c| c.id.clone());
         let switching = outgoing_id.as_deref() != Some(incoming_id.as_str());
@@ -1016,6 +1030,12 @@ impl App {
             let draft = self.core.composer_draft(&incoming_id).to_string();
             self.set_composer(&draft);
         }
+        // Auto-send a finished-in-the-background conversation's queued backlog.
+        // A no-op unless the now-open conversation is idle with a pending queue,
+        // so it is safe to call after every open (switch or same-id reload). Runs
+        // last so it sees the restored composer draft and never clobbers it (the
+        // flush leaves the live composer alone).
+        self.core.flush_pending_queue()
     }
 
     /// Apply a live `TitleChanged` signal: the sidebar list rename flows through
@@ -1830,6 +1850,80 @@ mod tests {
             recall_next_action(2, Some(2)),
             RecallNext::Cancel,
             "past newest"
+        );
+    }
+
+    #[test]
+    fn switching_back_flushes_a_finished_backgrounded_conversations_queue() {
+        // Queue two messages on c1 while its reply streams, switch away to c2, let
+        // c1's reply finish in the background (no flush — it's not in view), then
+        // switch back to c1: load_conversation must auto-send the backlog as one
+        // combined turn (the reducer's ConversationLoaded flush is bypassed when
+        // the TUI seeds detail directly via open_conversation).
+        let mut app = app_streaming_on_c1();
+        submit(&mut app, "first");
+        submit(&mut app, "second");
+
+        // Switch away — c1's stream keeps running in the background. (No backlog
+        // on c2, so this returns nothing.)
+        assert!(app.load_conversation(detail("c2")).is_empty());
+
+        // c1's reply completes while backgrounded: routed to c1 (the unique
+        // pending stream), but not the open conversation, so it does NOT flush.
+        let bg = app.apply_core(UiMessage::StreamComplete {
+            request_id: "srv-1".into(),
+            full_response: "reply".into(),
+        });
+        assert!(
+            sent_prompt(&bg).is_none(),
+            "a backgrounded completion must not flush the queue"
+        );
+
+        // Switch back to c1: NOW the idle backlog flushes as one combined send.
+        let effects = app.load_conversation(detail("c1"));
+        assert_eq!(
+            sent_prompt(&effects).expect("switch-back flushes the backlog as a send"),
+            "first\nsecond"
+        );
+        assert!(app.queued_messages_for_view().is_empty());
+    }
+
+    #[test]
+    fn switching_to_a_conversation_without_a_backlog_flushes_nothing() {
+        let mut app = App::new();
+        app.load_conversation(detail("c1"));
+        // A plain switch to an idle, empty conversation emits no send.
+        let effects = app.load_conversation(detail("c2"));
+        assert!(
+            sent_prompt(&effects).is_none() && effects.is_empty(),
+            "no backlog -> no flush: {effects:?}"
+        );
+    }
+
+    #[test]
+    fn switch_back_flush_preserves_the_restored_composer_draft() {
+        // A fresh, not-yet-Entered draft saved for c1 must survive the switch-back
+        // flush: the backlog sends, the draft is restored into the live composer.
+        let mut app = app_streaming_on_c1();
+        submit(&mut app, "queued one");
+        // Leave a draft in the composer, then switch away (it gets saved for c1).
+        app.set_composer("half-typed draft");
+        assert!(app.load_conversation(detail("c2")).is_empty());
+        app.apply_core(UiMessage::StreamComplete {
+            request_id: "srv-1".into(),
+            full_response: "reply".into(),
+        });
+
+        let effects = app.load_conversation(detail("c1"));
+        assert_eq!(
+            sent_prompt(&effects).as_deref(),
+            Some("queued one"),
+            "the backlog flushes"
+        );
+        assert_eq!(
+            app.textarea_content(),
+            "half-typed draft",
+            "the restored draft must not be clobbered by the flush"
         );
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -139,6 +139,43 @@ pub enum ScreenRequest {
 /// paths keep resolving unchanged.
 pub use adele_voice_client_common::AdeleOutput;
 
+/// What a `Down`-key queue step resolves to given the outbox length and the
+/// currently checked-out edit slot. Keeps the walk decision pure and testable,
+/// separate from the `apply_core` dispatch it drives.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RecallNext {
+    /// Check out the queued item at this index for editing.
+    Edit(usize),
+    /// Past the newest queued item: return the checked-out one and clear.
+    Cancel,
+    /// Not editing a queued message — nothing to step through.
+    None,
+}
+
+/// Target index for an `Up`-key recall: step one toward the oldest from the
+/// checked-out slot, or the newest queued item when composing fresh. `None` at
+/// the front of the queue (`Some(0)`) or when the queue is empty — a no-op that
+/// preserves any in-composer edits of the front item.
+fn recall_prev_index(queued_len: usize, editing: Option<usize>) -> Option<usize> {
+    match editing {
+        Some(0) => None,
+        Some(i) => Some(i - 1),
+        None => queued_len.checked_sub(1),
+    }
+}
+
+/// Resolve a `Down`-key queue step. Only meaningful while editing (`editing` is
+/// `Some`): step to the next queued item when one exists after the checked-out
+/// slot, otherwise cancel the edit (the checked-out message returns to the
+/// queue). `queued_len` is the outbox length *excluding* the checked-out item.
+fn recall_next_action(queued_len: usize, editing: Option<usize>) -> RecallNext {
+    match editing {
+        None => RecallNext::None,
+        Some(i) if i < queued_len => RecallNext::Edit(i + 1),
+        Some(_) => RecallNext::Cancel,
+    }
+}
+
 pub struct App {
     pub selected_conversation: Option<usize>,
     pub textarea: TextArea<'static>,
@@ -749,6 +786,25 @@ impl App {
                 self.assistant_status = None;
                 None
             }
+            // The reducer owns the composer for the message-queue flows: it
+            // clears it (`""`) when a submitted prompt is enqueued or an edit is
+            // cancelled, and loads a recalled queued message into it for editing.
+            // The live textarea is pure view state, so apply it here — routing it
+            // through `apply_core` means every dispatch (submit, recall, cancel,
+            // and the queue flush a StreamComplete emits) keeps the composer in
+            // sync without the caller having to special-case it.
+            Effect::SetComposerText(text) => {
+                if text.is_empty() {
+                    self.clear_composer();
+                } else {
+                    self.set_composer(&text);
+                }
+                None
+            }
+            // The TUI redraws the "N queued" indicator from `core` state each
+            // frame (`queued_messages_for_view` / `editing_queued_index`), so the
+            // render-ready snapshot carries no view-level work here.
+            Effect::SetQueuedMessages { .. } => None,
             Effect::SetContextUsage(usage) => {
                 self.context_usage = usage;
                 None
@@ -803,6 +859,59 @@ impl App {
     /// this so a second prompt can't be sent mid-stream (TUI-7).
     pub fn is_streaming(&self) -> bool {
         self.core.is_streaming()
+    }
+
+    /// The messages queued for the open conversation (submit order), read back
+    /// from the shared core. The draw path renders the "N queued" indicator from
+    /// this each frame; the key dispatch consults it to decide whether an empty
+    /// composer's `Up`/`Down` should recall a queued message.
+    pub fn queued_messages_for_view(&self) -> &[String] {
+        self.core.queued_messages_for_view()
+    }
+
+    /// The queue index currently checked out into the composer for editing, or
+    /// `None` when composing a fresh message. Drives the up/down queue walk.
+    pub fn editing_queued_index(&self) -> Option<usize> {
+        self.core.editing_queued_index()
+    }
+
+    /// Recall the previous queued message into the composer for editing (`Up`).
+    /// Walks one step toward the oldest from the checked-out item, or recalls the
+    /// newest when composing fresh. A no-op at the front of the queue or when the
+    /// queue is empty. The reducer loads the text via `SetComposerText`, applied
+    /// in `run_view_effect`.
+    pub fn recall_prev_queued(&mut self) {
+        let queued_len = self.core.queued_messages_for_view().len();
+        if let Some(index) = recall_prev_index(queued_len, self.core.editing_queued_index()) {
+            let _ = self.apply_core(UiMessage::EditQueued { index });
+        }
+    }
+
+    /// Step forward through the queue while editing (`Down`): recall the next
+    /// queued message, or — once past the newest — return the checked-out message
+    /// to the queue and clear the composer. A no-op when not editing a queued
+    /// message.
+    pub fn recall_next_queued(&mut self) {
+        let queued_len = self.core.queued_messages_for_view().len();
+        match recall_next_action(queued_len, self.core.editing_queued_index()) {
+            RecallNext::Edit(index) => {
+                let _ = self.apply_core(UiMessage::EditQueued { index });
+            }
+            RecallNext::Cancel => {
+                let _ = self.apply_core(UiMessage::CancelQueuedEdit);
+            }
+            RecallNext::None => {}
+        }
+    }
+
+    /// Return the currently checked-out queued message to the queue and clear the
+    /// composer, if an edit is in progress (`Esc` while editing a recalled item).
+    /// A no-op otherwise. Distinct from `enter_normal_mode`, which the caller runs
+    /// alongside this to leave edit mode.
+    pub fn cancel_queued_edit_if_active(&mut self) {
+        if self.core.editing_queued_index().is_some() {
+            let _ = self.apply_core(UiMessage::CancelQueuedEdit);
+        }
     }
 
     /// Record a `send_prompt` ack: register the in-flight turn (and its
@@ -1524,6 +1633,205 @@ mod tests {
     // no-conversation rejections moved to the shared core (`UiMessage::SubmitPrompt`,
     // Phase-2) and are spec'd by client-ui-common's reducer tests. The App tests
     // below cover only the TUI's own send-path wiring (composer text → effect).
+
+    // --- Message queuing (feat/queue-messages) ---
+    //
+    // These exercise the TUI's wiring of the queue reducer contract onto App's
+    // own composer widget + view accessors: enqueue-clears-composer, the
+    // stream-complete flush, and the up/down recall walk. The queue state machine
+    // itself is spec'd by client-ui-common's reducer tests; here we assert the
+    // `SetComposerText` effect reaches `App::textarea` and the recall index walk
+    // dispatches the right `EditQueued`/`CancelQueuedEdit`.
+
+    /// Enter a live stream on `c1` so a following `SubmitPrompt` queues (busy).
+    fn app_streaming_on_c1() -> App {
+        let mut app = App::new();
+        app.load_conversation(detail("c1"));
+        app.apply_prompt_ack("task-1".into(), "c1".into());
+        app
+    }
+
+    /// Type `text` into the composer and submit it through the shared core.
+    fn submit(app: &mut App, text: &str) -> Vec<Effect> {
+        app.textarea.insert_str(text);
+        let prompt = app.textarea_content();
+        app.apply_core(UiMessage::SubmitPrompt { prompt })
+    }
+
+    #[test]
+    fn submitting_while_streaming_queues_and_clears_the_composer() {
+        let mut app = app_streaming_on_c1();
+        let effects = submit(&mut app, "hello while busy");
+
+        assert!(
+            sent_prompt(&effects).is_none(),
+            "a busy submit must not send"
+        );
+        assert_eq!(
+            app.queued_messages_for_view(),
+            &["hello while busy".to_string()]
+        );
+        // The reducer cleared the live composer via SetComposerText, applied in
+        // run_view_effect.
+        assert!(
+            app.textarea_content().is_empty(),
+            "composer clears when a message is queued"
+        );
+    }
+
+    #[test]
+    fn queued_messages_flush_as_one_combined_send_on_stream_complete() {
+        let mut app = app_streaming_on_c1();
+        submit(&mut app, "first");
+        submit(&mut app, "second");
+        assert_eq!(app.queued_messages_for_view().len(), 2);
+
+        let effects = app.apply_core(UiMessage::StreamComplete {
+            request_id: "srv-1".into(),
+            full_response: "reply".into(),
+        });
+        assert_eq!(
+            sent_prompt(&effects).expect("stream completion flushes the queue as a send"),
+            "first\nsecond",
+            "the queued burst flushes as ONE combined turn joined with \\n"
+        );
+        assert!(
+            app.queued_messages_for_view().is_empty(),
+            "the queue drains on flush"
+        );
+    }
+
+    #[test]
+    fn recall_prev_loads_the_newest_queued_message_then_walks_to_the_front() {
+        let mut app = app_streaming_on_c1();
+        submit(&mut app, "alpha");
+        submit(&mut app, "bravo");
+
+        app.recall_prev_queued(); // Up -> newest
+        assert_eq!(app.textarea_content(), "bravo");
+        assert_eq!(app.editing_queued_index(), Some(1));
+        assert_eq!(app.queued_messages_for_view(), &["alpha".to_string()]);
+
+        app.recall_prev_queued(); // Up -> older
+        assert_eq!(app.textarea_content(), "alpha");
+        assert_eq!(app.editing_queued_index(), Some(0));
+
+        app.recall_prev_queued(); // Up at the front -> no-op, stays on alpha
+        assert_eq!(app.textarea_content(), "alpha");
+        assert_eq!(app.editing_queued_index(), Some(0));
+    }
+
+    #[test]
+    fn recall_next_steps_forward_then_cancels_past_the_newest() {
+        let mut app = app_streaming_on_c1();
+        submit(&mut app, "alpha");
+        submit(&mut app, "bravo");
+        app.recall_prev_queued(); // bravo
+        app.recall_prev_queued(); // alpha
+        assert_eq!(app.textarea_content(), "alpha");
+
+        app.recall_next_queued(); // Down -> bravo
+        assert_eq!(app.textarea_content(), "bravo");
+        assert_eq!(app.editing_queued_index(), Some(1));
+
+        app.recall_next_queued(); // Down past newest -> cancel, restore + clear
+        assert!(app.textarea_content().is_empty());
+        assert_eq!(app.editing_queued_index(), None);
+        assert_eq!(
+            app.queued_messages_for_view(),
+            &["alpha".to_string(), "bravo".to_string()]
+        );
+    }
+
+    #[test]
+    fn editing_a_recalled_message_reinserts_it_in_place_on_submit() {
+        let mut app = app_streaming_on_c1();
+        submit(&mut app, "alpha");
+        submit(&mut app, "bravo");
+        app.recall_prev_queued(); // check out bravo (slot 1)
+        app.clear_composer();
+        let effects = submit(&mut app, "bravo-edited");
+
+        assert!(
+            sent_prompt(&effects).is_none(),
+            "still streaming: the edited message re-queues, not sends"
+        );
+        assert!(app.textarea_content().is_empty());
+        assert_eq!(
+            app.queued_messages_for_view(),
+            &["alpha".to_string(), "bravo-edited".to_string()]
+        );
+        assert_eq!(app.editing_queued_index(), None);
+    }
+
+    #[test]
+    fn cancelling_a_recalled_edit_returns_the_message_and_clears_composer() {
+        let mut app = app_streaming_on_c1();
+        submit(&mut app, "solo");
+        app.recall_prev_queued();
+        assert_eq!(app.textarea_content(), "solo");
+        assert_eq!(app.editing_queued_index(), Some(0));
+
+        app.cancel_queued_edit_if_active(); // Esc while editing a queued item
+        assert!(app.textarea_content().is_empty());
+        assert_eq!(app.editing_queued_index(), None);
+        assert_eq!(app.queued_messages_for_view(), &["solo".to_string()]);
+    }
+
+    #[test]
+    fn cancel_queued_edit_is_a_no_op_when_not_editing() {
+        let mut app = app_streaming_on_c1();
+        submit(&mut app, "queued");
+        // Not checked out for editing: Esc must not disturb the queue.
+        app.cancel_queued_edit_if_active();
+        assert_eq!(app.queued_messages_for_view(), &["queued".to_string()]);
+        assert_eq!(app.editing_queued_index(), None);
+    }
+
+    #[test]
+    fn idle_send_emits_send_without_a_composer_effect() {
+        // The idle single-send path emits SendPrompt but NO SetComposerText, so
+        // apply_core leaves the live composer untouched — the submit path clears
+        // it itself for this case.
+        let mut app = App::new();
+        app.load_conversation(detail("c1"));
+        let effects = submit(&mut app, "just send it");
+        assert_eq!(sent_prompt(&effects).as_deref(), Some("just send it"));
+        assert_eq!(
+            app.textarea_content(),
+            "just send it",
+            "apply_core does not clear the composer on the idle-send path"
+        );
+    }
+
+    #[test]
+    fn recall_prev_index_walks_backward_and_stops_at_the_front() {
+        assert_eq!(
+            recall_prev_index(0, None),
+            None,
+            "empty queue: nothing to recall"
+        );
+        assert_eq!(
+            recall_prev_index(3, None),
+            Some(2),
+            "fresh compose -> newest"
+        );
+        assert_eq!(recall_prev_index(2, Some(2)), Some(1));
+        assert_eq!(recall_prev_index(2, Some(1)), Some(0));
+        assert_eq!(recall_prev_index(2, Some(0)), None, "at the front -> no-op");
+    }
+
+    #[test]
+    fn recall_next_action_steps_forward_then_cancels_at_the_end() {
+        assert_eq!(recall_next_action(2, None), RecallNext::None, "not editing");
+        assert_eq!(recall_next_action(2, Some(0)), RecallNext::Edit(1));
+        assert_eq!(recall_next_action(2, Some(1)), RecallNext::Edit(2));
+        assert_eq!(
+            recall_next_action(2, Some(2)),
+            RecallNext::Cancel,
+            "past newest"
+        );
+    }
 
     // --- Bracketed paste (TUI-3) ---
 

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -88,6 +88,38 @@ pub enum Action {
     ToggleVoiceIn,
     /// Toggle the keymap help overlay (`?` in Normal mode, or `F1` from anywhere).
     ToggleHelp,
+    /// Recall a queued message into the composer for editing, walking toward the
+    /// oldest (`Up` in edit mode when the composer is empty and a queue exists).
+    /// Dispatched only via [`editing_recall_action`]; the caller checks composer
+    /// emptiness + queue presence so an unmodified `Up` still moves the caret
+    /// when the user is mid-composing. The reducer owns the walk (`EditQueued`).
+    RecallQueued,
+    /// Step forward through the queued messages while editing one, or return the
+    /// checked-out message to the queue and clear the composer once past the
+    /// newest (`Down`, same gate as [`Action::RecallQueued`]).
+    RecallNext,
+}
+
+/// Decide whether an `Up`/`Down` key in edit mode should recall a queued message
+/// instead of moving the composer caret. Recall fires only when the composer is
+/// empty (so it does not fight caret movement while composing) AND there is a
+/// queue to walk (`has_queue`), and only for an unmodified arrow. Returns `None`
+/// to fall through to the normal keymap (which forwards a bare arrow to the
+/// textarea). Kept pure and separate from [`handle_key_event`] so the recall gate
+/// is unit-testable without threading composer state through the whole keymap.
+pub fn editing_recall_action(
+    key: KeyEvent,
+    composer_empty: bool,
+    has_queue: bool,
+) -> Option<Action> {
+    if !composer_empty || !has_queue || !key.modifiers.is_empty() {
+        return None;
+    }
+    match key.code {
+        KeyCode::Up => Some(Action::RecallQueued),
+        KeyCode::Down => Some(Action::RecallNext),
+        _ => None,
+    }
 }
 
 /// Handle key events that we intercept before passing to textarea.
@@ -588,6 +620,63 @@ mod tests {
             handle_key_event(key(KeyCode::Down), &InputMode::Editing, false),
             None
         );
+    }
+
+    // --- Queued-message recall gate (Up/Down in edit mode) ---
+
+    #[test]
+    fn up_recalls_queued_when_composer_empty_and_queue_present() {
+        assert_eq!(
+            editing_recall_action(key(KeyCode::Up), true, true),
+            Some(Action::RecallQueued)
+        );
+    }
+
+    #[test]
+    fn down_recalls_next_when_composer_empty_and_queue_present() {
+        assert_eq!(
+            editing_recall_action(key(KeyCode::Down), true, true),
+            Some(Action::RecallNext)
+        );
+    }
+
+    #[test]
+    fn up_does_not_recall_when_composer_non_empty() {
+        // A non-empty composer keeps Up as caret movement (forwarded to textarea).
+        assert_eq!(editing_recall_action(key(KeyCode::Up), false, true), None);
+        assert_eq!(editing_recall_action(key(KeyCode::Down), false, true), None);
+    }
+
+    #[test]
+    fn up_does_not_recall_when_queue_empty() {
+        assert_eq!(editing_recall_action(key(KeyCode::Up), true, false), None);
+        assert_eq!(editing_recall_action(key(KeyCode::Down), true, false), None);
+    }
+
+    #[test]
+    fn modified_arrows_never_recall() {
+        // Shift/Ctrl+Up must not hijack the queue walk (selection / scroll etc.).
+        assert_eq!(
+            editing_recall_action(key_with_mod(KeyCode::Up, KeyModifiers::SHIFT), true, true),
+            None
+        );
+        assert_eq!(
+            editing_recall_action(
+                key_with_mod(KeyCode::Down, KeyModifiers::CONTROL),
+                true,
+                true
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn recall_gate_ignores_non_arrow_keys() {
+        assert_eq!(
+            editing_recall_action(key(KeyCode::Char('a')), true, true),
+            None
+        );
+        assert_eq!(editing_recall_action(key(KeyCode::Enter), true, true), None);
     }
 
     // --- Scroll tests (Ctrl+u/d/e work in all modes) ---

--- a/src/main.rs
+++ b/src/main.rs
@@ -1276,10 +1276,11 @@ async fn run(
                         // exists daemon-side) and reselect it by ID — the
                         // sidebar selection is positional and the refreshed
                         // list may have reordered.
+                        let mut resync_flush: Vec<Effect> = Vec::new();
                         if let Some(open_id) = app.current_conversation().map(|c| c.id.clone()) {
                             app.select_conversation_by_id(&open_id);
                             match conn.client().get_conversation(&open_id).await {
-                                Ok(detail) => app.load_conversation(detail),
+                                Ok(detail) => resync_flush = app.load_conversation(detail),
                                 Err(e) => {
                                     app.status_message =
                                         format!("Error refreshing conversation: {e}");
@@ -1289,6 +1290,17 @@ async fn run(
                         finish_connection_init(&mut app, &conn).await;
                         reconnect = ReconnectState::Connected;
                         connector = Some(Rc::new(conn));
+                        // The connector is live again: flush any backlog the user
+                        // queued before the gap (a no-op unless idle with a queue).
+                        run_controller_effects(
+                            &mut app,
+                            &connector,
+                            resync_flush,
+                            &voice_daemon,
+                            &voice_session,
+                            &narration_tx,
+                        )
+                        .await;
                     }
                     Err(e) => {
                         reconnect = schedule_reconnect(prev_delay);
@@ -1351,11 +1363,23 @@ async fn run(
                 // daemon's live turn-event fan-out at the now-open conversation
                 // (#1 multi-client sync) so turns started elsewhere — another
                 // client, or the voice daemon — render live here.
-                if apply_rpc_outcome(&mut app, outcome)
+                let applied = apply_rpc_outcome(&mut app, outcome);
+                if applied.conversation_changed
                     && let Some(conn) = connector.as_ref()
                 {
                     subscribe_to_open_conversation(&mut app, conn).await;
                 }
+                // Run any switch-back queue flush the open surfaced. Subscribing
+                // first (above) means the flushed turn's live events route here.
+                run_controller_effects(
+                    &mut app,
+                    &connector,
+                    applied.effects,
+                    &voice_daemon,
+                    &voice_session,
+                    &narration_tx,
+                )
+                .await;
             }
         }
     }
@@ -1419,27 +1443,57 @@ enum RpcOutcome {
     TaskCancelFailed { task_id: String, error: String },
 }
 
+/// The result of applying an [`RpcOutcome`] to `App`: whether the open
+/// conversation changed (so the caller re-subscribes the live fan-out) and any
+/// controller-level effects the reducer bubbled up for the loop to run — today
+/// the switch-back queue flush's [`Effect::SendPrompt`], which needs the connector
+/// + narration handles this transport-free function deliberately does not hold.
+struct RpcApplied {
+    conversation_changed: bool,
+    effects: Vec<Effect>,
+}
+
+impl RpcApplied {
+    /// No conversation change and nothing to run — the common path.
+    fn inert() -> Self {
+        Self {
+            conversation_changed: false,
+            effects: Vec::new(),
+        }
+    }
+
+    /// A switch/open succeeded: re-subscribe, and run `effects` (a switch-back
+    /// flush's send, if any).
+    fn switched(effects: Vec<Effect>) -> Self {
+        Self {
+            conversation_changed: true,
+            effects,
+        }
+    }
+}
+
 /// Apply a completed [`RpcOutcome`] to `App` (TUI-5 / #83). This is the only
 /// place RPC results touch `App`; it runs on the event loop after the RPC has
 /// resolved off it.
 ///
-/// Returns `true` when the open conversation changed (an open/create succeeded),
-/// so the caller can (re)send `SubscribeConversations` for the now-open
-/// conversation (#1 live multi-client sync) — this function stays transport-free,
-/// so the actual command send happens on the event loop where the connector
-/// lives.
-fn apply_rpc_outcome(app: &mut App, outcome: RpcOutcome) -> bool {
+/// Returns an [`RpcApplied`]: `conversation_changed` is `true` when the open
+/// conversation changed (an open/create succeeded), so the caller can (re)send
+/// `SubscribeConversations` for the now-open conversation (#1 live multi-client
+/// sync); `effects` carries any switch-back queue flush to run. This function
+/// stays transport-free, so both the subscribe and the flush send happen on the
+/// event loop where the connector lives.
+fn apply_rpc_outcome(app: &mut App, outcome: RpcOutcome) -> RpcApplied {
     match outcome {
         RpcOutcome::ConversationOpened {
             result,
             enter_editing,
         } => match result {
             Ok(detail) => {
-                app.load_conversation(detail);
+                let flush = app.load_conversation(detail);
                 if enter_editing {
                     app.enter_editing_mode();
                 }
-                return true;
+                return RpcApplied::switched(flush);
             }
             Err(e) => app.status_message = format!("Error: {e}"),
         },
@@ -1452,7 +1506,7 @@ fn apply_rpc_outcome(app: &mut App, outcome: RpcOutcome) -> bool {
                 Ok(id) => id,
                 Err(e) => {
                     app.status_message = format!("Create error: {e}");
-                    return false;
+                    return RpcApplied::inert();
                 }
             };
             match list {
@@ -1468,9 +1522,11 @@ fn apply_rpc_outcome(app: &mut App, outcome: RpcOutcome) -> bool {
             }
             match detail {
                 Some(Ok(detail)) => {
-                    app.load_conversation(detail);
+                    // A freshly-created conversation has no backlog, so the flush
+                    // is empty; run it uniformly anyway.
+                    let flush = app.load_conversation(detail);
                     app.enter_editing_mode();
-                    return true;
+                    return RpcApplied::switched(flush);
                 }
                 Some(Err(e)) => app.status_message = format!("Error opening: {e}"),
                 None => {}
@@ -1524,7 +1580,7 @@ fn apply_rpc_outcome(app: &mut App, outcome: RpcOutcome) -> bool {
         }
     }
     // No open-conversation change on any path that reached here.
-    false
+    RpcApplied::inert()
 }
 
 /// What [`handle_signal`] asks its caller to do after handling a signal. Almost
@@ -1581,7 +1637,18 @@ async fn run_controller_effects(
                 prompt,
                 system_refinement,
             } => {
-                run_send_prompt(app, connector, conversation_id, prompt, system_refinement).await;
+                // Background queue flush: on failure, only recover the batch into
+                // the composer if it's empty — never clobber a fresh draft the
+                // reducer deliberately preserved through the flush.
+                run_send_prompt(
+                    app,
+                    connector,
+                    conversation_id,
+                    prompt,
+                    system_refinement,
+                    ComposerRecovery::IfComposerEmpty,
+                )
+                .await;
             }
             _ => {}
         }
@@ -2644,7 +2711,17 @@ async fn send_prompt_from_input(app: &mut App, connector: &Option<Rc<Connector>>
     // composer, so the clear lives here, not in `run_send_prompt`.
     app.clear_composer();
     app.scroll_to_bottom();
-    run_send_prompt(app, connector, conversation_id, prompt, system_refinement).await;
+    // Direct submit: on failure, refill the (now-cleared) composer with the
+    // unsent text so the user can retry.
+    run_send_prompt(
+        app,
+        connector,
+        conversation_id,
+        prompt,
+        system_refinement,
+        ComposerRecovery::Always,
+    )
+    .await;
 }
 
 /// Extract the `SendPrompt` payload from an effect list, if one is present. The
@@ -2660,21 +2737,47 @@ fn take_send_prompt(effects: Vec<Effect>) -> Option<(String, String, Option<Stri
     })
 }
 
+/// How [`run_send_prompt`] should recover the unsent text into the live composer
+/// when the send RPC fails, decided by which path issued the send.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ComposerRecovery {
+    /// Direct keyboard submit: the composer was cleared before sending, so refill
+    /// it with the failed text unconditionally (the user retries without retyping).
+    Always,
+    /// Background queue flush: the composer may hold a fresh, not-yet-Entered draft
+    /// the reducer deliberately left in place, so recover the failed batch ONLY
+    /// when the composer is empty — never clobber that draft.
+    IfComposerEmpty,
+}
+
+/// Whether a failed send should refill the composer with the unsent `prompt`.
+/// Pure so the branch is unit-testable without a live transport (the RPC itself
+/// isn't). See [`ComposerRecovery`] for why the flush path is conditional.
+fn should_restore_composer(recovery: ComposerRecovery, composer_empty: bool) -> bool {
+    match recovery {
+        ComposerRecovery::Always => true,
+        ComposerRecovery::IfComposerEmpty => composer_empty,
+    }
+}
+
 /// Run the actual send RPC for one [`Effect::SendPrompt`], shared by the keyboard
-/// submit path and the queue flush a `StreamComplete`/`StreamError` emits. Does
-/// NOT touch the live composer — the caller owns that (a direct submit clears it;
-/// a background flush must preserve a fresh, not-yet-Entered draft). `send_prompt_full`
-/// carries the staged model override (socket transports only); over D-Bus the
-/// refinement folds into the prompt, so the no-override voice path works
-/// everywhere. `system_refinement` is `None` when the conversation's `Adele:`
+/// submit path and the queue flush a `StreamComplete`/`StreamError`/switch-back
+/// emits. Does NOT clear the live composer — the caller owns that (a direct submit
+/// clears it; a background flush must preserve a fresh, not-yet-Entered draft).
+/// `send_prompt_full` carries the staged model override (socket transports only);
+/// over D-Bus the refinement folds into the prompt, so the no-override voice path
+/// works everywhere. `system_refinement` is `None` when the conversation's `Adele:`
 /// level is Disabled. A failed send rolls the optimistic bubble back via
-/// `UiMessage::SendFailed` and refills the composer with the unsent text.
+/// `UiMessage::SendFailed`; whether it also refills the composer with the unsent
+/// text is governed by `recovery` — the direct path always does, the flush path
+/// only when the composer is empty so it can't destroy an unrelated draft.
 async fn run_send_prompt(
     app: &mut App,
     connector: &Option<Rc<Connector>>,
     conversation_id: String,
     prompt: String,
     system_refinement: Option<String>,
+    recovery: ComposerRecovery,
 ) {
     let Some(connector) = connector.as_ref() else {
         // Reachable only via a queue flush racing a disconnect (the keyboard
@@ -2715,8 +2818,14 @@ async fn run_send_prompt(
                 conversation_id,
                 prompt: prompt.clone(),
             });
-            app.set_composer(&prompt);
-            app.status_message = format!("Send error: {e} (your text is preserved)");
+            if should_restore_composer(recovery, app.textarea_content().is_empty()) {
+                app.set_composer(&prompt);
+                app.status_message = format!("Send error: {e} (your text is preserved)");
+            } else {
+                // A background flush failed while the user was mid-composing a
+                // new message; keep their draft and report the batch was not sent.
+                app.status_message = format!("Send error: {e} (queued messages not sent)");
+            }
         }
     }
 }
@@ -3233,5 +3342,34 @@ mod tests {
         // whole set, since it's set-replace, not a delta).
         app.load_conversation(detail("conv-2"));
         assert_eq!(open_conversation_ids(&app), vec!["conv-2".to_string()]);
+    }
+
+    // --- Failed-send composer recovery (feat/queue-messages, Finding 2) ---
+    //
+    // The send RPC itself needs a live transport, so its Err arm can't be driven
+    // in a unit test; the recovery *decision* is factored out into
+    // `should_restore_composer` and asserted here. The key case is a background
+    // flush failing while the user has a fresh draft in the composer.
+
+    #[test]
+    fn direct_submit_error_always_restores_the_composer() {
+        // The composer was cleared before a direct send, so restore unconditionally.
+        assert!(should_restore_composer(ComposerRecovery::Always, true));
+        assert!(should_restore_composer(ComposerRecovery::Always, false));
+    }
+
+    #[test]
+    fn flush_send_error_never_overwrites_a_non_empty_composer() {
+        // A background flush failing must NOT clobber a fresh, not-yet-Entered
+        // draft the reducer preserved through the flush.
+        assert!(
+            !should_restore_composer(ComposerRecovery::IfComposerEmpty, false),
+            "a non-empty draft must survive a failed flush send"
+        );
+        // With nothing typed, recover the failed batch so it isn't silently lost.
+        assert!(should_restore_composer(
+            ComposerRecovery::IfComposerEmpty,
+            true
+        ));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,7 @@ use tokio::{
 // plumbing types) lives in this file.
 use adele::app::{AdeleOutput, App, InputMode, ScreenRequest};
 use adele::in_flight::InFlight;
-use adele::keys::{Action, handle_key_event};
+use adele::keys::{Action, editing_recall_action, handle_key_event};
 use adele::picker::PickerOutcome;
 use adele::profile::ProfileStore;
 use adele::settings::{Settings, default_settings_path};
@@ -1143,7 +1143,23 @@ async fn run(
                         }
                         continue;
                     }
-                    if let Some(action) = handle_key_event(key, &app.mode, app.tasks.visible) {
+                    // Queued-message recall (feat/queue-messages): an unmodified
+                    // Up/Down in edit mode walks the queue only when the composer
+                    // is empty (so it doesn't fight caret movement) and a queue
+                    // exists; otherwise fall through to the normal keymap, which
+                    // forwards a bare arrow to the textarea.
+                    let recall = if matches!(app.mode, InputMode::Editing) {
+                        editing_recall_action(
+                            key,
+                            app.textarea_content().is_empty(),
+                            !app.queued_messages_for_view().is_empty(),
+                        )
+                    } else {
+                        None
+                    };
+                    if let Some(action) =
+                        recall.or_else(|| handle_key_event(key, &app.mode, app.tasks.visible))
+                    {
                         if action == Action::Dictate {
                             // Push-to-talk (adele-tui#77). Prefer the voice
                             // daemon's dictation when it is running: it captures,
@@ -1533,27 +1549,41 @@ enum SignalAction {
     RefreshConversations,
 }
 
-/// Run the controller-level effects [`App::apply_core`] bubbled up from a
-/// streaming signal — the ones the view can't perform itself. Today the streaming
-/// arms bubble up only [`Effect::Speak`] (reply narration, already gated by
-/// core's `StreamComplete`); the view-level effects (including the side-pane
-/// no-ops) were already absorbed inside `apply_core`. Later CC-3 slices route the
-/// open-conversation RPC effects and handle them here.
-fn run_stream_controller_effects(
+/// Run the controller-level effects [`App::apply_core`] bubbled up from a signal
+/// — the ones the view can't perform itself. Two kinds reach here:
+///
+/// - [`Effect::Speak`] — reply narration, already gated by core's `StreamComplete`
+///   (reaching it means the gate passed; an empty reply is skipped so we don't
+///   enqueue silence).
+/// - [`Effect::SendPrompt`] — the queue flush a `StreamComplete`/`StreamError`
+///   emits when the user queued follow-ups while the reply streamed. It is a real
+///   send (not tied to the composer), so it runs through [`run_send_prompt`],
+///   which deliberately leaves the live composer alone (a fresh draft must
+///   survive the flush).
+///
+/// The view-level effects (transcript, chat status, and the composer clear on
+/// enqueue) were already absorbed inside `apply_core`.
+async fn run_controller_effects(
+    app: &mut App,
+    connector: &Option<Rc<Connector>>,
     effects: Vec<Effect>,
     voice_daemon: &VoiceController,
     voice_session: &Option<VoiceSession>,
     narration_tx: &UnboundedSender<NarrationRequest>,
 ) {
-    // Today the streaming arms bubble up only `Speak`; any other effect is
-    // ignored here (later CC-3 slices route the open-conversation RPC effects).
-    // Reaching the body means core's narration gate passed; skip an empty reply
-    // so we don't enqueue silence.
     for effect in effects {
-        if let Effect::Speak(text) = effect
-            && !text.trim().is_empty()
-        {
-            enqueue_narration(narration_tx, voice_daemon, voice_session, text);
+        match effect {
+            Effect::Speak(text) if !text.trim().is_empty() => {
+                enqueue_narration(narration_tx, voice_daemon, voice_session, text);
+            }
+            Effect::SendPrompt {
+                conversation_id,
+                prompt,
+                system_refinement,
+            } => {
+                run_send_prompt(app, connector, conversation_id, prompt, system_refinement).await;
+            }
+            _ => {}
         }
     }
 }
@@ -1581,11 +1611,12 @@ async fn handle_signal(
         // (`App::apply_core`): the reducer owns the in-flight state machine —
         // request-id claiming, originating-conversation targeting (TUI-4), and
         // the reply-narration gate — and emits effects. `apply_core` applies the
-        // view-level effects (transcript, chat status, context fill) onto `App`
-        // in place and returns the controller-level ones (narration) for
-        // `run_stream_controller_effects` to run. The events carry
-        // `conversation_id` too, but the in-flight slot routes the stream arms by
-        // `request_id`, so the reducer drops it there.
+        // view-level effects (transcript, chat status, context fill, and the
+        // composer clear on a queued submit) onto `App` in place and returns the
+        // controller-level ones (narration, and the queue-flush send) for
+        // `run_controller_effects` to run. The events carry `conversation_id` too,
+        // but the in-flight slot routes the stream arms by `request_id`, so the
+        // reducer drops it there.
         SignalEvent::UserMessageAdded {
             conversation_id,
             request_id,
@@ -1596,13 +1627,29 @@ async fn handle_signal(
                 request_id,
                 content,
             });
-            run_stream_controller_effects(effects, voice_daemon, voice_session, narration_tx);
+            run_controller_effects(
+                app,
+                connector,
+                effects,
+                voice_daemon,
+                voice_session,
+                narration_tx,
+            )
+            .await;
         }
         SignalEvent::Chunk {
             request_id, chunk, ..
         } => {
             let effects = app.apply_core(UiMessage::StreamChunk { request_id, chunk });
-            run_stream_controller_effects(effects, voice_daemon, voice_session, narration_tx);
+            run_controller_effects(
+                app,
+                connector,
+                effects,
+                voice_daemon,
+                voice_session,
+                narration_tx,
+            )
+            .await;
         }
         SignalEvent::Complete {
             request_id,
@@ -1614,14 +1661,24 @@ async fn handle_signal(
             // `OnDemand` AND `You == Enabled`), external-turn suppression, and the
             // `say_this` dedupe — now lives in core's `StreamComplete`, which
             // emits a `Speak` effect when (and only when) the reply should be
-            // spoken. `run_stream_controller_effects` routes that through the
-            // single narration queue (TUI-11) so synth never blocks the UI and a
-            // `say_this` aside can't interleave.
+            // spoken. `run_controller_effects` routes that through the single
+            // narration queue (TUI-11) so synth never blocks the UI and a
+            // `say_this` aside can't interleave — and, on this same completion,
+            // runs the `SendPrompt` the reducer emits to flush any queued
+            // follow-ups as one combined turn.
             let effects = app.apply_core(UiMessage::StreamComplete {
                 request_id,
                 full_response,
             });
-            run_stream_controller_effects(effects, voice_daemon, voice_session, narration_tx);
+            run_controller_effects(
+                app,
+                connector,
+                effects,
+                voice_daemon,
+                voice_session,
+                narration_tx,
+            )
+            .await;
         }
         SignalEvent::Error {
             request_id, error, ..
@@ -1630,7 +1687,15 @@ async fn handle_signal(
                 request_id,
                 error: error.clone(),
             });
-            run_stream_controller_effects(effects, voice_daemon, voice_session, narration_tx);
+            run_controller_effects(
+                app,
+                connector,
+                effects,
+                voice_daemon,
+                voice_session,
+                narration_tx,
+            )
+            .await;
             // The reducer surfaces "Error: …" in the status line only for the
             // matching in-flight stream; set it unconditionally too so an error
             // for an already-resolved request still reaches the user.
@@ -1645,7 +1710,15 @@ async fn handle_signal(
                 request_id,
                 message,
             });
-            run_stream_controller_effects(effects, voice_daemon, voice_session, narration_tx);
+            run_controller_effects(
+                app,
+                connector,
+                effects,
+                voice_daemon,
+                voice_session,
+                narration_tx,
+            )
+            .await;
         }
         SignalEvent::ContextUsage {
             conversation_id,
@@ -1660,7 +1733,15 @@ async fn handle_signal(
                 budget_tokens,
                 compaction_active,
             });
-            run_stream_controller_effects(effects, voice_daemon, voice_session, narration_tx);
+            run_controller_effects(
+                app,
+                connector,
+                effects,
+                voice_daemon,
+                voice_session,
+                narration_tx,
+            )
+            .await;
         }
         SignalEvent::TitleChanged {
             conversation_id,
@@ -1933,8 +2014,19 @@ async fn handle_action(
                 app.status_message = "Open a conversation first (Enter) or create one (n)".into();
             }
         }
-        Action::ExitEditMode => app.enter_normal_mode(),
+        Action::ExitEditMode => {
+            // Esc while editing a recalled queued message abandons the edit:
+            // return the checked-out message to the queue unchanged and clear the
+            // composer (a no-op when composing a fresh message), then leave edit
+            // mode.
+            app.cancel_queued_edit_if_active();
+            app.enter_normal_mode();
+        }
         Action::SubmitPrompt => send_prompt_from_input(app, connector).await,
+        // Up/Down in edit mode (empty composer + non-empty queue) recall queued
+        // messages for editing; the index walk + reducer dispatch live on `App`.
+        Action::RecallQueued => app.recall_prev_queued(),
+        Action::RecallNext => app.recall_next_queued(),
         // Dictation is handled in the event loop (it needs the embedded voice
         // session + a result channel + a spawned capture task — loop-local
         // resources that don't belong in `handle_action`'s signature), which
@@ -2526,38 +2618,75 @@ fn insert_dictated_text(app: &mut App, text: &str) {
 /// so both honor the staged model override and the same ack handling.
 ///
 /// The send *decision* lives in the shared core (`UiMessage::SubmitPrompt`,
-/// Phase-2): it runs the streaming/empty gate (TUI-7), draws the user bubble
-/// optimistically, and — when accepted — hands back an [`Effect::SendPrompt`]
-/// for this executor to run as the actual RPC. Only the connection gate and the
-/// transport-specific RPC + override stay here. A failed send rolls the
-/// optimistic bubble back via `UiMessage::SendFailed` and refills the composer.
+/// Phase-2): it draws the user bubble optimistically and, when the conversation
+/// is idle, hands back an [`Effect::SendPrompt`] for this executor to run. While
+/// a reply streams it instead QUEUES the text and clears the composer via
+/// [`Effect::SetComposerText`] (applied inside `apply_core`) — that burst flushes
+/// as one combined turn when the reply finishes (see [`run_controller_effects`]).
+/// Only the connection gate and the transport-specific RPC + override stay here.
 async fn send_prompt_from_input(app: &mut App, connector: &Option<Rc<Connector>>) {
     // Connection gate: transport state the core doesn't own.
-    let Some(connector) = connector.as_ref() else {
+    if connector.is_none() {
         app.status_message = "Not connected — message not sent (your text is preserved)".into();
         return;
-    };
+    }
     let prompt = app.textarea_content();
     let effects = app.apply_core(UiMessage::SubmitPrompt { prompt });
-    let Some(Effect::SendPrompt {
-        conversation_id,
-        prompt,
-        system_refinement,
-    }) = effects
-        .into_iter()
-        .find(|e| matches!(e, Effect::SendPrompt { .. }))
-    else {
-        // Rejected (still streaming / empty / no open conversation): the core
-        // already surfaced any status message and left the composer untouched.
+    let Some((conversation_id, prompt, system_refinement)) = take_send_prompt(effects) else {
+        // Queued / edit-reinsert / empty: the reducer already cleared the live
+        // composer (via SetComposerText, applied in apply_core) for the queue
+        // paths, or left a fresh draft untouched. Nothing to send right now.
         return;
     };
-    // Accepted: the user bubble is drawn, so clear the composer and snap to the
-    // bottom, then run the RPC. `send_prompt_full` carries the staged model
-    // override (socket transports only); over D-Bus the refinement folds into the
-    // prompt, so the no-override voice path works everywhere. `system_refinement`
-    // is `None` when the conversation's `Adele:` level is Disabled.
+    // A direct send consumes the composer's text, so clear it and snap to the
+    // bottom (the idle-send path emits no SetComposerText). A background flush
+    // takes a different route (`run_controller_effects`) and must NOT clear the
+    // composer, so the clear lives here, not in `run_send_prompt`.
     app.clear_composer();
     app.scroll_to_bottom();
+    run_send_prompt(app, connector, conversation_id, prompt, system_refinement).await;
+}
+
+/// Extract the `SendPrompt` payload from an effect list, if one is present. The
+/// reducer emits at most one per dispatch (a direct send or a queue flush).
+fn take_send_prompt(effects: Vec<Effect>) -> Option<(String, String, Option<String>)> {
+    effects.into_iter().find_map(|e| match e {
+        Effect::SendPrompt {
+            conversation_id,
+            prompt,
+            system_refinement,
+        } => Some((conversation_id, prompt, system_refinement)),
+        _ => None,
+    })
+}
+
+/// Run the actual send RPC for one [`Effect::SendPrompt`], shared by the keyboard
+/// submit path and the queue flush a `StreamComplete`/`StreamError` emits. Does
+/// NOT touch the live composer — the caller owns that (a direct submit clears it;
+/// a background flush must preserve a fresh, not-yet-Entered draft). `send_prompt_full`
+/// carries the staged model override (socket transports only); over D-Bus the
+/// refinement folds into the prompt, so the no-override voice path works
+/// everywhere. `system_refinement` is `None` when the conversation's `Adele:`
+/// level is Disabled. A failed send rolls the optimistic bubble back via
+/// `UiMessage::SendFailed` and refills the composer with the unsent text.
+async fn run_send_prompt(
+    app: &mut App,
+    connector: &Option<Rc<Connector>>,
+    conversation_id: String,
+    prompt: String,
+    system_refinement: Option<String>,
+) {
+    let Some(connector) = connector.as_ref() else {
+        // Reachable only via a queue flush racing a disconnect (the keyboard
+        // submit gates the connector upstream). Roll the optimistic bubble back
+        // and surface it rather than silently dropping the queued text.
+        let _ = app.apply_core(UiMessage::SendFailed {
+            conversation_id,
+            prompt,
+        });
+        app.status_message = "Not connected — queued message not sent".into();
+        return;
+    };
     let client = connector.client();
     let refinement = system_refinement.as_deref().unwrap_or("");
     let result = match (app.take_pending_override(), client.as_commands()) {

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -549,6 +549,19 @@ fn draw_messages(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
     f.render_widget(messages, area);
 }
 
+/// The composer-title prefix for the message queue (feat/queue-messages):
+/// `"N queued · "` when messages await a flush, `"editing queued · "` while one
+/// is checked out into the composer, or empty when neither. Pure so the wording
+/// is unit-testable without a live frame.
+fn queue_title_prefix(queued_len: usize, editing: bool) -> String {
+    match (queued_len, editing) {
+        (0, false) => String::new(),
+        (0, true) => "editing queued · ".to_string(),
+        (n, true) => format!("editing queued (+{n}) · "),
+        (n, false) => format!("{n} queued · "),
+    }
+}
+
 fn draw_input(f: &mut Frame, app: &mut App, area: ratatui::layout::Rect) {
     let wrap_width = usize::from(area.width.saturating_sub(2)).max(1);
     // Display-only wrap (issue #84): render a throwaway wrapped copy so the
@@ -564,14 +577,24 @@ fn draw_input(f: &mut Frame, app: &mut App, area: ratatui::layout::Rect) {
         ),
         InputMode::Renaming => ("Input", theme().input_border_idle),
     };
+    // Prepend the "N queued" indicator (feat/queue-messages) so a burst the user
+    // fired while Adele was replying is visible right where they type. Pulled from
+    // core state each frame (stateless draw); mirrors the `offline ·` tag shape.
+    let queue_prefix = queue_title_prefix(
+        app.queued_messages_for_view().len(),
+        app.editing_queued_index().is_some(),
+    );
     // When the daemon link is down the run loop projects `connected = false`;
     // surface it where the user types — a warn-colored border plus an `offline`
     // tag. The tag is text (not color-only) so it still reads under NO_COLOR,
     // where the recolor is a no-op; the status bar carries the backoff detail.
     let (title, border_color) = if app.connected {
-        (base_title.to_string(), mode_color)
+        (format!("{queue_prefix}{base_title}"), mode_color)
     } else {
-        (format!("offline · {base_title}"), theme().warn)
+        (
+            format!("{queue_prefix}offline · {base_title}"),
+            theme().warn,
+        )
     };
 
     display.set_block(
@@ -656,6 +679,18 @@ mod tests {
     use super::*;
     use crate::app::{ChatMessage, ConversationDetail, ConversationSummary};
     use ratatui::{Terminal, backend::TestBackend};
+
+    #[test]
+    fn queue_title_prefix_reflects_count_and_editing_state() {
+        assert_eq!(queue_title_prefix(0, false), "");
+        assert_eq!(queue_title_prefix(1, false), "1 queued · ");
+        assert_eq!(queue_title_prefix(3, false), "3 queued · ");
+        // Editing the sole queued item: nothing left in the outbox, but the edit
+        // is in progress.
+        assert_eq!(queue_title_prefix(0, true), "editing queued · ");
+        // Editing one while others remain queued.
+        assert_eq!(queue_title_prefix(2, true), "editing queued (+2) · ");
+    }
 
     #[test]
     fn context_usage_span_colours_track_thresholds() {


### PR DESCRIPTION
## What

Wires the shared queue-messages reducer into the TUI. Prompts submitted while a reply streams are queued instead of refused; the whole queue flushes as one combined turn when the reply ends. Up-arrow (with an empty composer) recalls a queued message to edit; an "N queued" indicator shows the count.

## Tests

Adds App-level regression tests for the two client-visible invariants that were previously unpinned:
- an in-view flush preserves a fresh composer draft (AC9);
- a completion firing while a queued item is checked out for editing defers the flush rather than orphaning the edit (AC8).

Both proven to fail against the injected regression, then pass. `just check` green.

## Interlock

Depends on the shared reducer: **merge adelie-ai/client-ui-common#22 first** — this crate path-deps `client-ui-common` as a sibling, so `main` must not path-dep a reducer-less version. Part of epic adelie-ai/client-ui-common#20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
