### PR TITLE
docs+chore: correct the board states in AGENTS.md 9.1, and ignore *.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /target
+
+# Gate and build output, never committed.
+*.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,8 +90,10 @@ This group runs it with its own tooling:
 ### 9.1 Tracker for this project
 
 GitHub Issues on `github.com/adelie-ai/adele-tui`, together with the shared `adelie-ai` project
-board. Manage entries with the `gh` CLI (`gh issue create`, `gh issue list`, `gh issue edit`,
-`gh pr create`). The board states in use are In Progress, In Review, and Done.
+board `Adelie AI Roadmap` (project number 1). Manage entries with the `gh` CLI
+(`gh issue create`, `gh issue list`, `gh issue edit`, `gh pr create`). Put a new issue on the
+board with `gh project item-add 1 --owner adelie-ai --url <issue-url>`, which lands it in
+Todo. The board states are Todo, In Progress, and Done.
 
 ### Platform, not a single product (addition)
 


### PR DESCRIPTION
Two independent hygiene fixes, one commit each.

**`docs: name the board states that the board actually has`** - section 9.1 said the board
states in use were In Progress, In Review and Done. The shared board (`Adelie AI Roadmap`,
project number 1) has Todo, In Progress and Done. There is no In Review option, and Todo was
missing from the text. The paragraph now also names the board and gives the
`gh project item-add` command, because a ticket that never reaches the board is the failure
that section exists to prevent. Refs adelie-ai/mcp-core#41

**`chore: ignore *.log`** - a gate run that redirected output into the working tree left
`gate.log` committed in 14 repos, each copy carrying the absolute worktree path of the machine
that produced it, which rule 5.2 forbids. Removed at HEAD where tracked, and `*.log` is now
ignored so the next gate run cannot repeat it. Refs adelie-ai/mcp-core#42

Removal is at HEAD only. The paths stay reachable in history, per the 2026-07-03 decision not
to rewrite adelie-ai history for local paths and RFC1918 hosts.

Docs and `.gitignore` only. No code, no dependency, no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NwX3UBag8yDp9Bm9BdpqTo
