### PR TITLE
fix: add tool_gate_disabled to ConversationDetail literals for desktop-assistant#1008

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1583,6 +1583,7 @@ mod tests {
             messages: vec![],
             model_selection: None,
             conversation_personality: None,
+            tool_gate_disabled: false,
         });
         let typed = "alpha beta gamma delta epsilon zeta eta theta iota kappa";
         app.textarea.insert_str(typed);
@@ -1628,6 +1629,7 @@ mod tests {
             messages: vec![],
             model_selection: None,
             conversation_personality: None,
+            tool_gate_disabled: false,
         });
         let typed = "first paragraph here\nsecond paragraph here";
         app.textarea.insert_str(typed);
@@ -2037,6 +2039,7 @@ mod tests {
             messages: vec![],
             model_selection: None,
             conversation_personality: None,
+            tool_gate_disabled: false,
         });
         app.enter_editing_mode();
         app.apply_paste("first\nsecond\nthird");
@@ -2101,6 +2104,7 @@ mod tests {
             messages: vec![],
             model_selection: None,
             conversation_personality: None,
+            tool_gate_disabled: false,
         }
     }
 
@@ -2415,6 +2419,7 @@ mod tests {
             messages: vec![],
             model_selection: None,
             conversation_personality: None,
+            tool_gate_disabled: false,
         });
         app.apply_prompt_ack("t-1".into(), "c1".into());
         assert_eq!(app.assistant_status.as_deref(), Some("Adele is thinking…"));
@@ -2503,6 +2508,7 @@ mod tests {
             ],
             model_selection: None,
             conversation_personality: None,
+            tool_gate_disabled: false,
         });
 
         // Refetched list: "1" was renamed and "3" was deleted elsewhere; "2"
@@ -2557,6 +2563,7 @@ mod tests {
             messages: vec![],
             model_selection: None,
             conversation_personality: None,
+            tool_gate_disabled: false,
         });
 
         let deleted = app.delete_selected_conversation();
@@ -2659,6 +2666,7 @@ mod tests {
             messages: vec![],
             model_selection: None,
             conversation_personality: None,
+            tool_gate_disabled: false,
         });
 
         app.apply_rename("2", "Renamed Second");
@@ -2789,6 +2797,7 @@ mod tests {
             messages: vec![],
             model_selection: None,
             conversation_personality: None,
+            tool_gate_disabled: false,
         });
         app.apply_rename("2", "Renamed");
         assert_eq!(app.conversations()[1].title, "Renamed");
@@ -2838,6 +2847,7 @@ mod tests {
             messages: vec![],
             model_selection: None,
             conversation_personality: None,
+            tool_gate_disabled: false,
         });
         let ovr = desktop_assistant_api_model::SendPromptOverride {
             connection_id: "work".into(),
@@ -3058,6 +3068,7 @@ mod tests {
             messages: vec![],
             model_selection: None,
             conversation_personality: None,
+            tool_gate_disabled: false,
         });
         app
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3394,6 +3394,7 @@ mod tests {
             messages: vec![],
             model_selection: None,
             conversation_personality: None,
+            tool_gate_disabled: false,
         }
     }
 

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -798,6 +798,7 @@ mod tests {
             ],
             model_selection: None,
             conversation_personality: None,
+            tool_gate_disabled: false,
         });
         terminal.draw(|f| draw(f, &mut app)).unwrap();
     }
@@ -827,6 +828,7 @@ mod tests {
             messages: vec![],
             model_selection: None,
             conversation_personality: None,
+            tool_gate_disabled: false,
         });
 
         // Disabled (default): no "Adele:" cue in the title.
@@ -860,6 +862,7 @@ mod tests {
             messages: vec![],
             model_selection: None,
             conversation_personality: None,
+            tool_gate_disabled: false,
         });
 
         // Disabled (default): no "You:" cue in the title.
@@ -885,6 +888,7 @@ mod tests {
             messages: vec![],
             model_selection: None,
             conversation_personality: None,
+            tool_gate_disabled: false,
         });
         app.apply_prompt_ack("task1".into(), "1".into());
         app.apply_core(UiMessage::StreamChunk {
@@ -1160,6 +1164,7 @@ mod tests {
             ],
             model_selection: None,
             conversation_personality: None,
+            tool_gate_disabled: false,
         });
         app
     }
@@ -1205,6 +1210,7 @@ mod tests {
             messages: vec![],
             model_selection: None,
             conversation_personality: None,
+            tool_gate_disabled: false,
         });
         app.set_assistant_status("Searching knowledge base...");
         terminal.draw(|f| draw(f, &mut app)).unwrap();
@@ -1273,6 +1279,7 @@ mod tests {
             }],
             model_selection: None,
             conversation_personality: None,
+            tool_gate_disabled: false,
         });
         terminal.draw(|f| draw(f, &mut app)).unwrap();
         let buf = terminal.backend().buffer().clone();


### PR DESCRIPTION
## Summary

desktop-assistant#1008 (not yet merged, branch `issue-1007-tool-gate-override`) adds a `tool_gate_disabled` field to `ConversationDetail`. This is the mechanical compile fix for adele-tui: the new field, added at every explicit-field-list construction site.

**blocked-by desktop-assistant#1008 - do not merge this until #1008 merges to desktop-assistant's `main`.**

## Scope

Purely mechanical. No UI feature to expose or toggle the setting - that is tracked separately (adele-tui#154).

## Sites touched

Search method: `grep -rn "ConversationDetail\s*{"` across the whole repo (2 independent passes, plus a search for local type aliases/re-exports - none found), cross-checked against the count of `conversation_personality:` field occurrences (the neighboring field mirrored at every site). Both methods agree on the same 19 sites:

- `src/app.rs` - 11 sites
- `src/main.rs` - 1 site
- `src/ui.rs` - 7 sites

All 19 are test fixtures constructing a fresh `ConversationDetail`; every one already set `conversation_personality: None,` (no forwarding anywhere in this repo), so every site got `tool_gate_disabled: false,` immediately after it, matching that pattern exactly.

Note: an earlier grep pass (mine) found only 3 of these sites; a second pass by another reviewer found 21 grep hits. The true count is 19 - 21 minus 2 false positives, since two of those grep hits are `fn detail(id: &str) -> ConversationDetail {` function signatures whose trailing `{` is the function body brace, not a struct literal.

## Verification

Run from a worktree with `../desktop-assistant` symlinked to the #1008 branch worktree (see dependency-mechanism note below):

- `cargo build --all-targets` - clean, zero errors.
- `cargo test --all-targets --no-run` - clean, zero errors, zero "missing field `tool_gate_disabled`" errors.
- `just check` (fmt-check, `cargo clippy --all-targets -- -D warnings`, build, test) - exit 0. 520+36+4 = 560 tests passed, 0 failed.
- Re-verified again by the pre-push hook on `git push` (same result).

## Dependency-mechanism note

This repo does not build against a git-rev-pinned copy of desktop-assistant despite `Cargo.toml` declaring `desktop-assistant-api-model = { git = "...", branch = "main" }`. A committed `[patch]` block unconditionally overrides that to `{ path = "../desktop-assistant/crates/..." }` - a path dependency on a sibling checkout. There is nothing to bump in `Cargo.lock`. Once desktop-assistant#1008 merges and the primary `~/Projects/adelie-ai/desktop-assistant` checkout there is updated to `main`, no further Cargo.lock or dependency change is needed in this repo at all.

## Test plan

- [x] `cargo build --all-targets` clean
- [x] `cargo test --all-targets --no-run` clean
- [x] `just check` green
- [ ] Merge only after desktop-assistant#1008 merges to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sg8yvx3atBTGjvYBkHE7bx