### PR TITLE
Knowledge browser rows show the entry summary

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1207,6 +1207,7 @@ impl Default for App {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_fixtures::{chat_message, conversation_detail, conversation_summary};
 
     // --- Context-usage indicator (#341) ---
 
@@ -1378,22 +1379,18 @@ mod tests {
     fn sample_conversations() -> Vec<ConversationSummary> {
         vec![
             ConversationSummary {
-                id: "1".into(),
                 title: "First".into(),
                 message_count: 2,
-                archived: false,
+                ..conversation_summary("1")
             },
             ConversationSummary {
-                id: "2".into(),
                 title: "Second".into(),
-                message_count: 0,
-                archived: false,
+                ..conversation_summary("2")
             },
             ConversationSummary {
-                id: "3".into(),
                 title: "Third".into(),
                 message_count: 5,
-                archived: false,
+                ..conversation_summary("3")
             },
         ]
     }
@@ -1470,10 +1467,8 @@ mod tests {
     fn single_item_next_stays() {
         let mut app = App::new();
         app.set_conversations(vec![ConversationSummary {
-            id: "1".into(),
             title: "Only".into(),
-            message_count: 0,
-            archived: false,
+            ..conversation_summary("1")
         }]);
         app.selected_conversation = Some(0);
         app.next_conversation();
@@ -1578,12 +1573,8 @@ mod tests {
     fn submit_prompt_sends_unwrapped_text_after_display_wrap() {
         let mut app = App::new();
         app.load_conversation(ConversationDetail {
-            id: "c1".into(),
             title: "t".into(),
-            messages: vec![],
-            model_selection: None,
-            conversation_personality: None,
-            tool_gate_disabled: false,
+            ..conversation_detail("c1")
         });
         let typed = "alpha beta gamma delta epsilon zeta eta theta iota kappa";
         app.textarea.insert_str(typed);
@@ -1624,12 +1615,8 @@ mod tests {
     fn submit_prompt_preserves_explicit_user_newlines() {
         let mut app = App::new();
         app.load_conversation(ConversationDetail {
-            id: "c1".into(),
             title: "t".into(),
-            messages: vec![],
-            model_selection: None,
-            conversation_personality: None,
-            tool_gate_disabled: false,
+            ..conversation_detail("c1")
         });
         let typed = "first paragraph here\nsecond paragraph here";
         app.textarea.insert_str(typed);
@@ -2034,12 +2021,8 @@ mod tests {
         // the newlines intact, not three partial prompts.
         let mut app = App::new();
         app.load_conversation(ConversationDetail {
-            id: "c1".into(),
             title: "Test".into(),
-            messages: vec![],
-            model_selection: None,
-            conversation_personality: None,
-            tool_gate_disabled: false,
+            ..conversation_detail("c1")
         });
         app.enter_editing_mode();
         app.apply_paste("first\nsecond\nthird");
@@ -2097,16 +2080,7 @@ mod tests {
 
     // --- Conversation-id threading (TUI-4) + disconnect reset (TUI-8) ---
 
-    fn detail(id: &str) -> ConversationDetail {
-        ConversationDetail {
-            id: id.into(),
-            title: format!("Conv {id}"),
-            messages: vec![],
-            model_selection: None,
-            conversation_personality: None,
-            tool_gate_disabled: false,
-        }
-    }
+    use crate::test_fixtures::conversation_detail as detail;
 
     // These exercise the TUI's *integration* with the shared core — that
     // `apply_core` applies the reducer's streaming effects onto `App`'s own
@@ -2414,12 +2388,8 @@ mod tests {
         // "thinking" cue so there's no dead air after pressing Enter.
         let mut app = App::new();
         app.load_conversation(ConversationDetail {
-            id: "c1".into(),
             title: "Test".into(),
-            messages: vec![],
-            model_selection: None,
-            conversation_personality: None,
-            tool_gate_disabled: false,
+            ..conversation_detail("c1")
         });
         app.apply_prompt_ack("t-1".into(), "c1".into());
         assert_eq!(app.assistant_status.as_deref(), Some("Adele is thinking…"));
@@ -2460,10 +2430,8 @@ mod tests {
         let mut app = app_with_conversations();
         app.selected_conversation = Some(2);
         app.set_conversations(vec![ConversationSummary {
-            id: "1".into(),
             title: "Only".into(),
-            message_count: 0,
-            archived: false,
+            ..conversation_summary("1")
         }]);
         assert_eq!(app.selected_conversation, Some(0));
     }
@@ -2486,45 +2454,36 @@ mod tests {
         let mut app = app_with_conversations();
         app.selected_conversation = Some(1);
         app.load_conversation(ConversationDetail {
-            id: "2".into(),
             title: "Second".into(),
             messages: vec![
                 ChatMessage {
                     id: "m1".into(),
                     role: "user".into(),
                     content: "hello".into(),
-                    kind: crate::app::MessageKind::Normal,
-                    idempotency_key: None,
-                    created_at_ms: None,
+                    ..chat_message()
                 },
                 ChatMessage {
                     id: "m2".into(),
                     role: "assistant".into(),
                     content: "hi there".into(),
-                    kind: crate::app::MessageKind::Normal,
-                    idempotency_key: None,
-                    created_at_ms: None,
+                    ..chat_message()
                 },
             ],
-            model_selection: None,
-            conversation_personality: None,
-            tool_gate_disabled: false,
+            ..conversation_detail("2")
         });
 
         // Refetched list: "1" was renamed and "3" was deleted elsewhere; "2"
         // (the open one) survives.
         let effects = app.apply_core(UiMessage::ConversationListRefetched(vec![
             ConversationSummary {
-                id: "1".into(),
                 title: "First (renamed elsewhere)".into(),
                 message_count: 3,
-                archived: false,
+                ..conversation_summary("1")
             },
             ConversationSummary {
-                id: "2".into(),
                 title: "Second".into(),
                 message_count: 2,
-                archived: false,
+                ..conversation_summary("2")
             },
         ]));
         assert!(
@@ -2558,12 +2517,8 @@ mod tests {
         // `load_conversation` (not a raw field write) so core's open-conversation
         // id is set — the reducer's delete keys its "clear the open chat" on it.
         app.load_conversation(ConversationDetail {
-            id: "2".into(),
             title: "Second".into(),
-            messages: vec![],
-            model_selection: None,
-            conversation_personality: None,
-            tool_gate_disabled: false,
+            ..conversation_detail("2")
         });
 
         let deleted = app.delete_selected_conversation();
@@ -2661,12 +2616,8 @@ mod tests {
     fn rename_routes_through_core_and_refreshes_the_open_title() {
         let mut app = app_with_conversations();
         app.load_conversation(ConversationDetail {
-            id: "2".into(),
             title: "Second".into(),
-            messages: vec![],
-            model_selection: None,
-            conversation_personality: None,
-            tool_gate_disabled: false,
+            ..conversation_detail("2")
         });
 
         app.apply_rename("2", "Renamed Second");
@@ -2692,10 +2643,8 @@ mod tests {
     fn delete_only_item_clears_selection() {
         let mut app = App::new();
         app.set_conversations(vec![ConversationSummary {
-            id: "1".into(),
             title: "Only".into(),
-            message_count: 0,
-            archived: false,
+            ..conversation_summary("1")
         }]);
         app.selected_conversation = Some(0);
 
@@ -2792,12 +2741,8 @@ mod tests {
     fn apply_rename_updates_sidebar_and_current() {
         let mut app = app_with_conversations();
         app.load_conversation(ConversationDetail {
-            id: "2".into(),
             title: "Second".into(),
-            messages: vec![],
-            model_selection: None,
-            conversation_personality: None,
-            tool_gate_disabled: false,
+            ..conversation_detail("2")
         });
         app.apply_rename("2", "Renamed");
         assert_eq!(app.conversations()[1].title, "Renamed");
@@ -2842,12 +2787,8 @@ mod tests {
     fn apply_model_override_updates_current_conversation_and_stages_pending() {
         let mut app = App::new();
         app.load_conversation(ConversationDetail {
-            id: "c1".into(),
             title: "Chat".into(),
-            messages: vec![],
-            model_selection: None,
-            conversation_personality: None,
-            tool_gate_disabled: false,
+            ..conversation_detail("c1")
         });
         let ovr = desktop_assistant_api_model::SendPromptOverride {
             connection_id: "work".into(),
@@ -2974,16 +2915,12 @@ mod tests {
         let mut app = App::new();
         app.set_conversations(vec![
             ConversationSummary {
-                id: "conv-1".into(),
                 title: "Other".into(),
-                message_count: 0,
-                archived: false,
+                ..conversation_summary("conv-1")
             },
             ConversationSummary {
-                id: "conv-x".into(),
                 title: "Linked".into(),
-                message_count: 0,
-                archived: false,
+                ..conversation_summary("conv-x")
             },
         ]);
         app.tasks
@@ -3063,12 +3000,8 @@ mod tests {
         let mut app = App::new();
         // Via `load_conversation` so core's open-conversation id is dual-written.
         app.load_conversation(ConversationDetail {
-            id: id.into(),
             title: "Chat".into(),
-            messages: vec![],
-            model_selection: None,
-            conversation_personality: None,
-            tool_gate_disabled: false,
+            ..detail(id)
         });
         app
     }

--- a/src/kb.rs
+++ b/src/kb.rs
@@ -35,7 +35,7 @@
 use std::{io, time::Duration};
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-use desktop_assistant_api_model::{KnowledgeEntryView, MaintenanceOp};
+use desktop_assistant_api_model::{KnowledgeEntryView, MaintenanceOp, SUMMARY_MAX_CHARS};
 use desktop_assistant_client_common::{AssistantClient, SignalEvent, TransportClient};
 use ratatui::{
     Frame, Terminal,
@@ -53,6 +53,15 @@ use crate::screen::Screen;
 const LIST_LIMIT: u32 = 100;
 const SEARCH_LIMIT: u32 = 50;
 const SEARCH_DEBOUNCE: Duration = Duration::from_millis(250);
+
+/// How much of the entry line the delete-confirm popup can show. The popup is
+/// 64 columns wide and 3 lines tall inside its border, and it must still fit
+/// the key hint under the question, so the label gets one line of it.
+const DELETE_LABEL_MAX_CHARS: usize = 60;
+
+/// What ends a label the popup had to cut, matching the marker the shared
+/// display line uses.
+const TRUNCATION_MARKER: &str = "...";
 
 use crate::theme::theme;
 
@@ -757,6 +766,36 @@ fn draw_search_bar(f: &mut Frame, state: &State, area: Rect) {
     f.render_widget(&ta, area);
 }
 
+/// One list row for an entry: the line that stands for it, then its tags.
+///
+/// The line comes from [`KnowledgeEntryView::display_line`] - the entry's
+/// written summary where there is one, otherwise a bounded, marked prefix of
+/// the content. That rule lives with the wire type, so this browser, the other
+/// clients and the daemon all show the same line for the same entry.
+fn entry_row(entry: &KnowledgeEntryView) -> Line<'static> {
+    let mut spans: Vec<Span<'static>> = vec![Span::styled(entry.display_line(), Style::default())];
+    if !entry.tags.is_empty() {
+        spans.push(Span::styled(
+            format!("  [{}]", entry.tags.join(", ")),
+            Style::default().fg(theme().text_dim),
+        ));
+    }
+    Line::from(spans)
+}
+
+/// The entry name the delete-confirm popup shows: the same line the list row
+/// shows, cut again to what the popup can hold.
+fn delete_label(entry: &KnowledgeEntryView) -> String {
+    let line = entry.display_line();
+    if line.chars().count() <= DELETE_LABEL_MAX_CHARS {
+        return line;
+    }
+    let keep = DELETE_LABEL_MAX_CHARS - TRUNCATION_MARKER.chars().count();
+    let mut out: String = line.chars().take(keep).collect();
+    out.push_str(TRUNCATION_MARKER);
+    out
+}
+
 fn draw_list(f: &mut Frame, state: &State, area: Rect) {
     let items: Vec<ListItem> = if state.entries.is_empty() {
         vec![ListItem::new(Line::from(Span::styled(
@@ -767,25 +806,7 @@ fn draw_list(f: &mut Frame, state: &State, area: Rect) {
         state
             .entries
             .iter()
-            .map(|entry| {
-                let summary = entry.content.lines().next().unwrap_or("").to_string();
-                let trimmed = if summary.chars().count() > 80 {
-                    let mut s: String = summary.chars().take(80).collect();
-                    s.push('…');
-                    s
-                } else {
-                    summary
-                };
-                let mut spans: Vec<Span<'static>> = Vec::new();
-                spans.push(Span::styled(trimmed, Style::default()));
-                if !entry.tags.is_empty() {
-                    spans.push(Span::styled(
-                        format!("  [{}]", entry.tags.join(", ")),
-                        Style::default().fg(theme().text_dim),
-                    ));
-                }
-                ListItem::new(Line::from(spans))
-            })
+            .map(|entry| ListItem::new(entry_row(entry)))
             .collect()
     };
 
@@ -1009,16 +1030,7 @@ fn draw_delete_overlay(f: &mut Frame, state: &State, area: Rect) {
     let label = state
         .entries
         .get(state.selected)
-        .map(|e| {
-            let summary = e.content.lines().next().unwrap_or("").to_string();
-            if summary.chars().count() > 60 {
-                let mut s: String = summary.chars().take(60).collect();
-                s.push('…');
-                s
-            } else {
-                summary
-            }
-        })
+        .map(delete_label)
         .unwrap_or_else(|| "this entry".into());
     let popup_width = 64.min(area.width.saturating_sub(4));
     let popup_height = 5.min(area.height.saturating_sub(2));

--- a/src/kb.rs
+++ b/src/kb.rs
@@ -35,7 +35,7 @@
 use std::{io, time::Duration};
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-use desktop_assistant_api_model::{KnowledgeEntryView, MaintenanceOp, SUMMARY_MAX_CHARS};
+use desktop_assistant_api_model::{KnowledgeEntryView, MaintenanceOp};
 use desktop_assistant_client_common::{AssistantClient, SignalEvent, TransportClient};
 use ratatui::{
     Frame, Terminal,
@@ -1104,6 +1104,7 @@ fn draw_recalc_overlay(f: &mut Frame, area: Rect) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use desktop_assistant_api_model::SUMMARY_MAX_CHARS;
     use serde_json::json;
 
     /// The one place in this crate that names every field of the upstream

--- a/src/kb.rs
+++ b/src/kb.rs
@@ -1094,6 +1094,10 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    /// The one place in this crate that names every field of the upstream
+    /// `KnowledgeEntryView`. Every other fixture starts from this one with
+    /// functional update syntax, so a field added upstream is a single edit
+    /// here rather than an edit per test.
     fn entry(id: &str, content: &str) -> KnowledgeEntryView {
         KnowledgeEntryView {
             id: id.into(),
@@ -1102,6 +1106,14 @@ mod tests {
             metadata: json!({"source": "manual"}),
             created_at: "2026-05-01T00:00:00Z".into(),
             updated_at: "2026-05-02T12:34:56Z".into(),
+            summary: None,
+        }
+    }
+
+    fn entry_with_summary(id: &str, content: &str, summary: &str) -> KnowledgeEntryView {
+        KnowledgeEntryView {
+            summary: Some(summary.into()),
+            ..entry(id, content)
         }
     }
 
@@ -1148,6 +1160,95 @@ mod tests {
         assert!(form.updated_at.is_some());
         assert_eq!(form.content.lines().join("\n"), "first line\nsecond line");
         assert_eq!(form.tags.lines().join(""), "preference");
+    }
+
+    /// The row's leading span: the one line that stands for the entry, before
+    /// the tag chip.
+    fn row_line(entry: &KnowledgeEntryView) -> String {
+        entry_row(entry).spans[0].content.to_string()
+    }
+
+    #[test]
+    fn a_list_row_shows_the_stored_summary_when_there_is_one() {
+        let e = entry_with_summary(
+            "kb-1",
+            "A long body that a reader should never meet in a list row.",
+            "Prefers dark themes",
+        );
+
+        assert_eq!(row_line(&e), "Prefers dark themes");
+    }
+
+    #[test]
+    fn a_list_row_falls_back_to_the_content_when_there_is_no_summary() {
+        // Nothing writes a summary yet, so this is the common path today.
+        let e = entry("kb-1", "User prefers dark mode");
+
+        assert_eq!(row_line(&e), "User prefers dark mode");
+    }
+
+    #[test]
+    fn a_list_row_marks_a_cut_line_so_it_never_reads_as_complete() {
+        let e = entry("kb-1", &"x".repeat(SUMMARY_MAX_CHARS + 1));
+
+        let line = row_line(&e);
+
+        assert!(line.ends_with("..."), "a cut row must say so: {line}");
+    }
+
+    #[test]
+    fn a_list_row_leaves_a_short_line_unmarked() {
+        let e = entry("kb-1", "short body");
+
+        assert!(!row_line(&e).ends_with("..."));
+    }
+
+    #[test]
+    fn a_list_row_never_exceeds_the_shared_cap_for_multibyte_content() {
+        // Each of these is two bytes, so a byte-indexed cut lands inside one
+        // and panics. The count that bounds the row is characters.
+        let e = entry("kb-1", &"\u{00e9}".repeat(SUMMARY_MAX_CHARS * 2));
+
+        let line = row_line(&e);
+
+        assert_eq!(line.chars().count(), SUMMARY_MAX_CHARS);
+        assert!(line.ends_with("..."));
+    }
+
+    #[test]
+    fn a_list_row_is_one_physical_line() {
+        // A row is one line of a terminal grid. An embedded newline renders as
+        // nothing there, so a body that spans lines must arrive collapsed.
+        let e = entry("kb-1", "first line\n\n  second   line\t");
+
+        assert_eq!(row_line(&e), "first line second line");
+    }
+
+    #[test]
+    fn a_list_row_still_carries_the_tag_chip() {
+        let e = entry_with_summary("kb-1", "body", "Prefers dark themes");
+
+        let row = entry_row(&e);
+
+        assert_eq!(row.spans.len(), 2);
+        assert!(row.spans[1].content.contains("preference"));
+    }
+
+    #[test]
+    fn the_delete_prompt_names_the_entry_by_the_line_the_row_shows() {
+        let e = entry_with_summary("kb-1", "a long body", "Prefers dark themes");
+
+        assert_eq!(delete_label(&e), "Prefers dark themes");
+    }
+
+    #[test]
+    fn the_delete_prompt_fits_its_popup() {
+        let e = entry("kb-1", &"x".repeat(SUMMARY_MAX_CHARS * 2));
+
+        let label = delete_label(&e);
+
+        assert!(label.chars().count() <= DELETE_LABEL_MAX_CHARS);
+        assert!(label.ends_with("..."), "a cut label must say so: {label}");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,8 @@ pub mod screen;
 pub mod settings;
 pub mod settings_screen;
 pub mod tasks;
+#[cfg(test)]
+pub mod test_fixtures;
 pub mod theme;
 pub mod toolbar;
 pub mod ui;

--- a/src/test_fixtures.rs
+++ b/src/test_fixtures.rs
@@ -1,0 +1,63 @@
+//! Base values for the upstream wire types this crate's tests construct.
+//!
+//! `desktop-assistant-api-model` and `client-ui-common` live in other repos and
+//! gain fields without notice. A test that names every field of one of those
+//! types stops compiling the moment a field arrives, and the repair is then one
+//! edit per test - this crate has paid that bill three times, for three
+//! different types.
+//!
+//! None of those types derives `Default`, so each one gets a base value here
+//! instead. A test starts from the base and names only the fields it cares
+//! about:
+//!
+//! ```ignore
+//! let detail = ConversationDetail {
+//!     title: "Second".into(),
+//!     ..conversation_detail("c1")
+//! };
+//! ```
+//!
+//! A field added upstream is then one edit in this file. Every function below
+//! is the only place in this crate that names every field of its type, so keep
+//! it that way: reach for functional update syntax rather than a second full
+//! literal.
+
+use desktop_assistant_client_common::{
+    ChatMessage, ConversationDetail, ConversationSummary, MessageKind,
+};
+
+/// A conversation with no messages and no per-conversation overrides.
+pub fn conversation_detail(id: &str) -> ConversationDetail {
+    ConversationDetail {
+        id: id.into(),
+        title: format!("Conv {id}"),
+        messages: vec![],
+        model_selection: None,
+        conversation_personality: None,
+        tool_gate_disabled: false,
+    }
+}
+
+/// A sidebar row for a live (not archived) conversation with no messages.
+pub fn conversation_summary(id: &str) -> ConversationSummary {
+    ConversationSummary {
+        id: id.into(),
+        title: format!("Conv {id}"),
+        message_count: 0,
+        archived: false,
+    }
+}
+
+/// An empty daemon-sourced chat message: no id, ordinary presentation, and
+/// none of the client-side send bookkeeping. A test names the `role` and
+/// `content` it needs on top of this.
+pub fn chat_message() -> ChatMessage {
+    ChatMessage {
+        id: String::new(),
+        role: String::new(),
+        content: String::new(),
+        kind: MessageKind::Normal,
+        idempotency_key: None,
+        created_at_ms: None,
+    }
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -678,6 +678,7 @@ fn context_usage_span(usage: crate::app::ContextUsageView) -> (String, Color) {
 mod tests {
     use super::*;
     use crate::app::{ChatMessage, ConversationDetail, ConversationSummary};
+    use crate::test_fixtures::{chat_message, conversation_detail, conversation_summary};
     use ratatui::{Terminal, backend::TestBackend};
 
     #[test]
@@ -754,16 +755,13 @@ mod tests {
         let mut app = App::new();
         app.set_conversations(vec![
             ConversationSummary {
-                id: "1".into(),
                 title: "Chat 1".into(),
                 message_count: 3,
-                archived: false,
+                ..conversation_summary("1")
             },
             ConversationSummary {
-                id: "2".into(),
                 title: "Chat 2".into(),
-                message_count: 0,
-                archived: false,
+                ..conversation_summary("2")
             },
         ]);
         app.selected_conversation = Some(0);
@@ -776,29 +774,20 @@ mod tests {
         let mut terminal = Terminal::new(backend).unwrap();
         let mut app = App::new();
         app.load_conversation(ConversationDetail {
-            id: "1".into(),
             title: "Test".into(),
             messages: vec![
                 ChatMessage {
-                    id: String::new(),
                     role: "user".into(),
                     content: "Hello".into(),
-                    kind: crate::app::MessageKind::Normal,
-                    idempotency_key: None,
-                    created_at_ms: None,
+                    ..chat_message()
                 },
                 ChatMessage {
-                    id: String::new(),
                     role: "assistant".into(),
                     content: "Hi there!".into(),
-                    kind: crate::app::MessageKind::Normal,
-                    idempotency_key: None,
-                    created_at_ms: None,
+                    ..chat_message()
                 },
             ],
-            model_selection: None,
-            conversation_personality: None,
-            tool_gate_disabled: false,
+            ..conversation_detail("1")
         });
         terminal.draw(|f| draw(f, &mut app)).unwrap();
     }
@@ -823,12 +812,8 @@ mod tests {
         // and reflects the current level label.
         let mut app = App::new();
         app.load_conversation(ConversationDetail {
-            id: "c1".into(),
             title: "ChatProbe".into(),
-            messages: vec![],
-            model_selection: None,
-            conversation_personality: None,
-            tool_gate_disabled: false,
+            ..conversation_detail("c1")
         });
 
         // Disabled (default): no "Adele:" cue in the title.
@@ -857,12 +842,8 @@ mod tests {
         // is distinct from the Adele cue.
         let mut app = App::new();
         app.load_conversation(ConversationDetail {
-            id: "c1".into(),
             title: "ChatProbe".into(),
-            messages: vec![],
-            model_selection: None,
-            conversation_personality: None,
-            tool_gate_disabled: false,
+            ..conversation_detail("c1")
         });
 
         // Disabled (default): no "You:" cue in the title.
@@ -883,12 +864,8 @@ mod tests {
         // the in-flight stream is active for the view; the chunk then buffers and
         // paints through the same render guard production uses.
         app.load_conversation(ConversationDetail {
-            id: "1".into(),
             title: "Test".into(),
-            messages: vec![],
-            model_selection: None,
-            conversation_personality: None,
-            tool_gate_disabled: false,
+            ..conversation_detail("1")
         });
         app.apply_prompt_ack("task1".into(), "1".into());
         app.apply_core(UiMessage::StreamChunk {
@@ -1068,10 +1045,8 @@ mod tests {
         let mut terminal = Terminal::new(backend).unwrap();
         let mut app = App::new();
         app.set_conversations(vec![ConversationSummary {
-            id: "1".into(),
             title: "Chat 1".into(),
-            message_count: 0,
-            archived: false,
+            ..conversation_summary("1")
         }]);
         app.selected_conversation = Some(0);
         app.begin_rename();
@@ -1084,10 +1059,8 @@ mod tests {
         let mut terminal = Terminal::new(backend).unwrap();
         let mut app = App::new();
         app.set_conversations(vec![ConversationSummary {
-            id: "1".into(),
             title: "Sidebar Title Probe".into(),
-            message_count: 0,
-            archived: false,
+            ..conversation_summary("1")
         }]);
         app.show_sidebar = false;
         terminal.draw(|f| draw(f, &mut app)).unwrap();
@@ -1103,10 +1076,8 @@ mod tests {
         let mut terminal = Terminal::new(backend).unwrap();
         let mut app = App::new();
         app.set_conversations(vec![ConversationSummary {
-            id: "1".into(),
             title: "Visible Probe".into(),
-            message_count: 0,
-            archived: false,
+            ..conversation_summary("1")
         }]);
         terminal.draw(|f| draw(f, &mut app)).unwrap();
         let buf = terminal.backend().buffer().clone();
@@ -1118,53 +1089,35 @@ mod tests {
         let mut app = App::new();
         app.show_debug = show_debug;
         app.load_conversation(ConversationDetail {
-            id: "1".into(),
             title: "Test".into(),
             messages: vec![
                 ChatMessage {
-                    id: String::new(),
                     role: "user".into(),
                     content: "Hello".into(),
-                    kind: crate::app::MessageKind::Normal,
-                    idempotency_key: None,
-                    created_at_ms: None,
+                    ..chat_message()
                 },
                 ChatMessage {
-                    id: String::new(),
                     role: "tool".into(),
                     content: "ran search(foo)".into(),
-                    kind: crate::app::MessageKind::Normal,
-                    idempotency_key: None,
-                    created_at_ms: None,
+                    ..chat_message()
                 },
                 ChatMessage {
-                    id: String::new(),
                     role: "system".into(),
                     content: "context updated".into(),
-                    kind: crate::app::MessageKind::Normal,
-                    idempotency_key: None,
-                    created_at_ms: None,
+                    ..chat_message()
                 },
                 ChatMessage {
-                    id: String::new(),
                     role: "assistant".into(),
                     content: "".into(), // empty — only shown in debug
-                    kind: crate::app::MessageKind::Normal,
-                    idempotency_key: None,
-                    created_at_ms: None,
+                    ..chat_message()
                 },
                 ChatMessage {
-                    id: String::new(),
                     role: "assistant".into(),
                     content: "Hi there!".into(),
-                    kind: crate::app::MessageKind::Normal,
-                    idempotency_key: None,
-                    created_at_ms: None,
+                    ..chat_message()
                 },
             ],
-            model_selection: None,
-            conversation_personality: None,
-            tool_gate_disabled: false,
+            ..conversation_detail("1")
         });
         app
     }
@@ -1205,12 +1158,8 @@ mod tests {
         let mut terminal = Terminal::new(backend).unwrap();
         let mut app = App::new();
         app.load_conversation(ConversationDetail {
-            id: "1".into(),
             title: "Test".into(),
-            messages: vec![],
-            model_selection: None,
-            conversation_personality: None,
-            tool_gate_disabled: false,
+            ..conversation_detail("1")
         });
         app.set_assistant_status("Searching knowledge base...");
         terminal.draw(|f| draw(f, &mut app)).unwrap();
@@ -1267,19 +1216,13 @@ mod tests {
         let mut terminal = Terminal::new(backend).unwrap();
         let mut app = App::new();
         app.load_conversation(ConversationDetail {
-            id: "1".into(),
             title: "Test".into(),
             messages: vec![ChatMessage {
-                id: String::new(),
                 role: "assistant".into(),
                 content: "answer with **strong** word".into(),
-                kind: crate::app::MessageKind::Normal,
-                idempotency_key: None,
-                created_at_ms: None,
+                ..chat_message()
             }],
-            model_selection: None,
-            conversation_personality: None,
-            tool_gate_disabled: false,
+            ..conversation_detail("1")
         });
         terminal.draw(|f| draw(f, &mut app)).unwrap();
         let buf = terminal.backend().buffer().clone();


### PR DESCRIPTION
Closes #158.

## Must merge with desktop-assistant #1105

This repo path-depends `desktop-assistant`. #1105 adds `summary` to
`KnowledgeEntryView`, so `main` here stops compiling the moment #1105 lands, and this
branch does not compile until #1105 lands. Neither is shippable alone. Land them
together.

Two things this branch takes from #1105:

- `KnowledgeEntryView::summary`
- `KnowledgeEntryView::display_line()` and the re-exported
  `desktop_assistant_api_model::SUMMARY_MAX_CHARS`

## What a user sees

A knowledge browser row showed the first physical line of the entry's content, cut at
80 characters and marked with an ellipsis. It now shows the entry's written summary
where there is one. Nothing writes a summary yet, so every entry today still shows its
content - the difference is that the content now arrives collapsed to one line, so an
entry whose body starts with a blank line no longer draws an empty row.

The delete-confirm popup names the entry by the same line, so the row and the question
that follows it cannot disagree.

## The truncation rule is not restated here

`KnowledgeEntryView::display_line` decides the line: the summary where there is one,
otherwise the content, collapsed to one physical line, cut on a character boundary,
and marked with `...` past `SUMMARY_MAX_CHARS`. This client calls it. The character
boundary handling and the cap live in one place for every client and the daemon.

The delete popup cuts the result again, to 60 characters. That is popup geometry, not
the display rule: the popup is 64 columns wide and must still fit its key hint.

## The build break, fixed as a class

`src/kb.rs` built `KnowledgeEntryView` with an exhaustive struct literal, so any field
added upstream broke it. That is the third time this crate has paid that bill:

| Commit | Type | Sites repaired |
| --- | --- | --- |
| e105f17 | `McpServerConfig::inherit_env` | 1 |
| fd7990f | `ConversationDetail::tool_gate_disabled` | 19 |
| this one | `KnowledgeEntryView::summary` | 1 |

`src/test_fixtures.rs` now holds one base value per upstream wire type the tests build.
A test starts from the base and names only the fields it cares about, so a field added
upstream is one edit in that file rather than one per test. Collapsed: 20
`ConversationDetail` sites, 15 `ConversationSummary`, 10 `ChatMessage`.

None of these types derives `Default`, so the base is a plain function rather than
`..Default::default()`.

## Gate

`just check` - **exit 0** (format, clippy with warnings denied, build, 568 tests).

Run against #1105's branch through a local, uncommitted cargo path override. The
override is not in the diff: the merged state resolves through the normal path, and a
committed override would break the build for everyone else.

## Limits of this change, stated

- **Verified against a moving branch.** #1105 was still being committed to while this
  was built. The gate passed against its `d4190d0`. If `display_line` or
  `SUMMARY_MAX_CHARS` is renamed before #1105 merges, this needs the same rename.
- **The sweep is not complete.** The types with the most sites are done. These upstream
  types still name every field, none of them near the 20-site pain that motivated the
  work: `ContextUsage` (5), `TaskView` (5), `ContextUsageView` (4), `BuiltinStatus`,
  `ClientToolRegistration`, `ConnectionView`, `ConversationModelSelectionView`,
  `SendPromptOverride` (3 each), and eight more at 1-2.
- **`src/main.rs` keeps one `ConversationDetail` literal.** It is a separate crate that
  links the library built without `cfg(test)`, so it cannot see the fixtures. It was
  already at one site.
- **`App::push_local_line` keeps its `ChatMessage` literal.** It is production code
  building a real message, not a fixture.
- **The row no longer caps at 80 characters,** so on a terminal wider than about 210
  columns a long content-fallback row can push the tag chip off screen. Fitting the row
  to the terminal width is a layout change, not a second truncation constant, and is
  not attempted here.

## Search axes used for the sweep

Symbol name (every capitalised struct-literal head in `src/` and `tests/`, cross-checked
against the definitions in `desktop-assistant` and `client-ui-common`); field name
(`tool_gate_disabled`, `inherit_env`, `summary`, `archived`, `idempotency_key`); git
history (`git log -S`, which found e105f17 and fd7990f); and compilation against the
unmerged upstream branch, which is the only axis that proves a literal is exhaustive.
