### PR TITLE
Settings screen (F6): retire two chords, rebind the voice pair, and unblock macOS builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1230,7 +1230,7 @@ checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
- "libloading",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -2893,6 +2893,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3520,6 +3530,7 @@ version = "2.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
 dependencies = [
+ "libloading 0.9.0",
  "ndarray",
  "ort-sys",
  "smallvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,26 @@ path = "../voice/crates/client-voice"
 [dependencies.adele-voice-vad-silero]
 path = "../voice/crates/vad-silero"
 
+# macOS: resolve ONNX Runtime at runtime instead of linking it at build time.
+#
+# `ort` ships no prebuilt ONNX Runtime for `x86_64-apple-darwin`, and because
+# `adele-voice-module` depends on vad-silero unconditionally, the link-time path
+# fails the WHOLE crate — `cargo build`/`test`/`clippy` are unavailable on an
+# Intel Mac even for work nowhere near voice. `load-dynamic` restores them.
+#
+# Target-scoped so Linux is completely untouched: cargo unifies features per
+# build, so a Linux build never sees this and keeps linking exactly as before.
+# Opting in here (rather than defaulting it on in vad-silero) keeps the blast
+# radius to this one target.
+#
+# Runtime cost of the opt-in: macOS needs `libonnxruntime` available
+# (`brew install onnxruntime`, or point `ORT_DYLIB_PATH` at it). Absent it, voice
+# input fails when first used instead of at build time — an acceptable trade for
+# a platform whose voice backend is unfinished anyway (adelie-ai/voice#133).
+[target.'cfg(target_os = "macos")'.dependencies.adele-voice-vad-silero]
+path = "../voice/crates/vad-silero"
+features = ["load-dynamic"]
+
 [dependencies.adele-voice-stt-whisper]
 path = "../voice/crates/stt-whisper"
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -2938,6 +2938,8 @@ mod tests {
             children: Vec::new(),
             title: title.into(),
             progress_hint: None,
+            owner_todo: String::new(),
+            spawn_marker: None,
         }
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -126,6 +126,9 @@ pub enum ScreenRequest {
     McpServers,
     ModelPicker,
     PersonalityPicker,
+    /// The client-local settings screen (`F6`, #135). Unlike its siblings this
+    /// one needs no connection — every setting it edits is stored locally.
+    Settings,
 }
 
 /// The `Adele:` voice-output level for a conversation. Decides reply narration
@@ -478,6 +481,7 @@ impl App {
             kind,
             // Client-local line, never an idempotent user send (#570).
             idempotency_key: None,
+            created_at_ms: None,
         });
         self.scroll_offset = 0;
         true
@@ -2486,6 +2490,7 @@ mod tests {
                     content: "hello".into(),
                     kind: crate::app::MessageKind::Normal,
                     idempotency_key: None,
+                    created_at_ms: None,
                 },
                 ChatMessage {
                     id: "m2".into(),
@@ -2493,6 +2498,7 @@ mod tests {
                     content: "hi there".into(),
                     kind: crate::app::MessageKind::Normal,
                     idempotency_key: None,
+                    created_at_ms: None,
                 },
             ],
             model_selection: None,

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -31,7 +31,7 @@ pub enum Action {
     CancelRename,
     ToggleDebug,
     /// Toggle the persisted "Share device info with the assistant" preference
-    /// (`Ctrl+O`, da#549 Phase 2b). Flips and saves
+    /// (da#549 Phase 2b), edited on the settings screen (`F6`, #135). Saves
     /// [`crate::settings::Settings::share_client_context`]; the new value shapes
     /// the connect handshake on the next (re)connect.
     ToggleShareClientContext,
@@ -44,14 +44,18 @@ pub enum Action {
     /// `OpenConnections`/`OpenPurposes`: a modal manager over the daemon's MCP
     /// server config.
     OpenMcpServers,
+    /// Open the settings screen (`F6`, #135): the client-local global
+    /// preferences, previously reachable only as the `Ctrl+T` / `Ctrl+O` chords.
+    /// Unlike the other screens this one needs no connection — the settings are
+    /// local, so it opens whether or not a daemon is reachable.
+    OpenSettings,
     OpenModelPicker,
     /// Open the per-conversation personality picker (`Ctrl+R`, "peRsonality").
     /// Mirrors `OpenModelPicker`; pins/clears the Expressive-7 traits for the
     /// active conversation via `set_conversation_personality`.
     OpenPersonalityPicker,
     /// Toggle the process-manager (tasks) overlay. Currently bound to
-    /// `Ctrl+P` ("process manager") since `Ctrl+T` is already used for
-    /// the debug-view toggle and a chord-style `g t` would require a
+    /// `Ctrl+P` ("process manager"), and a chord-style `g t` would require a
     /// new key-state machine that none of the existing bindings use.
     ToggleTasksPane,
     /// Tasks-pane navigation: move highlighted task selection. Only
@@ -70,9 +74,9 @@ pub enum Action {
     /// unless voice is in `embedded` mode. Available when `You == Enabled`.
     Dictate,
     /// Cycle the per-conversation `Adele:` voice-output level (adele-tui#77),
-    /// `Disabled → On Demand → Always → Disabled`. Bound to `Ctrl+S` ("Speech";
-    /// Adele's speech). The keyboard-enhancement flags pushed at startup deliver
-    /// Ctrl+S as a real key event (not terminal XOFF flow control). `Always`
+    /// `Disabled → On Demand → Always → Disabled`. Bound to `Alt+S` ("Speech";
+    /// Adele's speech) — moved off `Ctrl+S`, which is XOFF/terminal-freeze on some
+    /// setups (#137). `Always`
     /// reads every reply aloud in full (made speakable); `On Demand` reads
     /// replies only while `You == Enabled`, kept brief, and always speaks
     /// `say_this` asides; `Disabled` never speaks. Also set by the model via
@@ -80,8 +84,8 @@ pub enum Action {
     /// `Disabled` per conversation.
     CycleAdeleOutput,
     /// Toggle the per-conversation `You:` voice-input control (adele-tui#77),
-    /// `Disabled ↔ Enabled`. Bound to `Ctrl+V` ("Voice"; your voice), delivered
-    /// as a real key event by the same keyboard-enhancement flags. When Enabled,
+    /// `Disabled ↔ Enabled`. Bound to `Alt+V` ("Voice"; your voice) — moved off
+    /// `Ctrl+V`, which collides with paste muscle memory (#137). When Enabled,
     /// push-to-talk dictation is available (Ctrl+G) and — combined with
     /// `Adele == On Demand` — reply narration is on. Defaults `Disabled` (type
     /// only); text input is always available.
@@ -154,6 +158,14 @@ pub fn handle_key_event(
     if key.code == KeyCode::F(5) && key.modifiers.is_empty() {
         return Some(Action::OpenMcpServers);
     }
+    // F6 opens the settings screen (#135). The global preferences used to be
+    // reachable only as chords (Ctrl+T / Ctrl+O), so they were invisible unless
+    // you already knew them — and every new preference cost another binding in
+    // an already-crowded keymap. F6 rather than Ctrl+, because comma-with-
+    // modifier is not reliably distinguishable across terminals.
+    if key.code == KeyCode::F(6) && key.modifiers.is_empty() {
+        return Some(Action::OpenSettings);
+    }
     // F1 toggles the keymap help overlay from any mode (`?` also opens it in
     // Normal mode; F1 is offered too since `?` is a literal character in the
     // composer).
@@ -173,11 +185,12 @@ pub fn handle_key_event(
             KeyCode::Char('u') => Some(Action::ScrollUp),
             KeyCode::Char('d') => Some(Action::ScrollDown),
             KeyCode::Char('e') => Some(Action::ScrollToBottom),
-            KeyCode::Char('t') => Some(Action::ToggleDebug),
-            // Ctrl+O toggles the persisted "Share device info" preference
-            // (da#549). Like the other Ctrl toggles it shadows tui-textarea in
-            // Editing mode; Ctrl+O isn't a textarea binding, so nothing is lost.
-            KeyCode::Char('o') => Some(Action::ToggleShareClientContext),
+            // Ctrl+T (debug messages) and Ctrl+O (share device info) are
+            // deliberately GONE (#135): both are persisted global preferences —
+            // set once, then forgotten — so they live on the settings screen
+            // (F6) where they are visible and self-describing. A binding is for
+            // something you do on the fly, fairly regularly; these are not, and
+            // spending scarce keys on them is what crowded the keymap.
             KeyCode::Char('b') => Some(Action::ToggleSidebar),
             KeyCode::Char('k') => Some(Action::OpenKnowledgeBase),
             KeyCode::Char('m') => Some(Action::OpenModelPicker),
@@ -191,13 +204,27 @@ pub fn handle_key_event(
             // Ctrl+G starts embedded dictation (mic → prompt). A no-op when
             // voice isn't in embedded mode; main.rs gates on the session.
             KeyCode::Char('g') => Some(Action::Dictate),
-            // Ctrl+S cycles the per-conversation Adele output level
-            // (adele-tui#77). A no-op status hint when no conversation is open;
-            // main.rs gates.
+            // The voice toggles moved to Alt+S / Alt+V (#137). They stay
+            // bindings — they are per-conversation, so switching voice on for
+            // *this* chat is exactly an on-the-fly action — but their old Ctrl
+            // homes were both inherited-convention collisions: Ctrl+V is paste
+            // in most GUI apps (and readline's quoted-insert), and Ctrl+S is
+            // XOFF/terminal-freeze on some setups. Rebinding rather than
+            // rehoming, because no uncolliding Ctrl letter was left.
+            _ => None,
+        };
+    }
+
+    // Alt combos. Nearly untouched by this keymap, which is why the voice
+    // toggles moved here: no terminal or readline convention to collide with,
+    // and the V-for-voice / S-for-sound mnemonics survive intact (#137).
+    if alt && !matches!(mode, InputMode::Renaming) {
+        return match key.code {
+            // Cycle the per-conversation Adele output level (adele-tui#77). A
+            // no-op status hint when no conversation is open; main.rs gates.
             KeyCode::Char('s') => Some(Action::CycleAdeleOutput),
-            // Ctrl+V toggles the per-conversation You (voice-input) control
-            // (adele-tui#77). Like Ctrl+S it is delivered as a real key by the
-            // enhancement flags.
+            // Toggle the per-conversation You (voice-input) control
+            // (adele-tui#77). Delivered as a real key by the enhancement flags.
             KeyCode::Char('v') => Some(Action::ToggleVoiceIn),
             _ => None,
         };
@@ -327,12 +354,7 @@ pub fn help_sections() -> &'static [(&'static str, &'static [(&'static str, &'st
         ),
         (
             "View",
-            &[
-                ("Ctrl+B", "toggle sidebar"),
-                ("Ctrl+T", "toggle debug messages"),
-                ("Ctrl+O", "share device info on/off"),
-                ("Ctrl+P", "tasks pane"),
-            ],
+            &[("Ctrl+B", "toggle sidebar"), ("Ctrl+P", "tasks pane")],
         ),
         (
             "Open",
@@ -341,6 +363,7 @@ pub fn help_sections() -> &'static [(&'static str, &'static [(&'static str, &'st
                 ("F3", "connections manager"),
                 ("F4", "purposes"),
                 ("F5", "MCP servers"),
+                ("F6", "settings"),
                 ("Ctrl+K", "knowledge base"),
                 ("Ctrl+M", "model picker"),
                 ("Ctrl+R", "personality"),
@@ -350,8 +373,8 @@ pub fn help_sections() -> &'static [(&'static str, &'static [(&'static str, &'st
             "Voice",
             &[
                 ("Ctrl+G", "push-to-talk dictation"),
-                ("Ctrl+S", "cycle Adele voice output"),
-                ("Ctrl+V", "toggle You (voice input)"),
+                ("Alt+S", "cycle Adele voice output"),
+                ("Alt+V", "toggle You (voice input)"),
             ],
         ),
         (
@@ -818,56 +841,37 @@ mod tests {
         );
     }
 
-    // --- Debug toggle (Ctrl+T) ---
+    // --- Retired toggles now living on the settings screen (#135) ---
 
+    /// `Ctrl+T` and `Ctrl+O` are deliberately unbound: both edited persisted
+    /// GLOBAL preferences (debug messages, share-device-info), so they moved to
+    /// the settings screen where they are visible and explained. Asserting they
+    /// map to `None` is what stops someone quietly reinstating them and
+    /// re-crowding the keymap.
     #[test]
-    fn ctrl_t_toggles_debug_in_normal() {
-        assert_eq!(
-            handle_key_event(
-                key_with_mod(KeyCode::Char('t'), KeyModifiers::CONTROL),
-                &InputMode::Normal,
-                false
-            ),
-            Some(Action::ToggleDebug)
-        );
+    fn retired_preference_chords_are_unbound() {
+        for code in [KeyCode::Char('t'), KeyCode::Char('o')] {
+            for mode in [InputMode::Normal, InputMode::Editing] {
+                assert_eq!(
+                    handle_key_event(key_with_mod(code, KeyModifiers::CONTROL), &mode, false),
+                    None,
+                    "Ctrl+{code:?} must be unbound in {mode:?} — it lives on the settings screen"
+                );
+            }
+        }
     }
 
+    /// F6 opens the settings screen from both modes, so the preferences above
+    /// are still reachable — just from one discoverable place.
     #[test]
-    fn ctrl_t_toggles_debug_in_editing() {
-        assert_eq!(
-            handle_key_event(
-                key_with_mod(KeyCode::Char('t'), KeyModifiers::CONTROL),
-                &InputMode::Editing,
-                false
-            ),
-            Some(Action::ToggleDebug)
-        );
-    }
-
-    // --- Share device info toggle (Ctrl+O, da#549 Phase 2b) ---
-
-    #[test]
-    fn ctrl_o_toggles_share_client_context_in_normal() {
-        assert_eq!(
-            handle_key_event(
-                key_with_mod(KeyCode::Char('o'), KeyModifiers::CONTROL),
-                &InputMode::Normal,
-                false
-            ),
-            Some(Action::ToggleShareClientContext)
-        );
-    }
-
-    #[test]
-    fn ctrl_o_toggles_share_client_context_in_editing() {
-        assert_eq!(
-            handle_key_event(
-                key_with_mod(KeyCode::Char('o'), KeyModifiers::CONTROL),
-                &InputMode::Editing,
-                false
-            ),
-            Some(Action::ToggleShareClientContext)
-        );
+    fn f6_opens_settings_in_both_modes() {
+        for mode in [InputMode::Normal, InputMode::Editing] {
+            assert_eq!(
+                handle_key_event(key(KeyCode::F(6)), &mode, false),
+                Some(Action::OpenSettings),
+                "F6 must open settings in {mode:?}"
+            );
+        }
     }
 
     // --- Sidebar toggle (Ctrl+B) ---
@@ -1054,13 +1058,13 @@ mod tests {
         );
     }
 
-    // --- Ctrl+S cycles the Adele output level (adele-tui#77) ---
+    // --- Alt+S cycles the Adele output level (adele-tui#77, rebound #137) ---
 
     #[test]
-    fn ctrl_s_cycles_adele_output_in_normal() {
+    fn alt_s_cycles_adele_output_in_normal() {
         assert_eq!(
             handle_key_event(
-                key_with_mod(KeyCode::Char('s'), KeyModifiers::CONTROL),
+                key_with_mod(KeyCode::Char('s'), KeyModifiers::ALT),
                 &InputMode::Normal,
                 false
             ),
@@ -1069,17 +1073,35 @@ mod tests {
     }
 
     #[test]
-    fn ctrl_s_cycles_adele_output_in_editing() {
+    fn alt_s_cycles_adele_output_in_editing() {
         // Adele output is a per-conversation control the user will change while
         // composing, so it must be reachable from editing mode too.
         assert_eq!(
             handle_key_event(
-                key_with_mod(KeyCode::Char('s'), KeyModifiers::CONTROL),
+                key_with_mod(KeyCode::Char('s'), KeyModifiers::ALT),
                 &InputMode::Editing,
                 false
             ),
             Some(Action::CycleAdeleOutput)
         );
+    }
+
+    /// The collisions #137 was filed for must stay gone: `Ctrl+V` is paste in
+    /// most GUI apps (and readline's quoted-insert), `Ctrl+S` is XOFF on some
+    /// terminals. Rebinding voice to Alt only fixes that for as long as nobody
+    /// reinstates the Ctrl chords, so assert their absence rather than trusting
+    /// the rebind to stick.
+    #[test]
+    fn colliding_ctrl_voice_chords_stay_unbound() {
+        for code in [KeyCode::Char('v'), KeyCode::Char('s')] {
+            for mode in [InputMode::Normal, InputMode::Editing] {
+                assert_eq!(
+                    handle_key_event(key_with_mod(code, KeyModifiers::CONTROL), &mode, false),
+                    None,
+                    "Ctrl+{code:?} must stay unbound in {mode:?} (see #137)"
+                );
+            }
+        }
     }
 
     #[test]
@@ -1113,10 +1135,10 @@ mod tests {
     // --- Ctrl+V toggles the You (voice-input) control (adele-tui#77) ---
 
     #[test]
-    fn ctrl_v_toggles_voice_in_in_normal() {
+    fn alt_v_toggles_voice_in_in_normal() {
         assert_eq!(
             handle_key_event(
-                key_with_mod(KeyCode::Char('v'), KeyModifiers::CONTROL),
+                key_with_mod(KeyCode::Char('v'), KeyModifiers::ALT),
                 &InputMode::Normal,
                 false
             ),
@@ -1125,12 +1147,12 @@ mod tests {
     }
 
     #[test]
-    fn ctrl_v_toggles_voice_in_in_editing() {
+    fn alt_v_toggles_voice_in_in_editing() {
         // The You control is a per-conversation control the user will flip while
         // composing, so it must be reachable from editing mode too.
         assert_eq!(
             handle_key_event(
-                key_with_mod(KeyCode::Char('v'), KeyModifiers::CONTROL),
+                key_with_mod(KeyCode::Char('v'), KeyModifiers::ALT),
                 &InputMode::Editing,
                 false
             ),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@ pub mod profile;
 pub mod purposes;
 pub mod screen;
 pub mod settings;
+pub mod settings_screen;
 pub mod tasks;
 pub mod theme;
 pub mod toolbar;

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,7 @@ use adele::keys::{Action, editing_recall_action, handle_key_event};
 use adele::picker::PickerOutcome;
 use adele::profile::ProfileStore;
 use adele::settings::{Settings, default_settings_path};
+use adele::settings_screen;
 use adele::voice::{VoiceConfig, VoiceSession};
 use adele::voice_client::VoiceController;
 use adele::{
@@ -755,9 +756,8 @@ async fn run_app(
 }
 
 /// Snapshot the persisted preferences off live [`App`] state into a [`Settings`]
-/// for saving. Both preference toggles (`Ctrl+T` debug, `Ctrl+O` share-device-
-/// info) write through this so flipping one never clobbers another's on-disk
-/// value.
+/// for saving. The settings screen (`F6`, #135) writes through this so a change
+/// there never clobbers a value it does not edit.
 fn settings_from_app(app: &App) -> Settings {
     Settings {
         show_debug: app.show_debug,
@@ -1040,6 +1040,39 @@ async fn run(
                         let label = format!("{} · {}", picked.connection_id, picked.model_id);
                         app.apply_model_override(picked);
                         app.status_message = format!("Model: {label} (applies to next message)");
+                    }
+                }
+                ScreenRequest::Settings => {
+                    // No connector needed — every setting here is client-local.
+                    let mut changed = None;
+                    {
+                        let current = settings_from_app(&app);
+                        let mut sink = SubScreenSink {
+                            app: &mut app,
+                            connector: &connector,
+                            voice_daemon: &voice_daemon,
+                            voice_session: &voice_session,
+                            narration_tx: &narration_tx,
+                            disconnect: &mut disconnect,
+                        };
+                        match settings_screen::run(terminal, current, &mut signal_rx, &mut sink)
+                            .await
+                        {
+                            Ok(settings_screen::Outcome::Changed(next)) => changed = Some(next),
+                            Ok(settings_screen::Outcome::Unchanged) => {}
+                            Err(e) => sink.app.status_message = format!("Settings error: {e}"),
+                        }
+                    }
+                    // Apply + persist AFTER the sink's borrow of `app` ends.
+                    // `Unchanged` skips the write entirely, so merely opening the
+                    // screen never rewrites settings.json.
+                    if let Some(next) = changed {
+                        app.show_debug = next.show_debug;
+                        app.share_client_context = next.share_client_context;
+                        match next.save() {
+                            Ok(()) => app.status_message = "Settings saved".into(),
+                            Err(e) => app.status_message = format!("Settings not saved: {e}"),
+                        }
                     }
                 }
                 ScreenRequest::PersonalityPicker => {
@@ -2311,6 +2344,10 @@ async fn handle_action(
                 app.status_message = "Not connected — MCP servers manager unavailable".into();
             }
         }
+        // No `client.is_some()` gate, unlike every screen above: these settings
+        // are client-local, so the screen is just as useful (arguably more so)
+        // while disconnected.
+        Action::OpenSettings => app.request_screen(ScreenRequest::Settings),
         Action::OpenModelPicker => {
             if client.is_some() {
                 app.request_screen(ScreenRequest::ModelPicker);

--- a/src/model_selector.rs
+++ b/src/model_selector.rs
@@ -413,6 +413,7 @@ mod tests {
         ModelListing {
             connection_id: connection.into(),
             connection_label: format!("{connection} (test)"),
+            notices: Vec::new(),
             model: ModelInfoView {
                 id: model.into(),
                 display_name: model.into(),

--- a/src/settings_screen.rs
+++ b/src/settings_screen.rs
@@ -13,7 +13,22 @@
 //! The state machine below is pure: no terminal, no IO. [`State`] is what the
 //! tests drive; the [`Screen`] impl is a thin shell over it.
 
+use std::io;
+
+use crossterm::event::{KeyCode, KeyEvent};
+use desktop_assistant_client_common::SignalEvent;
+use ratatui::{
+    Frame, Terminal,
+    backend::CrosstermBackend,
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, List, ListItem, ListState, Paragraph, Wrap},
+};
+
+use crate::screen::Screen;
 use crate::settings::Settings;
+use crate::theme::theme;
 
 /// Which global setting a row edits.
 ///
@@ -73,11 +88,16 @@ impl SettingId {
 }
 
 /// What the screen hands back when it closes.
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// `Default` is `Unchanged` because [`crate::screen::run_screen`] requires it:
+/// if the driver ever has to bail without the screen settling (a terminal error),
+/// the safe reading is "the user changed nothing", which skips the write.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub enum Outcome {
     /// The user changed something; the caller should apply + persist these.
     Changed(Settings),
     /// Nothing changed — the caller can skip the write entirely.
+    #[default]
     Unchanged,
 }
 
@@ -163,9 +183,185 @@ impl State {
     }
 }
 
+/// Apply one key press to the screen state.
+///
+/// Pure and synchronous — no RPC, because every setting here is client-local.
+/// Split out from the [`Screen`] impl so the tests drive real key events rather
+/// than the state API.
+pub fn handle_key(state: &mut State, key: KeyEvent) {
+    match key.code {
+        KeyCode::Down | KeyCode::Char('j') => state.move_down(),
+        KeyCode::Up | KeyCode::Char('k') => state.move_up(),
+        // Both, because muscle memory splits: Space reads as "tick a checkbox",
+        // Enter as "activate the thing".
+        KeyCode::Char(' ') | KeyCode::Enter => state.toggle_selected(),
+        KeyCode::Esc | KeyCode::Char('q') => state.close(),
+        _ => {}
+    }
+}
+
+/// The settings screen as a [`Screen`]. No client and no `pending`: unlike the
+/// other screens this one issues no RPCs, so it never needs the off-loop
+/// machinery.
+struct SettingsScreen {
+    state: State,
+}
+
+impl Screen for SettingsScreen {
+    type Outcome = Outcome;
+
+    fn draw(&mut self, frame: &mut Frame) {
+        draw(frame, &self.state);
+    }
+
+    fn handle_key(&mut self, key: KeyEvent) -> impl std::future::Future<Output = ()> {
+        handle_key(&mut self.state, key);
+        std::future::ready(())
+    }
+
+    fn take_outcome(&mut self) -> Option<Outcome> {
+        State::take_outcome(&mut self.state)
+    }
+}
+
+/// Run the settings screen until the user closes it.
+///
+/// Takes the current settings by value and returns whether they changed; the
+/// caller owns persisting the result (there is one write path, in the run loop).
+pub async fn run(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    settings: Settings,
+    signal_rx: &mut tokio::sync::mpsc::UnboundedReceiver<SignalEvent>,
+    sink: &mut impl crate::screen::SignalSink,
+) -> anyhow::Result<Outcome> {
+    let mut screen = SettingsScreen {
+        state: State::new(settings),
+    };
+    crate::screen::run_screen(terminal, &mut screen, signal_rx, sink).await
+}
+
+fn draw(f: &mut Frame, state: &State) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(3),
+            Constraint::Min(3),
+            // Help for the highlighted row: the reason this screen beats a
+            // keybinding, so it gets fixed space rather than whatever is left.
+            Constraint::Length(5),
+            Constraint::Length(1),
+        ])
+        .split(f.area());
+
+    draw_header(f, chunks[0]);
+    draw_list(f, state, chunks[1]);
+    draw_help(f, state, chunks[2]);
+    draw_footer(f, chunks[3]);
+}
+
+fn draw_header(f: &mut Frame, area: Rect) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme().border));
+    let text = Line::from(vec![Span::styled(
+        "Settings",
+        Style::default()
+            .fg(theme().title)
+            .add_modifier(Modifier::BOLD),
+    )]);
+    f.render_widget(Paragraph::new(text).block(block), area);
+}
+
+fn draw_list(f: &mut Frame, state: &State, area: Rect) {
+    let label_w = ALL.iter().map(|s| s.label().len()).max().unwrap_or(0);
+    let items: Vec<ListItem> = ALL
+        .iter()
+        .map(|&id| {
+            let on = id.get(state.settings());
+            // A filled/empty box reads at a glance; the on/off word disambiguates
+            // it for anyone whose terminal renders the glyphs poorly.
+            let (mark, word, style) = if on {
+                (
+                    "[x]",
+                    "on",
+                    Style::default()
+                        .fg(theme().pinned)
+                        .add_modifier(Modifier::BOLD),
+                )
+            } else {
+                ("[ ]", "off", Style::default().fg(theme().text_dim))
+            };
+            ListItem::new(Line::from(vec![
+                Span::styled(format!("{mark} "), style),
+                Span::styled(
+                    format!("{:<width$}", id.label(), width = label_w),
+                    Style::default().add_modifier(Modifier::BOLD),
+                ),
+                Span::styled("   ", Style::default()),
+                Span::styled(word, style),
+            ]))
+        })
+        .collect();
+
+    let list = List::new(items)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(theme().border)),
+        )
+        .highlight_style(
+            Style::default()
+                .bg(theme().list_highlight)
+                .fg(theme().list_highlight_fg)
+                .add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol("▸ ");
+
+    let mut list_state = ListState::default();
+    list_state.select(Some(state.selected()));
+    f.render_stateful_widget(list, area, &mut list_state);
+}
+
+fn draw_help(f: &mut Frame, state: &State, area: Rect) {
+    let help = ALL.get(state.selected()).map(|id| id.help()).unwrap_or("");
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme().border))
+        .title(Line::from(Span::styled(
+            "What this does",
+            Style::default().fg(theme().title),
+        )));
+    f.render_widget(
+        Paragraph::new(help)
+            .style(Style::default().fg(theme().text_dim))
+            .wrap(Wrap { trim: true })
+            .block(block),
+        area,
+    );
+}
+
+fn draw_footer(f: &mut Frame, area: Rect) {
+    let hints = [("↑/↓", "move"), ("Space/Enter", "toggle"), ("Esc", "close")];
+    let mut spans = Vec::new();
+    for (i, (key, desc)) in hints.iter().enumerate() {
+        if i > 0 {
+            spans.push(Span::styled("  ·  ", Style::default().fg(theme().hint_sep)));
+        }
+        spans.push(Span::styled(*key, Style::default().fg(theme().hint_key)));
+        spans.push(Span::raw(" "));
+        spans.push(Span::styled(*desc, Style::default().fg(theme().text_dim)));
+    }
+    f.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crossterm::event::KeyModifiers;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
 
     fn state() -> State {
         State::new(Settings::default())
@@ -298,6 +494,119 @@ mod tests {
                 "row {target} must be toggleable"
             );
         }
+    }
+
+    /// Both toggle keys work. Space and Enter are both bound because muscle
+    /// memory splits between "tick the checkbox" and "activate the row"; a
+    /// screen that honoured only one would feel broken to half its users.
+    #[test]
+    fn space_and_enter_both_toggle() {
+        for code in [KeyCode::Char(' '), KeyCode::Enter] {
+            let mut s = state();
+            let before = s.value_at(0).unwrap();
+            handle_key(&mut s, key(code));
+            assert_eq!(
+                s.value_at(0).unwrap(),
+                !before,
+                "{code:?} must toggle the selected row"
+            );
+        }
+    }
+
+    /// Arrow keys and vim keys both navigate, matching the rest of the TUI.
+    #[test]
+    fn arrows_and_vim_keys_both_navigate() {
+        for (down, up) in [
+            (KeyCode::Down, KeyCode::Up),
+            (KeyCode::Char('j'), KeyCode::Char('k')),
+        ] {
+            let mut s = state();
+            handle_key(&mut s, key(down));
+            assert_eq!(s.selected(), 1, "{down:?} must move down");
+            handle_key(&mut s, key(up));
+            assert_eq!(s.selected(), 0, "{up:?} must move up");
+        }
+    }
+
+    /// Esc and q both close.
+    #[test]
+    fn esc_and_q_both_close() {
+        for code in [KeyCode::Esc, KeyCode::Char('q')] {
+            let mut s = state();
+            handle_key(&mut s, key(code));
+            assert!(
+                State::take_outcome(&mut s).is_some(),
+                "{code:?} must close the screen"
+            );
+        }
+    }
+
+    /// An unbound key is inert — it must not toggle, move, or close. The screen
+    /// mutates persisted user settings, so a stray keystroke silently flipping
+    /// something is the failure mode worth pinning.
+    #[test]
+    fn unbound_keys_do_nothing() {
+        let mut s = state();
+        let before = s.settings().clone();
+        for code in [KeyCode::Char('x'), KeyCode::Tab, KeyCode::Backspace] {
+            handle_key(&mut s, key(code));
+        }
+        assert_eq!(s.selected(), 0, "an unbound key must not move the cursor");
+        assert_eq!(
+            s.settings(),
+            &before,
+            "an unbound key must not change values"
+        );
+        assert!(
+            State::take_outcome(&mut s).is_none(),
+            "an unbound key must not close the screen"
+        );
+    }
+
+    /// The screen renders without panicking, at a normal size and squeezed down
+    /// to a height where the fixed-size sections cannot all fit — the classic
+    /// ratatui layout panic.
+    #[test]
+    fn draw_does_not_panic_at_any_size() {
+        for (w, h) in [(80u16, 24u16), (40, 12), (20, 6), (10, 3)] {
+            let backend = ratatui::backend::TestBackend::new(w, h);
+            let mut terminal = Terminal::new(backend).expect("terminal");
+            let s = state();
+            terminal
+                .draw(|f| draw(f, &s))
+                .unwrap_or_else(|e| panic!("draw failed at {w}x{h}: {e}"));
+        }
+    }
+
+    /// The rendered screen actually shows each setting's label and its on/off
+    /// state — a draw that silently rendered an empty list would still pass a
+    /// no-panic test.
+    #[test]
+    fn draw_shows_labels_and_values() {
+        let backend = ratatui::backend::TestBackend::new(100, 24);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+        let s = state();
+        terminal.draw(|f| draw(f, &s)).expect("draw");
+
+        let rendered: String = terminal
+            .backend()
+            .buffer()
+            .content()
+            .iter()
+            .map(|c| c.symbol())
+            .collect();
+
+        for &id in ALL {
+            assert!(
+                rendered.contains(id.label()),
+                "rendered screen is missing the label {:?}",
+                id.label()
+            );
+        }
+        assert!(
+            rendered.contains("[x]") || rendered.contains("[ ]"),
+            "rendered screen shows no on/off markers"
+        );
     }
 
     /// The screen's settings round-trip through the on-disk format, so a toggle

--- a/src/settings_screen.rs
+++ b/src/settings_screen.rs
@@ -1,0 +1,321 @@
+//! The global-settings screen (#135).
+//!
+//! A modal list of the TUI's **global** preferences — the ones persisted to
+//! `settings.json` — so they are visible, self-describing, and changeable
+//! without knowing a chord. Before this, every preference was a hotkey you had
+//! to already know (`Ctrl+T`, `Ctrl+O`), which does not scale: each new setting
+//! cost another binding in an already-crowded keymap.
+//!
+//! Deliberately scoped to **global** settings. Per-conversation controls (voice
+//! input, Adele output level) are keyed by conversation id and stay as on-the-fly
+//! bindings — showing them here would imply they apply everywhere.
+//!
+//! The state machine below is pure: no terminal, no IO. [`State`] is what the
+//! tests drive; the [`Screen`] impl is a thin shell over it.
+
+use crate::settings::Settings;
+
+/// Which global setting a row edits.
+///
+/// Adding a setting means adding a variant plus its entry in [`ALL`] — the label,
+/// help text, getter and setter all live in one place, so a new preference costs
+/// no keybinding and no screen surgery.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SettingId {
+    /// Render tool/system/empty-assistant messages dimly inline.
+    ShowDebug,
+    /// Share device context (name, username, home, hostname, timezone, OS).
+    ShareClientContext,
+}
+
+/// Every setting the screen shows, in display order.
+pub const ALL: &[SettingId] = &[SettingId::ShowDebug, SettingId::ShareClientContext];
+
+impl SettingId {
+    /// Short label shown in the list.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::ShowDebug => "Show debug messages",
+            Self::ShareClientContext => "Share device info",
+        }
+    }
+
+    /// One-line explanation. This is the whole point of the screen over a
+    /// keybinding: `Ctrl+O` could never convey what it actually shares.
+    pub fn help(self) -> &'static str {
+        match self {
+            Self::ShowDebug => {
+                "Show tool, system and empty assistant messages inline, dimmed, \
+                 instead of hiding them."
+            }
+            Self::ShareClientContext => {
+                "Send your real name, username, home folder, hostname, timezone \
+                 and OS to the assistant so it can personalise replies."
+            }
+        }
+    }
+
+    /// Read this setting's current value.
+    pub fn get(self, settings: &Settings) -> bool {
+        match self {
+            Self::ShowDebug => settings.show_debug,
+            Self::ShareClientContext => settings.share_client_context,
+        }
+    }
+
+    /// Write this setting's value.
+    pub fn set(self, settings: &mut Settings, value: bool) {
+        match self {
+            Self::ShowDebug => settings.show_debug = value,
+            Self::ShareClientContext => settings.share_client_context = value,
+        }
+    }
+}
+
+/// What the screen hands back when it closes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Outcome {
+    /// The user changed something; the caller should apply + persist these.
+    Changed(Settings),
+    /// Nothing changed — the caller can skip the write entirely.
+    Unchanged,
+}
+
+/// Pure screen state: the working copy of the settings, the cursor, and whether
+/// anything has actually changed.
+#[derive(Debug, Clone)]
+pub struct State {
+    settings: Settings,
+    original: Settings,
+    selected: usize,
+    closing: bool,
+}
+
+impl State {
+    /// Open the screen over a copy of the current settings.
+    pub fn new(settings: Settings) -> Self {
+        Self {
+            original: settings.clone(),
+            settings,
+            selected: 0,
+            closing: false,
+        }
+    }
+
+    /// Index of the highlighted row.
+    pub fn selected(&self) -> usize {
+        self.selected
+    }
+
+    /// The working settings, reflecting any toggles made so far.
+    pub fn settings(&self) -> &Settings {
+        &self.settings
+    }
+
+    /// Whether the working copy differs from what the screen opened with. Drives
+    /// [`Outcome`], so an open-and-escape never rewrites `settings.json`.
+    pub fn is_dirty(&self) -> bool {
+        self.settings != self.original
+    }
+
+    /// Current value of the row at `index`, or `None` when out of range.
+    pub fn value_at(&self, index: usize) -> Option<bool> {
+        ALL.get(index).map(|id| id.get(&self.settings))
+    }
+
+    /// Move the cursor down one row, stopping at the last (no wrap: a list this
+    /// short reads better clamped than cycling).
+    pub fn move_down(&mut self) {
+        if self.selected + 1 < ALL.len() {
+            self.selected += 1;
+        }
+    }
+
+    /// Move the cursor up one row, stopping at the first.
+    pub fn move_up(&mut self) {
+        self.selected = self.selected.saturating_sub(1);
+    }
+
+    /// Flip the highlighted setting.
+    pub fn toggle_selected(&mut self) {
+        let Some(&id) = ALL.get(self.selected) else {
+            return;
+        };
+        let next = !id.get(&self.settings);
+        id.set(&mut self.settings, next);
+    }
+
+    /// Ask the screen to close.
+    pub fn close(&mut self) {
+        self.closing = true;
+    }
+
+    /// The outcome once closed, or `None` while still open.
+    pub fn take_outcome(&mut self) -> Option<Outcome> {
+        if !self.closing {
+            return None;
+        }
+        Some(if self.is_dirty() {
+            Outcome::Changed(self.settings.clone())
+        } else {
+            Outcome::Unchanged
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn state() -> State {
+        State::new(Settings::default())
+    }
+
+    /// Every setting in `ALL` renders with a non-empty label and help string.
+    /// The help text is the screen's entire reason to exist over a hotkey, so an
+    /// unexplained setting is a defect, not a cosmetic gap.
+    #[test]
+    fn every_setting_has_a_label_and_help_text() {
+        for &id in ALL {
+            assert!(!id.label().is_empty(), "{id:?} has no label");
+            assert!(
+                id.help().len() > 20,
+                "{id:?} help text is too thin to explain the setting: {:?}",
+                id.help()
+            );
+        }
+    }
+
+    /// Toggling flips only the highlighted setting, and leaves its neighbours
+    /// alone — the obvious off-by-one this screen could have.
+    #[test]
+    fn toggle_flips_only_the_selected_row() {
+        let mut s = state();
+        let before: Vec<bool> = (0..ALL.len()).map(|i| s.value_at(i).unwrap()).collect();
+
+        s.toggle_selected();
+
+        assert_eq!(
+            s.value_at(0).unwrap(),
+            !before[0],
+            "the selected row must flip"
+        );
+        for i in 1..ALL.len() {
+            assert_eq!(
+                s.value_at(i).unwrap(),
+                before[i],
+                "row {i} must be untouched when row 0 is toggled"
+            );
+        }
+    }
+
+    /// The cursor clamps at both ends rather than wrapping or running past the
+    /// list (which would panic on `value_at` or silently toggle nothing).
+    #[test]
+    fn cursor_clamps_at_both_ends() {
+        let mut s = state();
+        s.move_up();
+        assert_eq!(s.selected(), 0, "up from the first row stays at the first");
+
+        for _ in 0..ALL.len() * 2 {
+            s.move_down();
+        }
+        assert_eq!(
+            s.selected(),
+            ALL.len() - 1,
+            "down past the end stays on the last row"
+        );
+        assert!(
+            s.value_at(s.selected()).is_some(),
+            "the clamped cursor must still address a real row"
+        );
+    }
+
+    /// Opening and closing without touching anything reports `Unchanged`, so the
+    /// caller skips the file write. A screen that always saved would rewrite
+    /// settings.json on every glance.
+    #[test]
+    fn untouched_screen_closes_unchanged() {
+        let mut s = state();
+        s.close();
+        assert_eq!(s.take_outcome(), Some(Outcome::Unchanged));
+    }
+
+    /// A real change is reported with the updated settings.
+    #[test]
+    fn changed_screen_returns_the_new_settings() {
+        let mut s = state();
+        let before = s.settings().show_debug;
+        s.toggle_selected();
+        s.close();
+
+        match s.take_outcome() {
+            Some(Outcome::Changed(settings)) => {
+                assert_eq!(settings.show_debug, !before, "the flip must be carried out");
+            }
+            other => panic!("expected Changed, got {other:?}"),
+        }
+    }
+
+    /// Toggling a setting and toggling it back is not a change — the outcome is
+    /// value-based, not "did the user press anything".
+    #[test]
+    fn toggling_back_to_the_original_is_not_a_change() {
+        let mut s = state();
+        s.toggle_selected();
+        s.toggle_selected();
+        s.close();
+        assert_eq!(
+            s.take_outcome(),
+            Some(Outcome::Unchanged),
+            "a net-zero edit must not trigger a save"
+        );
+    }
+
+    /// While open, there is no outcome — the driver keeps looping.
+    #[test]
+    fn no_outcome_until_closed() {
+        let mut s = state();
+        s.toggle_selected();
+        assert_eq!(s.take_outcome(), None, "an open screen has no outcome");
+    }
+
+    /// Every setting is individually reachable and toggleable, so none is
+    /// stranded by a cursor that cannot reach it.
+    #[test]
+    fn every_setting_is_reachable_and_toggleable() {
+        for target in 0..ALL.len() {
+            let mut s = state();
+            for _ in 0..target {
+                s.move_down();
+            }
+            assert_eq!(s.selected(), target);
+            let before = s.value_at(target).unwrap();
+            s.toggle_selected();
+            assert_eq!(
+                s.value_at(target).unwrap(),
+                !before,
+                "row {target} must be toggleable"
+            );
+        }
+    }
+
+    /// The screen's settings round-trip through the on-disk format, so a toggle
+    /// made here survives a restart.
+    #[test]
+    fn changed_settings_round_trip_through_disk() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("settings.json");
+
+        let mut s = state();
+        s.toggle_selected();
+        s.close();
+        let Some(Outcome::Changed(changed)) = s.take_outcome() else {
+            panic!("expected a change");
+        };
+        changed.save_to(&path).expect("save");
+
+        let loaded = Settings::load_from(&path);
+        assert_eq!(loaded, changed, "settings must survive a save/load cycle");
+    }
+}

--- a/src/settings_screen.rs
+++ b/src/settings_screen.rs
@@ -200,10 +200,10 @@ mod tests {
             !before[0],
             "the selected row must flip"
         );
-        for i in 1..ALL.len() {
+        for (i, &was) in before.iter().enumerate().skip(1) {
             assert_eq!(
                 s.value_at(i).unwrap(),
-                before[i],
+                was,
                 "row {i} must be untouched when row 0 is toggled"
             );
         }

--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -555,6 +555,8 @@ mod tests {
             children: Vec::new(),
             title: title.into(),
             progress_hint: None,
+            owner_todo: String::new(),
+            spawn_marker: None,
         }
     }
 
@@ -805,6 +807,7 @@ mod tests {
         let v = TaskView {
             id: TaskId("t-1".into()),
             kind: TaskKind::Subagent {
+                session_conversation_id: String::new(),
                 parent_task_id: TaskId("parent".into()),
                 conversation_id: "subagent-conv".into(),
                 name: "child".into(),
@@ -817,6 +820,8 @@ mod tests {
             children: Vec::new(),
             title: "child".into(),
             progress_hint: None,
+            owner_todo: String::new(),
+            spawn_marker: None,
         };
         let row = TaskRow::from_view(&v);
         assert_eq!(row.conversation_id.as_deref(), Some("subagent-conv"));
@@ -843,6 +848,8 @@ mod tests {
             children: Vec::new(),
             title: "Chatting".into(),
             progress_hint: None,
+            owner_todo: String::new(),
+            spawn_marker: None,
         };
         assert_eq!(TaskRow::from_view(&conv).kind_label, "Chat");
 
@@ -850,6 +857,7 @@ mod tests {
         let sub = TaskView {
             id: TaskId("t-3".into()),
             kind: TaskKind::Subagent {
+                session_conversation_id: String::new(),
                 parent_task_id: TaskId("parent".into()),
                 conversation_id: "sub-conv".into(),
                 name: "child".into(),
@@ -862,6 +870,8 @@ mod tests {
             children: Vec::new(),
             title: "child".into(),
             progress_hint: None,
+            owner_todo: String::new(),
+            spawn_marker: None,
         };
         assert_eq!(TaskRow::from_view(&sub).kind_label, "Subagent");
     }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -785,6 +785,7 @@ mod tests {
                     content: "Hello".into(),
                     kind: crate::app::MessageKind::Normal,
                     idempotency_key: None,
+                    created_at_ms: None,
                 },
                 ChatMessage {
                     id: String::new(),
@@ -792,6 +793,7 @@ mod tests {
                     content: "Hi there!".into(),
                     kind: crate::app::MessageKind::Normal,
                     idempotency_key: None,
+                    created_at_ms: None,
                 },
             ],
             model_selection: None,
@@ -1121,6 +1123,7 @@ mod tests {
                     content: "Hello".into(),
                     kind: crate::app::MessageKind::Normal,
                     idempotency_key: None,
+                    created_at_ms: None,
                 },
                 ChatMessage {
                     id: String::new(),
@@ -1128,6 +1131,7 @@ mod tests {
                     content: "ran search(foo)".into(),
                     kind: crate::app::MessageKind::Normal,
                     idempotency_key: None,
+                    created_at_ms: None,
                 },
                 ChatMessage {
                     id: String::new(),
@@ -1135,6 +1139,7 @@ mod tests {
                     content: "context updated".into(),
                     kind: crate::app::MessageKind::Normal,
                     idempotency_key: None,
+                    created_at_ms: None,
                 },
                 ChatMessage {
                     id: String::new(),
@@ -1142,6 +1147,7 @@ mod tests {
                     content: "".into(), // empty — only shown in debug
                     kind: crate::app::MessageKind::Normal,
                     idempotency_key: None,
+                    created_at_ms: None,
                 },
                 ChatMessage {
                     id: String::new(),
@@ -1149,6 +1155,7 @@ mod tests {
                     content: "Hi there!".into(),
                     kind: crate::app::MessageKind::Normal,
                     idempotency_key: None,
+                    created_at_ms: None,
                 },
             ],
             model_selection: None,
@@ -1262,6 +1269,7 @@ mod tests {
                 content: "answer with **strong** word".into(),
                 kind: crate::app::MessageKind::Normal,
                 idempotency_key: None,
+                created_at_ms: None,
             }],
             model_selection: None,
             conversation_personality: None,


### PR DESCRIPTION
Closes #135. Closes #137.

Four commits, each standalone. Requires adelie-ai/voice#134 (merged).

## Settings screen (F6)

A modal list of the client-local **global** settings, each with a live on/off marker and a sentence explaining what it does. That explanation is the entire justification for the screen over a hotkey: `Ctrl+O` could never convey that "share device info" means sending your **real name, username, home folder, hostname, timezone and OS**.

Unlike every other screen it takes no connection gate — these settings are local, so it works just as well (arguably better) while disconnected.

`SettingId` is a declarative table of label / help / getter / setter, so adding a preference is one variant plus one list entry — **no keybinding, no screen surgery**. That is the point: `mouse_enabled` (#133) and everything after it now cost nothing.

## Keymap paydown

**Retired** `Ctrl+T` (debug messages) and `Ctrl+O` (share device info). Both edit persisted global preferences — set once, then forgotten — which is what a screen is for. Per the rule we settled on: a binding is for something you'd do *on the fly, fairly regularly*. Spending scarce keys on set-once toggles is what crowded the keymap.

**Rebound** voice: `Ctrl+S`/`Ctrl+V` → `Alt+S`/`Alt+V`. These stay bindings, because they are **per-conversation** — switching voice on for *this* chat genuinely is on-the-fly. But their Ctrl homes were inherited-convention collisions: `Ctrl+V` is paste in most GUI apps (and readline's quoted-insert), `Ctrl+S` is XOFF on some terminals. Alt was nearly untouched here, so the V-for-voice / S-for-sound mnemonics survive with nothing to collide with.

Worth noting this **corrects the original plan on #135**, which had grouped all four toggles together. Checking the code first showed `voice_in`/`adele_output` are keyed by `conversation_id`; listing them on a *global* settings screen would have implied they apply everywhere. So #137 needed a rebind, not a removal.

`help_sections()` remains the single source of truth and is updated in step.

## Also: macOS builds work now

`ort` ships no prebuilt ONNX Runtime for `x86_64-apple-darwin`, and `vad-silero` is an unconditional dep of `adele-voice-module` — so **the whole crate failed to build on an Intel Mac**, blocking any work at all, voice-related or not. Opting into `load-dynamic` under `[target.'cfg(target_os = "macos")']` fixes it; Linux resolves an identical dependency graph.

That also surfaced latent breakage nobody could see *because* the crate never compiled here: test fixtures had drifted from `api-model` (`owner_todo`, `spawn_marker`, `session_conversation_id`, `notices`, `created_at_ms`). Fixed in their own commit.

## Testing

**514 pass**, clippy `-D warnings` and fmt clean.

The load-bearing tests are the **negative** ones — `retired_preference_chords_are_unbound` and `colliding_ctrl_voice_chords_stay_unbound` — because a rebind only holds for as long as nobody quietly reinstates the old chord.

Screen coverage: Space *and* Enter toggle, arrows *and* vim keys navigate, Esc *and* q close, unbound keys are inert (this screen mutates persisted settings, so a stray keystroke silently flipping one is the failure worth pinning), open-and-close reports `Unchanged` so a glance never rewrites `settings.json`, toggle-and-toggle-back is likewise not a change, draw survives down to a 10x3 terminal, and draw actually renders the labels and markers rather than an empty list.

## Not included

- The `F3`/`F4`/`F5`/`Ctrl+R` consolidation (config screens as settings sections) — flagged on #135 as a deliberate decision, deserves its own change.
- #136 (help screen) — unaffected by this beyond the updated table.
- A flaky `picker` test found while running the suite is filed separately as #138; it is pre-existing and unrelated (shared on-disk profile store, ~1 failure in 3 runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)