### PR TITLE
fix(tasks): set TaskKind::Subagent::notify_parent in test fixtures

### DIFF
--- a/src/tasks.rs
+++ b/src/tasks.rs
@@ -808,6 +808,7 @@ mod tests {
             id: TaskId("t-1".into()),
             kind: TaskKind::Subagent {
                 session_conversation_id: String::new(),
+                notify_parent: false,
                 parent_task_id: TaskId("parent".into()),
                 conversation_id: "subagent-conv".into(),
                 name: "child".into(),
@@ -858,6 +859,7 @@ mod tests {
             id: TaskId("t-3".into()),
             kind: TaskKind::Subagent {
                 session_conversation_id: String::new(),
+                notify_parent: false,
                 parent_task_id: TaskId("parent".into()),
                 conversation_id: "sub-conv".into(),
                 name: "child".into(),


### PR DESCRIPTION
desktop-assistant #929 added `notify_parent` to `TaskKind::Subagent`, so a blocking `spawn_subagent { wait: true }` no longer triggers a second, unrequested wake turn on the parent.

The field is `#[serde(default)]`, so the wire format stays backward compatible and no persisted row breaks. Rust struct-variant initializers must name it, though, and this repo constructs the variant in its test fixtures, so `cargo test` stopped compiling against current desktop-assistant main.

Only fixtures are affected. Every production path here matches with `..` and needed no change.

## Testing

`just check` green in a worktree, zero warnings. No behaviour change: the fixtures set `notify_parent: false`, which is the variant default and matches the pre-existing behaviour they were written to pin.