### PR TITLE
fix(config): set McpServerConfig::inherit_env, unbreaking main

### DIFF
--- a/src/config_cmd.rs
+++ b/src/config_cmd.rs
@@ -216,6 +216,13 @@ pub fn mcp_add_server(
     // The definition is always enabled at the definition level (the surface
     // enable list is the on/off switch the `enable`/`disable` subcommands drive);
     // `--enabled` decides whether it is turned on for the given surface(s) now.
+    //
+    // `env`, `env_secrets`, and `inherit_env` are empty because this subcommand
+    // takes no flag for any of them. `inherit_env` names the host-environment
+    // variables one server may inherit, so an empty list is also the value that
+    // keeps the spawned child isolated: it receives only the small global
+    // allowlist. An operator who needs a wider environment edits
+    // `client-mcp.toml` directly, the same way they must for `env`.
     let server = McpServerConfig {
         name: name.to_string(),
         command: command.to_string(),
@@ -224,6 +231,7 @@ pub fn mcp_add_server(
         enabled: true,
         env: HashMap::new(),
         env_secrets: HashMap::new(),
+        inherit_env: Vec::new(),
         http: None,
         description: None,
     };
@@ -430,6 +438,44 @@ mod tests {
         assert!(
             listed.contains("enabled"),
             "an added+enabled server lists as enabled: {listed}"
+        );
+    }
+
+    /// `add-server` takes no environment flag, so the definition it writes must
+    /// grant the spawned child nothing beyond the host's global allowlist. An
+    /// empty `inherit_env` is what keeps that isolation; a later edit that fills
+    /// it in by default would widen every CLI-created server at once.
+    #[test]
+    fn add_server_grants_no_environment_inheritance() {
+        let (_dir, path) = temp_cfg();
+        mcp_add_server(
+            &path,
+            "notes",
+            "notes-mcp",
+            &[],
+            None,
+            &["tui".to_string()],
+            true,
+            &mut Vec::new(),
+        )
+        .expect("add");
+
+        let cfg = ClientMcpConfig::load(&path);
+        let server = cfg
+            .list_defined_servers()
+            .iter()
+            .find(|s| s.name == "notes")
+            .expect("notes server defined after add")
+            .clone();
+        assert!(
+            server.inherit_env.is_empty(),
+            "add-server grants no host-environment inheritance, got {:?}",
+            server.inherit_env
+        );
+        assert!(server.env.is_empty(), "add-server sets no env");
+        assert!(
+            server.env_secrets.is_empty(),
+            "add-server sets no env secrets"
         );
     }
 


### PR DESCRIPTION
## The break

`main` does not build.

```
error[E0063]: missing field `inherit_env` in initializer of `McpServerConfig`
   --> src/config_cmd.rs:219:18
    |
219 |     let server = McpServerConfig {
    |                  ^^^^^^^^^^^^^^^ missing `inherit_env`
```

## The cause

desktop-assistant PR #964 (issue #910) env-isolates spawned stdio MCP children. It calls `Command::env_clear()`, passes a small global allowlist, then applies the server's own `env`/`env_secrets`. Two variables that some servers genuinely need -- `XDG_RUNTIME_DIR` and `DBUS_SESSION_BUS_ADDRESS` -- are also how a stock D-Bus library finds the session bus, which fronts the Secret Service that holds connector API keys and MCP OAuth tokens. Granting them globally would give every spawned server, including a third-party one, a route to the credential store.

So that PR added a per-server opt-in instead: `McpServerConfig::inherit_env: Vec<String>` names the variables one specific server may inherit from the host process.

`McpServerConfig` does not derive `Default`. Any construction that names its fields explicitly must now name the new one. This repo has exactly one such site, and it is production code.

## The change

One site: `mcp_add_server` in `src/config_cmd.rs`, the `adele config mcp add-server` subcommand handler.

**Value: empty (`Vec::new()`).** Two reasons.

1. This subcommand takes no environment flag. It builds a server definition from CLI arguments alone (`--name`, `--command`, `--args`, `--namespace`, `--surfaces`, `--enabled`), and it already sets `env` and `env_secrets` to empty for exactly that reason. `inherit_env` matches its two siblings, so this is the field's existing support level rather than a new gap. An operator who needs a wider environment edits `client-mcp.toml` directly, the same way they must for `env`.
2. Empty is the isolating value. The field exists to keep a spawned child's environment narrow, so anything non-empty here would widen every server this subcommand creates.

Nothing is wired through, because nothing parses a config at this site. The definition comes from CLI flags, not from a file that could carry an `inherit_env` list.

## Test

`config_cmd::tests::add_server_grants_no_environment_inheritance` asserts the written definition has an empty `inherit_env` (and empty `env`/`env_secrets`). Confirmed it goes red for the wrong value, not just green by default: setting `inherit_env: vec!["DBUS_SESSION_BUS_ADDRESS".to_string()]` fails it with

```
add-server grants no host-environment inheritance, got ["DBUS_SESSION_BUS_ADDRESS"]
test result: FAILED. 0 passed; 1 failed
```

The red for the fix itself is the E0063 above, reproduced on unmodified `origin/main` before any edit.

## No lockfile change

`Cargo.toml` declares `desktop-assistant-client-common` as a git dependency on `branch = "main"`, but the `[patch."https://github.com/adelie-ai/desktop-assistant.git"]` block redirects it to `../desktop-assistant`. `Cargo.lock` therefore carries no git source for it (`grep -c 'desktop-assistant.git' Cargo.lock` is 0), and the break reproduces from the local checkout with no `cargo update`.

## Gate

`just check` (fmt-check, clippy `-D warnings` all-targets, build, test) as one blocking call with the exit code captured in the same invocation:

```
$ just check > tui-check-final.log 2>&1; echo "TUI_CHECK_EXIT=$?"
TUI_CHECK_EXIT=0
```

```
test config_cmd::tests::add_server_grants_no_environment_inheritance ... ok
test result: ok. 519 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out
test result: ok. 36 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## Scope

Only the compile break. One pre-existing behaviour noticed and filed rather than fixed here: #148.

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VAafhZphAVDuzkYh316j3v
