### PR TITLE
Adopt adelie-telemetry in init_logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ dependencies = [
 [[package]]
 name = "adelie-telemetry"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/adelie-telemetry?rev=1b8166ab483174e76aa23079858b8a31aaa52ae1#1b8166ab483174e76aa23079858b8a31aaa52ae1"
+source = "git+https://github.com/adelie-ai/adelie-telemetry?rev=36dcd571c1b2d35a6afc9376e1600766480c4fdc#36dcd571c1b2d35a6afc9376e1600766480c4fdc"
 dependencies = [
  "opentelemetry",
  "opentelemetry-appender-tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,7 @@ dependencies = [
  "adele-voice-module",
  "adele-voice-stt-whisper",
  "adele-voice-vad-silero",
+ "adelie-telemetry",
  "anyhow",
  "async-trait",
  "clap",
@@ -77,7 +78,7 @@ dependencies = [
  "pulldown-cmark",
  "rubato",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
 ]
 
@@ -149,6 +150,22 @@ dependencies = [
  "ndarray",
  "ort",
  "tracing",
+]
+
+[[package]]
+name = "adelie-telemetry"
+version = "0.1.0"
+source = "git+https://github.com/adelie-ai/adelie-telemetry?rev=59c152db11f22281ea2ae8f1c67e00389dbf74f8#59c152db11f22281ea2ae8f1c67e00389dbf74f8"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry-appender-tracing",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1152,7 +1169,7 @@ dependencies = [
  "reqwest 0.13.1",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "url",
@@ -1693,7 +1710,7 @@ dependencies = [
  "serde_json",
  "serde_yaml_ng",
  "sha2 0.10.9",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1713,9 +1730,10 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "desktop-assistant-core",
+ "desktop-assistant-protocol",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "toml 1.1.2+spec-1.1.0",
  "tracing",
@@ -1770,7 +1788,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1870,7 +1888,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1956,7 +1974,7 @@ dependencies = [
  "serde_json",
  "shellexpand",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
 ]
 
@@ -2172,7 +2190,7 @@ dependencies = [
  "reqwest 0.13.1",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
 ]
 
@@ -2453,6 +2471,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2685,7 +2716,7 @@ dependencies = [
  "reqwest 0.13.1",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
 ]
 
@@ -2846,7 +2877,7 @@ checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
 dependencies = [
  "hashbrown 0.16.1",
  "portable-atomic",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -3026,7 +3057,7 @@ dependencies = [
  "clap",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
 ]
 
@@ -3187,7 +3218,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3495,8 +3526,95 @@ dependencies = [
  "reqwest 0.13.1",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
+]
+
+[[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.19",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-appender-tracing"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c0080f0dc1d7c786f467cd85a4e395fcab11ee852004f39a29a18ab7c25d837"
+dependencies = [
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 1.4.0",
+ "opentelemetry",
+ "reqwest 0.13.1",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
+dependencies = [
+ "http 1.4.0",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest 0.13.1",
+ "thiserror 2.0.19",
+ "tokio",
+ "tonic",
+ "tonic-types",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "portable-atomic",
+ "rand 0.9.4",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -3711,6 +3829,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3843,6 +3981,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
+dependencies = [
+ "anyhow",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
+dependencies = [
+ "prost",
+]
+
+[[package]]
 name = "pulldown-cmark"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3876,7 +4046,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "web-time",
@@ -3899,7 +4069,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tracing",
  "web-time",
@@ -4053,7 +4223,7 @@ dependencies = [
  "kasuari",
  "lru",
  "strum",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width",
@@ -4155,7 +4325,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -4260,7 +4430,9 @@ dependencies = [
  "base64",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
+ "futures-util",
  "h2",
  "http 1.4.0",
  "http-body 1.0.1",
@@ -4290,6 +4462,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -4372,7 +4545,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4431,7 +4604,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4795,7 +4968,7 @@ checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "time",
 ]
 
@@ -4817,7 +4990,7 @@ dependencies = [
  "serde_json",
  "serde_yaml_ng",
  "shellexpand",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "walkdir",
 ]
@@ -4975,7 +5148,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "walkdir",
  "yaml-rust",
 ]
@@ -5013,7 +5186,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "shellexpand",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "uuid",
  "zbus",
@@ -5029,7 +5202,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5042,7 +5215,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shellexpand",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "uuid",
 ]
@@ -5121,11 +5294,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -5141,13 +5314,13 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -5219,9 +5392,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -5253,6 +5426,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -5361,6 +5545,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "tonic-types"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
+dependencies = [
+ "prost",
+ "prost-types",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5368,11 +5602,15 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -5449,6 +5687,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-opentelemetry"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
+dependencies = [
+ "js-sys",
+ "opentelemetry",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5495,7 +5749,7 @@ dependencies = [
  "log",
  "rand 0.9.4",
  "sha1",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "utf-8",
 ]
 
@@ -5514,7 +5768,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "sha1",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -5870,7 +6124,7 @@ dependencies = [
  "reqwest 0.13.1",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
 ]
 
@@ -5885,7 +6139,7 @@ dependencies = [
  "mcp-core",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "url",
 ]
@@ -6062,7 +6316,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,7 +155,7 @@ dependencies = [
 [[package]]
 name = "adelie-telemetry"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/adelie-telemetry?rev=59c152db11f22281ea2ae8f1c67e00389dbf74f8#59c152db11f22281ea2ae8f1c67e00389dbf74f8"
+source = "git+https://github.com/adelie-ai/adelie-telemetry?rev=1b8166ab483174e76aa23079858b8a31aaa52ae1#1b8166ab483174e76aa23079858b8a31aaa52ae1"
 dependencies = [
  "opentelemetry",
  "opentelemetry-appender-tracing",
@@ -1166,7 +1166,7 @@ dependencies = [
  "futures",
  "futures-timer",
  "pin-project-lite",
- "reqwest 0.13.1",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "thiserror 2.0.19",
@@ -1683,7 +1683,7 @@ dependencies = [
  "iana-time-zone",
  "libc",
  "mcp-core",
- "reqwest 0.13.1",
+ "reqwest 0.13.4",
  "rustls",
  "rustls-pki-types",
  "serde",
@@ -1788,7 +1788,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1888,7 +1888,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2187,7 +2187,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "mcp-core",
- "reqwest 0.13.1",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "thiserror 2.0.19",
@@ -2713,7 +2713,7 @@ version = "0.1.0"
 dependencies = [
  "mcp-core",
  "nix 0.31.3",
- "reqwest 0.13.1",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "thiserror 2.0.19",
@@ -3218,7 +3218,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3523,7 +3523,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "mcp-core",
- "reqwest 0.13.1",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "thiserror 2.0.19",
@@ -3566,7 +3566,7 @@ dependencies = [
  "bytes",
  "http 1.4.0",
  "opentelemetry",
- "reqwest 0.13.1",
+ "reqwest 0.13.4",
 ]
 
 [[package]]
@@ -3581,7 +3581,7 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest 0.13.1",
+ "reqwest 0.13.4",
  "thiserror 2.0.19",
  "tokio",
  "tonic",
@@ -3997,7 +3997,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4423,9 +4423,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.1"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04e9018c9d814e5f30cc16a0f03271aeab3571e609612d9fe78c1aa8d11c2f62"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
@@ -4462,7 +4462,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -4545,7 +4544,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4604,7 +4603,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5202,7 +5201,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5561,6 +5560,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
+ "rustls-native-certs",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -5569,7 +5569,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
- "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -6121,7 +6120,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "mcp-core",
- "reqwest 0.13.1",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "thiserror 2.0.19",
@@ -6316,7 +6315,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # the metrics facade + in-process registry, the shutdown guard, and the
 # trace-context helpers. Depends on no other Adelie crate. The `otel` feature
 # below is off by default and adds no opentelemetry crate to a default build.
-adelie-telemetry = { git = "https://github.com/adelie-ai/adelie-telemetry", rev = "1b8166ab483174e76aa23079858b8a31aaa52ae1" }
+adelie-telemetry = { git = "https://github.com/adelie-ai/adelie-telemetry", rev = "36dcd571c1b2d35a6afc9376e1600766480c4fdc" }
 # Direct zbus client for the standalone voice daemon (`org.desktopAssistant.Voice`),
 # a separate D-Bus service from the orchestrator transport. Used by
 # `voice_client::VoiceController` to route narration through the daemon's warm

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,11 @@ toml = "0.9"
 uuid = { version = "1", features = ["v4"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+# Shared telemetry setup (epic mcp-core#38, adele-tui#152): the subscriber,
+# the metrics facade + in-process registry, the shutdown guard, and the
+# trace-context helpers. Depends on no other Adelie crate. The `otel` feature
+# below is off by default and adds no opentelemetry crate to a default build.
+adelie-telemetry = { git = "https://github.com/adelie-ai/adelie-telemetry", rev = "59c152db11f22281ea2ae8f1c67e00389dbf74f8" }
 # Direct zbus client for the standalone voice daemon (`org.desktopAssistant.Voice`),
 # a separate D-Bus service from the orchestrator transport. Used by
 # `voice_client::VoiceController` to route narration through the daemon's warm
@@ -178,6 +183,12 @@ mcp-internet-radio = ["dep:internet-radio-mcp"]
 mcp-openstreetmap = ["dep:openstreetmap-mcp"]
 mcp-geocode = ["dep:geocode-mcp"]
 mcp-skills = ["dep:skills-mcp"]
+
+# OTLP export via adelie-telemetry (epic mcp-core#38 D2), off by default.
+# `cargo build --features otel` turns on the traces/metrics/logs exporters,
+# configured from the standard `OTEL_*` environment variables. A default
+# build (including `cargo install`) resolves no opentelemetry crate at all.
+otel = ["adelie-telemetry/otel"]
 
 [lints.rust]
 warnings = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # the metrics facade + in-process registry, the shutdown guard, and the
 # trace-context helpers. Depends on no other Adelie crate. The `otel` feature
 # below is off by default and adds no opentelemetry crate to a default build.
-adelie-telemetry = { git = "https://github.com/adelie-ai/adelie-telemetry", rev = "59c152db11f22281ea2ae8f1c67e00389dbf74f8" }
+adelie-telemetry = { git = "https://github.com/adelie-ai/adelie-telemetry", rev = "1b8166ab483174e76aa23079858b8a31aaa52ae1" }
 # Direct zbus client for the standalone voice daemon (`org.desktopAssistant.Voice`),
 # a separate D-Bus service from the orchestrator transport. Used by
 # `voice_client::VoiceController` to route narration through the daemon's warm

--- a/README.md
+++ b/README.md
@@ -174,6 +174,56 @@ Given before any subcommand (they apply to the TUI and `exec` alike):
 | `--ws-subject` | `DESKTOP_ASSISTANT_TUI_WS_SUBJECT` | `desktop-tui` | JWT subject |
 | `-v`, `--verbose` | | | Verbose logging to stderr (`-v`/`-vv`/`-vvv`) |
 
+## Logging
+
+`adele` is silent by default: with no `-v` and no `RUST_LOG`, it writes
+nothing to either stream. Logs always go to stderr, never stdout — the
+headless `exec` (and deprecated `--prompt`) path writes the model reply to
+stdout, and a log line there would corrupt it.
+
+- `-v` / `-vv` / `-vvv` raise the level for `adele` and its client crates
+  (`info` / `debug` / `trace`); everything else stays at `warn`.
+- `RUST_LOG`, when set, overrides the level entirely (standard
+  `tracing_subscriber::EnvFilter` syntax, e.g. `RUST_LOG=debug` or
+  `RUST_LOG=info,adele=trace`).
+
+### OpenTelemetry export (`otel` feature)
+
+Off by default: `cargo build` and `cargo install --path .` resolve no
+`opentelemetry` crate. Build with `cargo build --features otel` (or
+`cargo install --path . --features otel`) to also export traces, metrics,
+and log records to a collector over OTLP, through the shared
+[`adelie-telemetry`](https://github.com/adelie-ai/adelie-telemetry) crate.
+`RUST_LOG` governs the exported log records too — there is no separate
+filter for the collector.
+
+Configuration is entirely through the standard `OTEL_*` environment
+variables; `adele` adds no flags or variables of its own:
+
+| Variable | Effect |
+|---|---|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Collector endpoint for all three signals |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | Endpoint for traces, overrides the generic one |
+| `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT` | Endpoint for metrics, overrides the generic one |
+| `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` | Endpoint for log records, overrides the generic one |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `grpc`, `http/protobuf`, or `http/json` (per-signal forms exist too) |
+| `OTEL_EXPORTER_OTLP_HEADERS` | Extra headers, as `key=value,key=value` (per-signal forms exist too) |
+| `OTEL_EXPORTER_OTLP_TIMEOUT` | Export timeout in milliseconds (per-signal forms exist too) |
+| `OTEL_EXPORTER_OTLP_COMPRESSION` | `gzip` or `zstd` |
+| `OTEL_RESOURCE_ATTRIBUTES` | Extra resource attributes, as `key=value,key=value` |
+
+See the [`adelie-telemetry` README](https://github.com/adelie-ai/adelie-telemetry)
+for the complete variable reference, the transport tradeoffs (`grpc` vs.
+`http/protobuf`), and what an `otel` build costs in dependencies and binary
+size.
+
+`adele` opens a span around connecting to the daemon, around advertising its
+client tools, and around one turn's reply streaming, all children of a
+per-turn root span. None of them ever carry the prompt or reply text — only
+ids, counts, and durations. These spans stay local to this process for now:
+carrying them to the daemon as a `traceparent` so one trace covers a whole
+turn end to end is tracked separately (`desktop-assistant#1152`).
+
 ## Test
 
 ```sh

--- a/examples/logging_probe.rs
+++ b/examples/logging_probe.rs
@@ -1,13 +1,21 @@
-//! Probe for the `adele-tui#152` acceptance tests.
+//! Probe for the `adele-tui#152` acceptance tests, and for a manual check
+//! against a real collector.
 //!
-//! Installs telemetry exactly the way `adele`'s `main` does, logs at every
-//! level, then optionally writes a fixed marker to stdout standing in for
-//! the model reply `run_headless` writes there. The tests in
-//! `tests/acceptance_telemetry.rs` run this as a real process and inspect
-//! its real file descriptors — the only honest way to prove what does and
-//! does not reach stdout versus stderr.
+//! Installs telemetry exactly the way `adele`'s `main` does, opens the same
+//! span shape `run_headless` does, records both of `adele-tui`'s own metrics,
+//! logs at every level, then optionally writes a fixed marker to stdout
+//! standing in for the model reply `run_headless` writes there. The tests in
+//! `tests/acceptance_telemetry.rs` run this as a real process and inspect its
+//! real file descriptors — the only honest way to prove what does and does
+//! not reach stdout versus stderr.
 //!
 //! Usage: `logging_probe [-v]... [--with-reply]`
+//!
+//! Against a collector (see the `adelie-telemetry` README for how to run
+//! one): `OTEL_EXPORTER_OTLP_ENDPOINT=... OTEL_EXPORTER_OTLP_PROTOCOL=... \
+//! cargo run --features otel --example logging_probe -- -v`
+
+use std::time::Duration;
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();
@@ -21,6 +29,24 @@ fn main() {
     tracing::info!("info level");
     tracing::warn!("warn level");
     tracing::error!("error level");
+
+    // The same span shape `run_headless` opens, and both of `adele-tui`'s own
+    // metrics (adele-tui#152 task 6), so a manual check against a collector
+    // sees exactly what a real turn would export.
+    let turn = adele::telemetry::turn_span();
+    let _turn_guard = turn.enter();
+    adele::telemetry::record_conversation_id(&turn, "probe-conversation");
+    adele::telemetry::connect_span().in_scope(|| tracing::info!("connected"));
+    adele::telemetry::registration_span().in_scope(|| tracing::info!("registered"));
+    let stream = adele::telemetry::reply_streaming_span("probe-request");
+    let _stream_guard = stream.enter();
+    adele::telemetry::trace_chunk_received(4);
+    adele::telemetry::record_reply_bytes(&stream, 4);
+    drop(_stream_guard);
+    drop(_turn_guard);
+
+    adele::telemetry::record_reconnect();
+    adele::telemetry::record_turn_duration(Duration::from_millis(1));
 
     // Stands in for the model reply `run_headless` writes to stdout.
     if with_reply {

--- a/examples/logging_probe.rs
+++ b/examples/logging_probe.rs
@@ -1,0 +1,29 @@
+//! Probe for the `adele-tui#152` acceptance tests.
+//!
+//! Installs telemetry exactly the way `adele`'s `main` does, logs at every
+//! level, then optionally writes a fixed marker to stdout standing in for
+//! the model reply `run_headless` writes there. The tests in
+//! `tests/acceptance_telemetry.rs` run this as a real process and inspect
+//! its real file descriptors — the only honest way to prove what does and
+//! does not reach stdout versus stderr.
+//!
+//! Usage: `logging_probe [-v]... [--with-reply]`
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let verbose = args.iter().filter(|a| a.as_str() == "-v").count() as u8;
+    let with_reply = args.iter().any(|a| a == "--with-reply");
+
+    let _guard = adele::telemetry::init_logging(verbose);
+
+    tracing::trace!("trace level");
+    tracing::debug!("debug level");
+    tracing::info!("info level");
+    tracing::warn!("warn level");
+    tracing::error!("error level");
+
+    // Stands in for the model reply `run_headless` writes to stdout.
+    if with_reply {
+        print!("REPLY-MARKER");
+    }
+}

--- a/justfile
+++ b/justfile
@@ -34,11 +34,11 @@ test:
 test-integration:
     cargo test -- --ignored
 
-# The gate with the `otel` feature on too (OTLP export via adelie-telemetry,
-# epic mcp-core#38 D2). Not part of the default `check`/pre-push path — it
-# needs a C toolchain for the TLS backend and adds real build time — but a
-# change that compiles with default features can still fail with `otel` on,
-# so run this before a change that touches telemetry.
+# OTLP export via adelie-telemetry needs a C toolchain for the TLS backend
+# and adds real build time, so it is not part of the default `check`/pre-push
+# path (epic mcp-core#38 D2) — but a change that compiles with default
+# features can still fail with `otel` on. Run this before a telemetry change.
+# The gate with the `otel` feature on too.
 check-otel: fmt-check
     cargo clippy --all-targets --features otel -- -D warnings
     cargo build --features otel

--- a/justfile
+++ b/justfile
@@ -34,6 +34,19 @@ test:
 test-integration:
     cargo test -- --ignored
 
+# The gate with the `otel` feature on too (OTLP export via adelie-telemetry,
+# epic mcp-core#38 D2). Not part of the default `check`/pre-push path — it
+# needs a C toolchain for the TLS backend and adds real build time — but a
+# change that compiles with default features can still fail with `otel` on,
+# so run this before a change that touches telemetry.
+check-otel: fmt-check
+    cargo clippy --all-targets --features otel -- -D warnings
+    cargo build --features otel
+    cargo test --features otel
+
+# Both configurations.
+check-all: check check-otel
+
 # Rebase onto latest origin/main then run the gate (catches clean-rebase-but-broken-build)
 premerge:
     git fetch origin

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ pub mod screen;
 pub mod settings;
 pub mod settings_screen;
 pub mod tasks;
+pub mod telemetry;
 #[cfg(test)]
 pub mod test_fixtures;
 pub mod theme;

--- a/src/main.rs
+++ b/src/main.rs
@@ -583,6 +583,11 @@ async fn run_headless(config: &ConnectionConfig, prompt: String) -> Result<()> {
         let mut streamed = false;
         let mut reply_bytes = 0usize;
         let stream_span = adele::telemetry::reply_streaming_span(&request_id);
+        // A turn error breaks the loop rather than returning directly, so the
+        // byte count and duration below are recorded on every exit — a turn
+        // that streamed several chunks before failing must not lose that
+        // count just because it ended in an error.
+        let mut turn_error = None;
         async {
             while let Some(event) = signal_rx.recv().await {
                 match event {
@@ -615,7 +620,8 @@ async fn run_headless(config: &ConnectionConfig, prompt: String) -> Result<()> {
                         error,
                         ..
                     } if rid == request_id => {
-                        return Err(anyhow::anyhow!("{error}"));
+                        turn_error = Some(error);
+                        break;
                     }
                     SignalEvent::ClientToolCall {
                         task_id,
@@ -640,12 +646,14 @@ async fn run_headless(config: &ConnectionConfig, prompt: String) -> Result<()> {
                 }
             }
             adele::telemetry::record_reply_bytes(&tracing::Span::current(), reply_bytes);
-            Ok(())
         }
         .instrument(stream_span)
-        .await?;
+        .await;
 
         adele::telemetry::record_turn_duration(turn_started.elapsed());
+        if let Some(error) = turn_error {
+            return Err(anyhow::anyhow!("{error}"));
+        }
         Ok(())
     }
     .instrument(adele::telemetry::turn_span())

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ use tokio::{
     sync::mpsc::{UnboundedReceiver, UnboundedSender, unbounded_channel},
     time::{Instant, sleep_until},
 };
+use tracing::Instrument as _;
 
 // The binary is a thin shim over the `adele` library crate (refactor #3): every
 // screen/widget/helper module lives in `lib.rs` and is reached via `adele::`,
@@ -426,44 +427,6 @@ fn install_panic_hook() {
     }));
 }
 
-/// Build the tracing `EnvFilter` directive for a `-v` count. `RUST_LOG`, when
-/// set, takes precedence and this is not consulted. Higher counts widen the
-/// level for our own crates while keeping third-party noise at `warn`.
-fn log_filter(verbose: u8) -> String {
-    let level = match verbose {
-        0 => "warn",
-        1 => "info",
-        2 => "debug",
-        _ => "trace",
-    };
-    format!(
-        "warn,adele={level},desktop_assistant_client_common={level},\
-         desktop_assistant_mcp_client={level},client_ui_common={level}"
-    )
-}
-
-/// Install a stderr tracing subscriber when `-v`/`--verbose` is given or
-/// `RUST_LOG` is set; otherwise stay silent so normal output is clean. Logging
-/// to stderr keeps a headless `--prompt` run's reply (stdout) separable from
-/// diagnostics. Best-effort: an already-installed global subscriber is a no-op.
-fn init_logging(verbose: u8) {
-    use tracing_subscriber::EnvFilter;
-    let has_rust_log = std::env::var_os("RUST_LOG").is_some();
-    if verbose == 0 && !has_rust_log {
-        return;
-    }
-    let filter = if has_rust_log {
-        EnvFilter::from_default_env()
-    } else {
-        EnvFilter::new(log_filter(verbose))
-    };
-    let _ = tracing_subscriber::fmt()
-        .with_env_filter(filter)
-        .with_writer(std::io::stderr)
-        .with_target(true)
-        .try_init();
-}
-
 #[tokio::main]
 async fn main() -> Result<()> {
     // Both `ring` and `aws-lc-rs` end up enabled in rustls because reqwest 0.12
@@ -479,9 +442,13 @@ async fn main() -> Result<()> {
     let cli = CliArgs::from_arg_matches(&matches)?;
     let cli_explicit = any_explicit_connection_arg(&matches);
 
-    // Install logging first so connection/registration/streaming diagnostics are
-    // captured for the headless path too (verbose or RUST_LOG; silent otherwise).
-    init_logging(cli.global.verbose);
+    // Install telemetry first so connection/registration/streaming diagnostics
+    // are captured for the headless path too (verbose or RUST_LOG; silent
+    // otherwise). Held for the life of `main` (epic mcp-core#38 D6): dropping
+    // the guard flushes the exporters, so every return path below — `config`,
+    // headless `exec`, and the interactive TUI — needs it alive through its
+    // own return.
+    let _telemetry_guard = adele::telemetry::init_logging(cli.global.verbose);
 
     // `config …`: pure, daemon-free config management. Dispatch and return
     // before any terminal setup or daemon connection.
@@ -542,118 +509,147 @@ async fn main() -> Result<()> {
 /// tools, send the prompt, stream the reply to stdout, and exit. A client tool
 /// call during the turn is routed to the MCP host (or resolved via the built-in
 /// dispatch) and its result submitted so the turn always resumes.
+///
+/// The whole function runs inside the turn root span (epic mcp-core#38
+/// D12/D13, adele-tui#152): it opens here, the moment the prompt is read, and
+/// closes when the function returns, which is exactly when the reply finishes
+/// streaming (there is no work after the loop below). Connect, registration,
+/// and reply streaming are its child spans. None of this carries the prompt
+/// or reply text (D10) — only ids and byte counts.
 async fn run_headless(config: &ConnectionConfig, prompt: String) -> Result<()> {
     use std::io::Write as _;
 
-    let conn = Connector::connect(config)
-        .await
-        .map_err(|e| anyhow::anyhow!("connection failed: {e}"))?;
-    let mut signal_rx = conn.subscribe();
+    async move {
+        let conn = Connector::connect(config)
+            .instrument(adele::telemetry::connect_span())
+            .await
+            .map_err(|e| anyhow::anyhow!("connection failed: {e}"))?;
+        let mut signal_rx = conn.subscribe();
 
-    // Start the client-side MCP host for the `tui` surface and advertise its
-    // tools (merged with the built-ins) so a headless prompt can trigger local
-    // tools exactly like the interactive client. Keep the loaded config in scope
-    // so its per-surface disabled-built-in list can be consulted below.
-    let mcp_cfg = ClientMcpConfig::load(&default_client_mcp_path());
-    let servers: Vec<_> = mcp_cfg
-        .resolved_servers("tui")
-        .into_iter()
-        .cloned()
-        .collect();
-    // Compiled-in built-ins (da#538 Phase C/D): host the full core MCP set
-    // in-process. `McpHost::start_with_disabled` centralizes the override,
-    // skipping (and logging) any built-in whose name a client-mcp.toml server
-    // already provides, plus any the user disabled for the `tui` surface in
-    // client config (da#538 slice 4).
-    let mcp_builtins = adele::builtins::builtin_servers();
-    let host = if servers.is_empty() && mcp_builtins.is_empty() {
-        None
-    } else {
-        Some(
-            McpHost::start_with_disabled(
-                &servers,
-                mcp_builtins,
-                mcp_cfg.surface_disabled_builtins("tui"),
+        // Start the client-side MCP host for the `tui` surface and advertise its
+        // tools (merged with the built-ins) so a headless prompt can trigger local
+        // tools exactly like the interactive client. Keep the loaded config in scope
+        // so its per-surface disabled-built-in list can be consulted below.
+        let mcp_cfg = ClientMcpConfig::load(&default_client_mcp_path());
+        let servers: Vec<_> = mcp_cfg
+            .resolved_servers("tui")
+            .into_iter()
+            .cloned()
+            .collect();
+        // Compiled-in built-ins (da#538 Phase C/D): host the full core MCP set
+        // in-process. `McpHost::start_with_disabled` centralizes the override,
+        // skipping (and logging) any built-in whose name a client-mcp.toml server
+        // already provides, plus any the user disabled for the `tui` surface in
+        // client config (da#538 slice 4).
+        let mcp_builtins = adele::builtins::builtin_servers();
+        let host = if servers.is_empty() && mcp_builtins.is_empty() {
+            None
+        } else {
+            Some(
+                McpHost::start_with_disabled(
+                    &servers,
+                    mcp_builtins,
+                    mcp_cfg.surface_disabled_builtins("tui"),
+                )
+                .await,
             )
-            .await,
-        )
-    };
-    let host_tools = host.as_ref().map(|h| h.registrations()).unwrap_or_default();
-    let builtins = vec![
-        client_tools::say_this_registration(),
-        client_tools::request_voice_registration(),
-        client_tools::stop_voice_registration(),
-    ];
-    // Best-effort: client tools need a command channel (UDS/WS), not D-Bus.
-    let _ = conn
-        .register_client_tools(merge_registrations(builtins, host_tools))
-        .await;
+        };
+        let host_tools = host.as_ref().map(|h| h.registrations()).unwrap_or_default();
+        let builtins = vec![
+            client_tools::say_this_registration(),
+            client_tools::request_voice_registration(),
+            client_tools::stop_voice_registration(),
+        ];
+        // Best-effort: client tools need a command channel (UDS/WS), not D-Bus.
+        let _ = conn
+            .register_client_tools(merge_registrations(builtins, host_tools))
+            .instrument(adele::telemetry::registration_span())
+            .await;
 
-    let conversation_id = conn
-        .client()
-        .create_conversation("adele --prompt")
-        .await
-        .map_err(|e| anyhow::anyhow!("could not create conversation: {e}"))?;
-    let request_id = conn
-        .send_prompt_with_system_refinement(&conversation_id, &prompt, "")
-        .await
-        .map_err(|e| anyhow::anyhow!("could not send prompt: {e}"))?;
+        let conversation_id = conn
+            .client()
+            .create_conversation("adele --prompt")
+            .await
+            .map_err(|e| anyhow::anyhow!("could not create conversation: {e}"))?;
+        adele::telemetry::record_conversation_id(&tracing::Span::current(), &conversation_id);
 
-    let mut stdout = io::stdout();
-    let mut streamed = false;
-    while let Some(event) = signal_rx.recv().await {
-        match event {
-            SignalEvent::Chunk {
-                request_id: rid,
-                chunk,
-                ..
-            } if rid == request_id => {
-                streamed = true;
-                let _ = stdout.write_all(chunk.as_bytes());
-                let _ = stdout.flush();
-            }
-            SignalEvent::Complete {
-                request_id: rid,
-                full_response,
-                ..
-            } if rid == request_id => {
-                // Some providers don't stream chunks; fall back to the final text.
-                if !streamed {
-                    let _ = stdout.write_all(full_response.as_bytes());
-                }
-                let _ = writeln!(stdout);
-                break;
-            }
-            SignalEvent::Error {
-                request_id: rid,
-                error,
-                ..
-            } if rid == request_id => {
-                return Err(anyhow::anyhow!("{error}"));
-            }
-            SignalEvent::ClientToolCall {
-                task_id,
-                tool_call_id,
-                tool_name,
-                arguments,
-                ..
-            } => {
-                let result = match host.as_ref() {
-                    Some(host) if host.handles(&tool_name) => {
-                        host.call(&tool_name, arguments).await
+        let turn_started = Instant::now();
+        let request_id = conn
+            .send_prompt_with_system_refinement(&conversation_id, &prompt, "")
+            .await
+            .map_err(|e| anyhow::anyhow!("could not send prompt: {e}"))?;
+
+        let mut stdout = io::stdout();
+        let mut streamed = false;
+        let mut reply_bytes = 0usize;
+        let stream_span = adele::telemetry::reply_streaming_span(&request_id);
+        async {
+            while let Some(event) = signal_rx.recv().await {
+                match event {
+                    SignalEvent::Chunk {
+                        request_id: rid,
+                        chunk,
+                        ..
+                    } if rid == request_id => {
+                        streamed = true;
+                        reply_bytes += chunk.len();
+                        adele::telemetry::trace_chunk_received(chunk.len());
+                        let _ = stdout.write_all(chunk.as_bytes());
+                        let _ = stdout.flush();
                     }
-                    // The built-in client tools are TUI-visual (speak / show);
-                    // headless just resolves them so the turn completes.
-                    _ => client_tools::dispatch(&tool_name, &arguments, false).result,
-                };
-                let _ = conn
-                    .submit_client_tool_result(&task_id, &tool_call_id, result)
-                    .await;
+                    SignalEvent::Complete {
+                        request_id: rid,
+                        full_response,
+                        ..
+                    } if rid == request_id => {
+                        // Some providers don't stream chunks; fall back to the final text.
+                        if !streamed {
+                            reply_bytes += full_response.len();
+                            let _ = stdout.write_all(full_response.as_bytes());
+                        }
+                        let _ = writeln!(stdout);
+                        break;
+                    }
+                    SignalEvent::Error {
+                        request_id: rid,
+                        error,
+                        ..
+                    } if rid == request_id => {
+                        return Err(anyhow::anyhow!("{error}"));
+                    }
+                    SignalEvent::ClientToolCall {
+                        task_id,
+                        tool_call_id,
+                        tool_name,
+                        arguments,
+                        ..
+                    } => {
+                        let result = match host.as_ref() {
+                            Some(host) if host.handles(&tool_name) => {
+                                host.call(&tool_name, arguments).await
+                            }
+                            // The built-in client tools are TUI-visual (speak / show);
+                            // headless just resolves them so the turn completes.
+                            _ => client_tools::dispatch(&tool_name, &arguments, false).result,
+                        };
+                        let _ = conn
+                            .submit_client_tool_result(&task_id, &tool_call_id, result)
+                            .await;
+                    }
+                    _ => {}
+                }
             }
-            _ => {}
+            adele::telemetry::record_reply_bytes(&tracing::Span::current(), reply_bytes);
+            Ok(())
         }
+        .instrument(stream_span)
+        .await?;
+
+        adele::telemetry::record_turn_duration(turn_started.elapsed());
+        Ok(())
     }
-    Ok(())
+    .instrument(adele::telemetry::turn_span())
+    .await
 }
 
 /// Reconnect backoff state machine. Sequence: 2s → 4s → 8s → 16s → 30s,
@@ -825,7 +821,10 @@ async fn run(
 
     // Initial connect — on failure, fall straight into the backoff loop
     // instead of running with no connection.
-    match Connector::connect(config).await {
+    match Connector::connect(config)
+        .instrument(adele::telemetry::connect_span())
+        .await
+    {
         Ok(conn) => {
             signal_rx = subscribe_and_load(&mut app, &conn).await;
             finish_connection_init(&mut app, &conn).await;
@@ -1298,8 +1297,14 @@ async fn run(
                     ReconnectState::Connected => None,
                 };
                 app.status_message = "Reconnecting...".to_string();
-                match Connector::connect(config).await {
+                match Connector::connect(config)
+                    .instrument(adele::telemetry::connect_span())
+                    .await
+                {
                     Ok(conn) => {
+                        // A live connection replacing a dropped one — count it (task 6).
+                        // The initial connect above is not a reconnect and is not counted.
+                        adele::telemetry::record_reconnect();
                         // Subscribe + refresh the sidebar first (so the resync's
                         // by-id reselect runs against the FRESH list).
                         signal_rx = subscribe_and_load(&mut app, &conn).await;
@@ -2649,6 +2654,7 @@ async fn register_client_tools(conn: &Connector, host_tools: Vec<ClientToolRegis
     ];
     if let Err(e) = conn
         .register_client_tools(merge_registrations(builtins, host_tools))
+        .instrument(adele::telemetry::registration_span())
         .await
     {
         tracing::debug!("client tool registration skipped: {e}");
@@ -3033,24 +3039,9 @@ mod tests {
         out
     }
 
-    #[test]
-    fn log_filter_scales_level_with_verbosity_and_quiets_third_party() {
-        assert!(
-            log_filter(0).contains("adele=warn"),
-            "no -v => our crates stay at warn"
-        );
-        assert!(log_filter(1).contains("adele=info"), "one -v => info");
-        assert!(log_filter(2).contains("adele=debug"), "two -v => debug");
-        assert!(log_filter(3).contains("adele=trace"), "three -v => trace");
-        assert!(log_filter(9).contains("adele=trace"), "saturates at trace");
-        // Our client crates track the same level so streaming/registration is visible.
-        assert!(log_filter(2).contains("desktop_assistant_client_common=debug"));
-        // Third-party noise stays at warn regardless of verbosity.
-        assert!(
-            log_filter(3).starts_with("warn,"),
-            "base directive keeps third-party at warn"
-        );
-    }
+    // log_filter's own scaling behavior is covered by
+    // telemetry::tests::log_filter_scales_level_with_verbosity_and_quiets_third_party
+    // now that the function lives in that module (adele-tui#152).
 
     #[test]
     fn clap_parses_transport_flags() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -517,8 +517,6 @@ async fn main() -> Result<()> {
 /// and reply streaming are its child spans. None of this carries the prompt
 /// or reply text (D10) — only ids and byte counts.
 async fn run_headless(config: &ConnectionConfig, prompt: String) -> Result<()> {
-    use std::io::Write as _;
-
     async move {
         let conn = Connector::connect(config)
             .instrument(adele::telemetry::connect_span())
@@ -574,79 +572,40 @@ async fn run_headless(config: &ConnectionConfig, prompt: String) -> Result<()> {
         adele::telemetry::record_conversation_id(&tracing::Span::current(), &conversation_id);
 
         let turn_started = Instant::now();
-        let request_id = conn
+        let request_id = match conn
             .send_prompt_with_system_refinement(&conversation_id, &prompt, "")
             .await
-            .map_err(|e| anyhow::anyhow!("could not send prompt: {e}"))?;
+        {
+            Ok(request_id) => request_id,
+            Err(e) => {
+                // Deliberate choice (adele-tui#152 review): record a duration
+                // here too, symmetric with the stream-error path below. A
+                // turn rejected at submit still took time, and that time is
+                // exactly what an operator wants when the daemon is refusing
+                // or slow to accept work, not only when it accepts and then
+                // fails mid-stream.
+                adele::telemetry::record_turn_duration(turn_started.elapsed());
+                return Err(anyhow::anyhow!("could not send prompt: {e}"));
+            }
+        };
 
         let mut stdout = io::stdout();
-        let mut streamed = false;
-        let mut reply_bytes = 0usize;
         let stream_span = adele::telemetry::reply_streaming_span(&request_id);
-        // A turn error breaks the loop rather than returning directly, so the
-        // byte count and duration below are recorded on every exit — a turn
-        // that streamed several chunks before failing must not lose that
-        // count just because it ended in an error.
-        let mut turn_error = None;
-        async {
-            while let Some(event) = signal_rx.recv().await {
-                match event {
-                    SignalEvent::Chunk {
-                        request_id: rid,
-                        chunk,
-                        ..
-                    } if rid == request_id => {
-                        streamed = true;
-                        reply_bytes += chunk.len();
-                        adele::telemetry::trace_chunk_received(chunk.len());
-                        let _ = stdout.write_all(chunk.as_bytes());
-                        let _ = stdout.flush();
-                    }
-                    SignalEvent::Complete {
-                        request_id: rid,
-                        full_response,
-                        ..
-                    } if rid == request_id => {
-                        // Some providers don't stream chunks; fall back to the final text.
-                        if !streamed {
-                            reply_bytes += full_response.len();
-                            let _ = stdout.write_all(full_response.as_bytes());
-                        }
-                        let _ = writeln!(stdout);
-                        break;
-                    }
-                    SignalEvent::Error {
-                        request_id: rid,
-                        error,
-                        ..
-                    } if rid == request_id => {
-                        turn_error = Some(error);
-                        break;
-                    }
-                    SignalEvent::ClientToolCall {
-                        task_id,
-                        tool_call_id,
-                        tool_name,
-                        arguments,
-                        ..
-                    } => {
-                        let result = match host.as_ref() {
-                            Some(host) if host.handles(&tool_name) => {
-                                host.call(&tool_name, arguments).await
-                            }
-                            // The built-in client tools are TUI-visual (speak / show);
-                            // headless just resolves them so the turn completes.
-                            _ => client_tools::dispatch(&tool_name, &arguments, false).result,
-                        };
-                        let _ = conn
-                            .submit_client_tool_result(&task_id, &tool_call_id, result)
-                            .await;
-                    }
-                    _ => {}
-                }
-            }
-            adele::telemetry::record_reply_bytes(&tracing::Span::current(), reply_bytes);
-        }
+        // A `&Connector` (Copy) rather than `conn` itself, so the closure
+        // below can borrow it on every call instead of moving the one
+        // `Connector` value out of an `FnMut` closure it must survive.
+        let conn_ref = &conn;
+        let (_reply_bytes, turn_error) = stream_reply(
+            &mut signal_rx,
+            &request_id,
+            &mut stdout,
+            host.as_ref(),
+            |task_id, tool_call_id, result| async move {
+                let _ = conn_ref
+                    .submit_client_tool_result(&task_id, &tool_call_id, result)
+                    .await;
+            },
+        )
         .instrument(stream_span)
         .await;
 
@@ -658,6 +617,96 @@ async fn run_headless(config: &ConnectionConfig, prompt: String) -> Result<()> {
     }
     .instrument(adele::telemetry::turn_span())
     .await
+}
+
+/// Stream one turn's headless reply to `stdout`, dispatching any client-tool
+/// call that arrives mid-turn. Returns the total reply byte count and, if
+/// the turn ended in an error, the daemon's error text — the caller decides
+/// whether to record the duration and return `Err`.
+///
+/// Extracted from `run_headless` (adele-tui#152 review) so the loop that
+/// actually touches `chunk` and `full_response` is directly unit-testable
+/// with real content, not just with a byte count standing in for it — see
+/// `stream_reply_never_logs_chunk_or_reply_content` below, which failed
+/// against the inline version when reply content was logged directly and
+/// passes here. Only a byte count ever reaches telemetry (D10), via
+/// `adele::telemetry::trace_chunk_received` / `record_reply_bytes`.
+///
+/// `submit_tool_result` takes the place of a `&Connector` so this loop does
+/// not depend on a live daemon connection to be testable: production passes
+/// a closure that calls `conn.submit_client_tool_result`, and a test that
+/// never sends `SignalEvent::ClientToolCall` can pass one that panics if it
+/// is ever actually called.
+async fn stream_reply<F, Fut>(
+    signal_rx: &mut UnboundedReceiver<SignalEvent>,
+    request_id: &str,
+    stdout: &mut impl std::io::Write,
+    host: Option<&McpHost>,
+    mut submit_tool_result: F,
+) -> (usize, Option<String>)
+where
+    F: FnMut(String, String, Result<String, String>) -> Fut,
+    Fut: std::future::Future<Output = ()>,
+{
+    let mut streamed = false;
+    let mut reply_bytes = 0usize;
+    let mut turn_error = None;
+    while let Some(event) = signal_rx.recv().await {
+        match event {
+            SignalEvent::Chunk {
+                request_id: rid,
+                chunk,
+                ..
+            } if rid == request_id => {
+                streamed = true;
+                reply_bytes += chunk.len();
+                adele::telemetry::trace_chunk_received(chunk.len());
+                let _ = stdout.write_all(chunk.as_bytes());
+                let _ = stdout.flush();
+            }
+            SignalEvent::Complete {
+                request_id: rid,
+                full_response,
+                ..
+            } if rid == request_id => {
+                // Some providers don't stream chunks; fall back to the final text.
+                if !streamed {
+                    reply_bytes += full_response.len();
+                    let _ = stdout.write_all(full_response.as_bytes());
+                }
+                let _ = writeln!(stdout);
+                break;
+            }
+            SignalEvent::Error {
+                request_id: rid,
+                error,
+                ..
+            } if rid == request_id => {
+                turn_error = Some(error);
+                break;
+            }
+            SignalEvent::ClientToolCall {
+                task_id,
+                tool_call_id,
+                tool_name,
+                arguments,
+                ..
+            } => {
+                let result = match host {
+                    Some(host) if host.handles(&tool_name) => {
+                        host.call(&tool_name, arguments).await
+                    }
+                    // The built-in client tools are TUI-visual (speak / show);
+                    // headless just resolves them so the turn completes.
+                    _ => client_tools::dispatch(&tool_name, &arguments, false).result,
+                };
+                submit_tool_result(task_id, tool_call_id, result).await;
+            }
+            _ => {}
+        }
+    }
+    adele::telemetry::record_reply_bytes(&tracing::Span::current(), reply_bytes);
+    (reply_bytes, turn_error)
 }
 
 /// Reconnect backoff state machine. Sequence: 2s → 4s → 8s → 16s → 30s,
@@ -3050,6 +3099,157 @@ mod tests {
     // log_filter's own scaling behavior is covered by
     // telemetry::tests::log_filter_scales_level_with_verbosity_and_quiets_third_party
     // now that the function lives in that module (adele-tui#152).
+
+    #[derive(Clone, Default)]
+    struct SharedBuf(std::sync::Arc<std::sync::Mutex<Vec<u8>>>);
+
+    impl std::io::Write for SharedBuf {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for SharedBuf {
+        type Writer = SharedBuf;
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    /// D10, proven by mutation rather than read alone (adele-tui#152 review):
+    /// a version of this test that called the telemetry helpers directly
+    /// with `secret.len()` instead of `secret` passed the whole suite even
+    /// with `tracing::info!(%chunk, ...)` injected into the real `Chunk`
+    /// arm — the secret never reached the code under test, so the assertion
+    /// could not fail. This one instead drives [`stream_reply`], the actual
+    /// function `run_headless` calls, with the real secret through a real
+    /// channel, under a real capturing subscriber, and does fail against
+    /// that same mutation.
+    #[tokio::test]
+    async fn stream_reply_never_logs_chunk_or_reply_content() {
+        let secret = "the user's real conversation: TOP-SECRET-CONVERSATION-CONTENT";
+
+        let (tx, mut rx) = unbounded_channel::<SignalEvent>();
+        tx.send(SignalEvent::Chunk {
+            conversation_id: "conv-1".to_string(),
+            request_id: "req-1".to_string(),
+            chunk: secret.to_string(),
+        })
+        .expect("the receiver is still open");
+        tx.send(SignalEvent::Complete {
+            conversation_id: "conv-1".to_string(),
+            request_id: "req-1".to_string(),
+            full_response: secret.to_string(),
+        })
+        .expect("the receiver is still open");
+        drop(tx);
+
+        let buf = SharedBuf::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(buf.clone())
+            .with_ansi(false)
+            .with_max_level(tracing::Level::TRACE)
+            .finish();
+        // #[tokio::test] defaults to the current-thread flavor, so this
+        // thread-local default is safe to hold across the `.await` below —
+        // the task never migrates to another OS thread mid-poll.
+        let guard = tracing::subscriber::set_default(subscriber);
+
+        let mut stdout: Vec<u8> = Vec::new();
+        let (reply_bytes, turn_error) = stream_reply(
+            &mut rx,
+            "req-1",
+            &mut stdout,
+            None,
+            |_task_id, _tool_call_id, _result: Result<String, String>| async {
+                panic!("this test never sends a ClientToolCall event")
+            },
+        )
+        .await;
+
+        drop(guard);
+
+        assert!(turn_error.is_none(), "no error was sent: {turn_error:?}");
+        assert_eq!(
+            reply_bytes,
+            secret.len(),
+            "the streamed chunk's byte count must still be recorded"
+        );
+
+        let stdout_text = String::from_utf8(stdout).expect("stdout is valid utf8");
+        assert!(
+            stdout_text.contains(secret),
+            "the reply must still reach stdout, its legitimate channel: {stdout_text:?}"
+        );
+
+        let logs =
+            String::from_utf8(buf.0.lock().unwrap().clone()).expect("log output is valid utf8");
+        assert!(
+            !logs.contains(secret),
+            "reply content reached a log line or span field: {logs}"
+        );
+    }
+
+    /// The non-streaming fallback (a provider that sent no `Chunk` events,
+    /// only `Complete`) writes `full_response` from a different branch of
+    /// the same match arm and carries the same D10 risk — covered
+    /// separately so a leak specific to that branch cannot hide behind the
+    /// streamed case above.
+    #[tokio::test]
+    async fn stream_reply_never_logs_full_response_when_not_streamed() {
+        let secret = "the assistant's real, unstreamed reply: SECOND-SECRET-CONTENT";
+
+        let (tx, mut rx) = unbounded_channel::<SignalEvent>();
+        tx.send(SignalEvent::Complete {
+            conversation_id: "conv-1".to_string(),
+            request_id: "req-1".to_string(),
+            full_response: secret.to_string(),
+        })
+        .expect("the receiver is still open");
+        drop(tx);
+
+        let buf = SharedBuf::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(buf.clone())
+            .with_ansi(false)
+            .with_max_level(tracing::Level::TRACE)
+            .finish();
+        let guard = tracing::subscriber::set_default(subscriber);
+
+        let mut stdout: Vec<u8> = Vec::new();
+        let (reply_bytes, turn_error) = stream_reply(
+            &mut rx,
+            "req-1",
+            &mut stdout,
+            None,
+            |_task_id, _tool_call_id, _result: Result<String, String>| async {
+                panic!("this test never sends a ClientToolCall event")
+            },
+        )
+        .await;
+
+        drop(guard);
+
+        assert!(turn_error.is_none(), "no error was sent: {turn_error:?}");
+        assert_eq!(reply_bytes, secret.len());
+
+        let stdout_text = String::from_utf8(stdout).expect("stdout is valid utf8");
+        assert!(
+            stdout_text.contains(secret),
+            "the reply must still reach stdout: {stdout_text:?}"
+        );
+
+        let logs =
+            String::from_utf8(buf.0.lock().unwrap().clone()).expect("log output is valid utf8");
+        assert!(
+            !logs.contains(secret),
+            "reply content reached a log line or span field: {logs}"
+        );
+    }
 
     #[test]
     fn clap_parses_transport_flags() {

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -17,6 +17,24 @@
 
 use std::time::Duration;
 
+use tracing::field::Empty;
+
+/// Verbose-count -> `EnvFilter` directive. `RUST_LOG`, when set, wins over
+/// this; see [`init_logging`]. Higher counts widen the level for our own
+/// crates while keeping third-party noise at `warn`.
+fn log_filter(verbose: u8) -> String {
+    let level = match verbose {
+        0 => "warn",
+        1 => "info",
+        2 => "debug",
+        _ => "trace",
+    };
+    format!(
+        "warn,adele={level},desktop_assistant_client_common={level},\
+         desktop_assistant_mcp_client={level},client_ui_common={level}"
+    )
+}
+
 /// Install telemetry for this process (epic `mcp-core#38`, `adele-tui#152`).
 ///
 /// Silent by default: with `verbose == 0` and `RUST_LOG` unset, this installs
@@ -24,8 +42,28 @@ use std::time::Duration;
 /// headless `exec` run must stay quiet unless asked). Hold the returned guard
 /// for the life of `main` — dropping it early stops the process from
 /// flushing on exit.
-pub fn init_logging(_verbose: u8) -> Option<adelie_telemetry::Guard> {
-    unimplemented!("adele-tui#152: init_logging must route through adelie_telemetry::init")
+///
+/// The periodic metrics summary stays off here (`Duration::ZERO`): a TUI has
+/// a screen to protect, and the daemon is where the interesting numbers
+/// live. `init` itself never fails the process — a bad `OTEL_*` value costs
+/// the run its exporter, not its console logging — but its signature still
+/// returns a `Result`, so a failure that cannot happen today is still
+/// reported rather than unwrapped.
+pub fn init_logging(verbose: u8) -> Option<adelie_telemetry::Guard> {
+    let has_rust_log = std::env::var_os("RUST_LOG").is_some();
+    if verbose == 0 && !has_rust_log {
+        return None;
+    }
+    let config = adelie_telemetry::Config::new("adele-tui")
+        .with_default_filter(log_filter(verbose))
+        .with_metrics_dump_interval(Duration::ZERO);
+    match adelie_telemetry::init(config) {
+        Ok(guard) => Some(guard),
+        Err(error) => {
+            eprintln!("adele: telemetry did not start: {error}");
+            None
+        }
+    }
 }
 
 /// The root span for one turn (D12/D13 shape). Open it the moment the prompt
@@ -34,49 +72,51 @@ pub fn init_logging(_verbose: u8) -> Option<adelie_telemetry::Guard> {
 /// streaming. Carries the conversation id once known, via
 /// [`record_conversation_id`]. Never carries the prompt or reply text (D10).
 pub fn turn_span() -> tracing::Span {
-    unimplemented!("adele-tui#152: turn_span")
+    tracing::info_span!("turn", conversation_id = Empty)
 }
 
 /// Record the conversation a turn span belongs to, once it is known.
-pub fn record_conversation_id(_span: &tracing::Span, _conversation_id: &str) {
-    unimplemented!("adele-tui#152: record_conversation_id")
+pub fn record_conversation_id(span: &tracing::Span, conversation_id: &str) {
+    span.record("conversation_id", conversation_id);
 }
 
 /// A span around establishing the daemon connection.
 pub fn connect_span() -> tracing::Span {
-    unimplemented!("adele-tui#152: connect_span")
+    tracing::info_span!("connect")
 }
 
 /// A span around advertising this client's tools to the daemon.
 pub fn registration_span() -> tracing::Span {
-    unimplemented!("adele-tui#152: registration_span")
+    tracing::info_span!("registration")
 }
 
 /// A span around streaming one turn's reply. Carries the request id and,
 /// once streaming ends, the byte count — never the reply text (D10).
-pub fn reply_streaming_span(_request_id: &str) -> tracing::Span {
-    unimplemented!("adele-tui#152: reply_streaming_span")
+pub fn reply_streaming_span(request_id: &str) -> tracing::Span {
+    tracing::info_span!("reply_streaming", request_id = %request_id, reply_bytes = Empty)
 }
 
 /// Record how many bytes a completed reply carried, without recording the
 /// text itself (D10).
-pub fn record_reply_bytes(_span: &tracing::Span, _bytes: usize) {
-    unimplemented!("adele-tui#152: record_reply_bytes")
+pub fn record_reply_bytes(span: &tracing::Span, bytes: usize) {
+    span.record("reply_bytes", bytes as u64);
 }
 
 /// Log that a reply chunk arrived, at TRACE, without its content (D10).
-pub fn trace_chunk_received(_chunk_len: usize) {
-    unimplemented!("adele-tui#152: trace_chunk_received")
+/// Content-level detail belongs to the daemon's own DEBUG logging of the
+/// same turn (D10), not the client's.
+pub fn trace_chunk_received(chunk_len: usize) {
+    tracing::trace!(chunk_len, "reply chunk received");
 }
 
 /// Count a successful reconnect to the daemon after a connection drop.
 pub fn record_reconnect() {
-    unimplemented!("adele-tui#152: record_reconnect")
+    adelie_telemetry::metrics::increment("adele_tui.reconnects", &[]);
 }
 
 /// Record how long one turn took end to end, from submit to reply-complete.
-pub fn record_turn_duration(_elapsed: Duration) {
-    unimplemented!("adele-tui#152: record_turn_duration")
+pub fn record_turn_duration(elapsed: Duration) {
+    adelie_telemetry::metrics::record_duration("adele_tui.turn_duration", elapsed, &[]);
 }
 
 #[cfg(test)]
@@ -102,6 +142,23 @@ mod tests {
         fn make_writer(&'a self) -> Self::Writer {
             self.clone()
         }
+    }
+
+    #[test]
+    fn log_filter_scales_level_with_verbosity_and_quiets_third_party() {
+        assert!(
+            log_filter(0).contains("adele=warn"),
+            "no -v => our crates stay at warn"
+        );
+        assert!(log_filter(1).contains("adele=info"), "one -v => info");
+        assert!(log_filter(2).contains("adele=debug"), "two -v => debug");
+        assert!(log_filter(3).contains("adele=trace"), "three -v => trace");
+        assert!(log_filter(9).contains("adele=trace"), "saturates at trace");
+        assert!(log_filter(2).contains("desktop_assistant_client_common=debug"));
+        assert!(
+            log_filter(3).starts_with("warn,"),
+            "base directive keeps third-party at warn"
+        );
     }
 
     /// D10: none of the span/metric helpers may let prompt or reply content

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -1,0 +1,171 @@
+//! Telemetry wiring for the `adele` binary (epic `mcp-core#38`, `adele-tui#152`).
+//!
+//! `init_logging` is the only place in this process that installs a tracing
+//! subscriber (epic D5); this binary hosts mcp-core server libraries
+//! in-process, and none of them installs one of their own.
+//!
+//! The span and metric helpers below are the seam the D10 content contract is
+//! enforced at: none of them accept the prompt or reply text, only ids and
+//! counts, so a call site cannot pass content through them even by accident.
+//!
+//! The root `turn` span follows the shape `desktop-assistant#1152` needs
+//! (D12/D13): open it the moment a prompt is committed, close it when the
+//! reply finishes streaming, and carry the conversation id as an attribute.
+//! This crate does not yet carry that span to the daemon as a `traceparent`
+//! — that propagation is `desktop-assistant#1152`'s job. Placing the span
+//! correctly now means that ticket does not have to move it.
+
+use std::time::Duration;
+
+/// Install telemetry for this process (epic `mcp-core#38`, `adele-tui#152`).
+///
+/// Silent by default: with `verbose == 0` and `RUST_LOG` unset, this installs
+/// nothing and returns `None`, matching the CLI's documented behavior (a
+/// headless `exec` run must stay quiet unless asked). Hold the returned guard
+/// for the life of `main` — dropping it early stops the process from
+/// flushing on exit.
+pub fn init_logging(_verbose: u8) -> Option<adelie_telemetry::Guard> {
+    unimplemented!("adele-tui#152: init_logging must route through adelie_telemetry::init")
+}
+
+/// The root span for one turn (D12/D13 shape). Open it the moment the prompt
+/// is committed — read from the CLI in the headless path, submitted from the
+/// composer in the interactive one — and hold it until the reply finishes
+/// streaming. Carries the conversation id once known, via
+/// [`record_conversation_id`]. Never carries the prompt or reply text (D10).
+pub fn turn_span() -> tracing::Span {
+    unimplemented!("adele-tui#152: turn_span")
+}
+
+/// Record the conversation a turn span belongs to, once it is known.
+pub fn record_conversation_id(_span: &tracing::Span, _conversation_id: &str) {
+    unimplemented!("adele-tui#152: record_conversation_id")
+}
+
+/// A span around establishing the daemon connection.
+pub fn connect_span() -> tracing::Span {
+    unimplemented!("adele-tui#152: connect_span")
+}
+
+/// A span around advertising this client's tools to the daemon.
+pub fn registration_span() -> tracing::Span {
+    unimplemented!("adele-tui#152: registration_span")
+}
+
+/// A span around streaming one turn's reply. Carries the request id and,
+/// once streaming ends, the byte count — never the reply text (D10).
+pub fn reply_streaming_span(_request_id: &str) -> tracing::Span {
+    unimplemented!("adele-tui#152: reply_streaming_span")
+}
+
+/// Record how many bytes a completed reply carried, without recording the
+/// text itself (D10).
+pub fn record_reply_bytes(_span: &tracing::Span, _bytes: usize) {
+    unimplemented!("adele-tui#152: record_reply_bytes")
+}
+
+/// Log that a reply chunk arrived, at TRACE, without its content (D10).
+pub fn trace_chunk_received(_chunk_len: usize) {
+    unimplemented!("adele-tui#152: trace_chunk_received")
+}
+
+/// Count a successful reconnect to the daemon after a connection drop.
+pub fn record_reconnect() {
+    unimplemented!("adele-tui#152: record_reconnect")
+}
+
+/// Record how long one turn took end to end, from submit to reply-complete.
+pub fn record_turn_duration(_elapsed: Duration) {
+    unimplemented!("adele-tui#152: record_turn_duration")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Clone, Default)]
+    struct SharedBuf(Arc<Mutex<Vec<u8>>>);
+
+    impl std::io::Write for SharedBuf {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for SharedBuf {
+        type Writer = SharedBuf;
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    /// D10: none of the span/metric helpers may let prompt or reply content
+    /// reach a log line or a span field. This exercises every helper with a
+    /// secret standing in for real conversation content and asserts the
+    /// secret never appears in the captured console output, while the
+    /// structural markers (span names, ids) do.
+    #[test]
+    fn spans_do_not_record_prompt_or_reply_text() {
+        let buf = SharedBuf::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(buf.clone())
+            .with_ansi(false)
+            .with_max_level(tracing::Level::TRACE)
+            .finish();
+
+        let secret = "the model must never see this logged: SECRET-PROMPT-CONTENT";
+
+        tracing::subscriber::with_default(subscriber, || {
+            let turn = turn_span();
+            let _turn_guard = turn.enter();
+            record_conversation_id(&turn, "conv-abc123");
+
+            let connect = connect_span();
+            connect.in_scope(|| tracing::info!("connected"));
+
+            let register = registration_span();
+            register.in_scope(|| tracing::info!("registered"));
+
+            let stream = reply_streaming_span("req-xyz789");
+            let _stream_guard = stream.enter();
+            trace_chunk_received(secret.len());
+            record_reply_bytes(&stream, secret.len());
+            tracing::trace!("stream closed");
+        });
+
+        let output = String::from_utf8(buf.0.lock().unwrap().clone()).unwrap();
+        assert!(
+            !output.contains("SECRET-PROMPT-CONTENT") && !output.contains(secret),
+            "a span or event recorded reply content: {output}"
+        );
+        assert!(
+            output.contains("turn"),
+            "the root turn span must appear: {output}"
+        );
+        assert!(
+            output.contains("conv-abc123"),
+            "the conversation id must be recorded on the root span: {output}"
+        );
+        assert!(
+            output.contains("connect"),
+            "the connect span must appear: {output}"
+        );
+        assert!(
+            output.contains("registration"),
+            "the registration span must appear: {output}"
+        );
+        assert!(
+            output.contains("reply_streaming"),
+            "the reply-streaming span must appear: {output}"
+        );
+        assert!(
+            output.contains("req-xyz789"),
+            "the request id must be recorded on the streaming span: {output}"
+        );
+    }
+}

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -161,21 +161,29 @@ mod tests {
         );
     }
 
-    /// D10: none of the span/metric helpers may let prompt or reply content
-    /// reach a log line or a span field. This exercises every helper with a
-    /// secret standing in for real conversation content and asserts the
-    /// secret never appears in the captured console output, while the
-    /// structural markers (span names, ids) do.
+    /// Structural check on the span/metric helpers: each one's name and id
+    /// field actually reach the console, correctly nested and recorded.
+    ///
+    /// This is *not* the D10 content test. Every helper here takes only
+    /// `&str` ids and `usize` counts, so no string of conversation content
+    /// can be passed to them at all - the type signature is the D10
+    /// enforcement, and a test that fed one of them `secret.len()` instead
+    /// of `secret` would prove nothing beyond what the compiler already
+    /// guarantees (a real prior version of this test did exactly that, and
+    /// passed even with a review-injected content leak in the code that
+    /// calls these helpers). The real D10 guarantee - that the call sites in
+    /// `run_headless` never pass content through in the first place - is
+    /// `stream_reply_never_logs_chunk_or_reply_content` and
+    /// `stream_reply_never_logs_full_response_when_not_streamed` in
+    /// `main.rs`, which drive the actual code with real content.
     #[test]
-    fn spans_do_not_record_prompt_or_reply_text() {
+    fn span_helpers_record_ids_and_structure() {
         let buf = SharedBuf::default();
         let subscriber = tracing_subscriber::fmt()
             .with_writer(buf.clone())
             .with_ansi(false)
             .with_max_level(tracing::Level::TRACE)
             .finish();
-
-        let secret = "the model must never see this logged: SECRET-PROMPT-CONTENT";
 
         tracing::subscriber::with_default(subscriber, || {
             let turn = turn_span();
@@ -190,16 +198,12 @@ mod tests {
 
             let stream = reply_streaming_span("req-xyz789");
             let _stream_guard = stream.enter();
-            trace_chunk_received(secret.len());
-            record_reply_bytes(&stream, secret.len());
+            trace_chunk_received(61);
+            record_reply_bytes(&stream, 61);
             tracing::trace!("stream closed");
         });
 
         let output = String::from_utf8(buf.0.lock().unwrap().clone()).unwrap();
-        assert!(
-            !output.contains("SECRET-PROMPT-CONTENT") && !output.contains(secret),
-            "a span or event recorded reply content: {output}"
-        );
         assert!(
             output.contains("turn"),
             "the root turn span must appear: {output}"

--- a/tests/acceptance_telemetry.rs
+++ b/tests/acceptance_telemetry.rs
@@ -1,0 +1,167 @@
+//! Acceptance criteria for `adele-tui#152` (adopt `adelie-telemetry`).
+//!
+//! The stdout/stderr checks run a separate process on purpose (mirroring
+//! `adelie-telemetry`'s own acceptance tests): a subscriber built against a
+//! capture writer proves what it was told to do, not what actually reached
+//! file descriptor 1. The headless `--prompt`/`exec` path writes the model
+//! reply to stdout, so the difference is the whole point (D1).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Where `cargo test` leaves the example binary. `cargo test` builds
+/// examples (to verify they compile) even when it does not run them, so the
+/// probe is always there by the time these tests run.
+fn probe_binary() -> PathBuf {
+    let mut path = std::env::current_exe().expect("a test binary knows its own path");
+    path.pop(); // this test binary's file name
+    if path.ends_with("deps") {
+        path.pop();
+    }
+    path.push("examples");
+    path.push("logging_probe");
+    path
+}
+
+fn run_probe(args: &[&str], rust_log: Option<&str>) -> std::process::Output {
+    let probe = probe_binary();
+    assert!(
+        probe.is_file(),
+        "the logging_probe example must be built before this test can prove anything; \
+         expected it at {}",
+        probe.display()
+    );
+
+    let mut command = Command::new(&probe);
+    command.args(args);
+    // A clean environment: the test must control RUST_LOG/verbosity itself,
+    // not inherit whatever the outer shell happens to have set.
+    command.env_remove("RUST_LOG");
+    if let Some(value) = rust_log {
+        command.env("RUST_LOG", value);
+    }
+    command.output().expect("the probe must run")
+}
+
+/// With `verbose == 0` and `RUST_LOG` unset, no subscriber is installed and
+/// nothing is written to either stream.
+#[test]
+fn no_subscriber_when_quiet() {
+    let output = run_probe(&[], None);
+
+    assert!(
+        output.status.success(),
+        "the probe must exit cleanly: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "quiet by default: stdout must be empty, got {:?}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        output.stderr.is_empty(),
+        "quiet by default: no subscriber means no log line on stderr either, got {:?}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// `-v` produces output on stderr and nothing on stdout.
+#[test]
+fn verbose_flag_installs_a_stderr_subscriber() {
+    let output = run_probe(&["-v"], None);
+
+    assert!(
+        output.status.success(),
+        "the probe must exit cleanly: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "no --with-reply was given, so stdout must stay empty, got {:?}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("ERROR"),
+        "-v must install a subscriber that writes to stderr; got {stderr:?}"
+    );
+}
+
+/// With `RUST_LOG=trace` and the headless `--prompt`/`exec` path, stdout
+/// holds only the model reply and no log line.
+#[test]
+fn prompt_mode_stdout_carries_only_the_reply() {
+    let output = run_probe(&["--with-reply"], Some("trace"));
+
+    assert!(
+        output.status.success(),
+        "the probe must exit cleanly: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(
+        stdout, "REPLY-MARKER",
+        "stdout must hold only the reply marker, nothing else: {stdout:?}"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    for level in ["TRACE", "DEBUG", "INFO", "WARN", "ERROR"] {
+        assert!(
+            stderr.contains(level),
+            "RUST_LOG=trace must reach every level on stderr; missing {level} in {stderr:?}"
+        );
+    }
+    for level in ["TRACE", "DEBUG", "INFO", "WARN", "ERROR"] {
+        assert!(
+            !stdout.contains(level),
+            "no log line may reach stdout; found {level} in {stdout:?}"
+        );
+    }
+}
+
+/// A default-feature build of `adele` resolves no `opentelemetry` crate.
+#[test]
+fn default_build_pulls_no_opentelemetry() {
+    if cfg!(feature = "otel") {
+        // This test binary was compiled with the feature on, so it cannot
+        // say anything about a default build. `just check` runs the plain
+        // configuration too, and that run makes this assertion for real.
+        return;
+    }
+
+    let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_owned());
+    let manifest = concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml");
+
+    let output = Command::new(cargo)
+        .args([
+            "tree",
+            "--edges",
+            "normal",
+            "--prefix",
+            "none",
+            "--manifest-path",
+            manifest,
+        ])
+        .output()
+        .expect("cargo tree must run");
+
+    assert!(
+        output.status.success(),
+        "cargo tree failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let tree = String::from_utf8_lossy(&output.stdout);
+    let leaked: Vec<&str> = tree
+        .lines()
+        .map(str::trim)
+        .filter(|line| line.starts_with("opentelemetry"))
+        .collect();
+
+    assert!(
+        leaked.is_empty(),
+        "a default build must resolve no opentelemetry crate, found: {leaked:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `adelie-telemetry` as a git dependency pinned by revision (currently `36dcd57`, the bidi-label-sanitiser fix - see "Dependency pin" below), plus an off-by-default `otel` passthrough feature (epic `mcp-core#38` D2).
- `init_logging` now routes through `adelie_telemetry::init`, returning `Option<Guard>` (held for the life of `main`, epic D6) instead of `()`. The silent-by-default gate (`verbose == 0`, `RUST_LOG` unset) is unchanged, and logs still go to stderr only.
- Adds `turn`/`connect`/`registration`/`reply_streaming` spans (D12/D13 shape) around `run_headless` and the interactive path's connect/reconnect/registration, plus a `adele_tui.turn_duration` metric and an `adele_tui.reconnects` counter through the `adelie-telemetry` metrics facade. No span or metric ever carries prompt or reply text (D10).
- README gains a Logging section (`-v`, `RUST_LOG`, stderr, the `otel` feature, the per-signal `OTEL_*` variables). `justfile` gains `check-otel` / `check-all`.

## Dependency pin

Bumped three times during review, `59c152d` (Phase 0) -> `1b8166a` -> `36dcd57`:

- `1b8166a` fixed two bugs: `otel-tls`, a *default* feature, requested a reqwest feature that no longer exists, so every consumer silently resolved `reqwest` 0.13.1 instead of its current 0.13.4, whether or not `otel` was ever enabled. Bumping the pin alone did not clear this (`cargo update -p adelie-telemetry` only re-resolves what the new rev strictly requires); it took a further `cargo update -p reqwest@0.13.1` to let it move. It now resolves to 0.13.4 for the six crates in this graph that depend on it. Also: gRPC over TLS never verified anything (the OTLP exporter built its channel with no trust roots enabled and rejected every certificate); both transports now read the OS trust store.
- `36dcd57` closes a gap in the crate's own label sanitiser: it stripped control characters but not the bidirectional format characters, so a metric label containing U+202E rendered in a terminal with everything after it visually reversed. Our `adele_tui.reconnects`/`adele_tui.turn_duration` metrics go through this same facade. Confirmed against the crate's own history that this fix touches no dependency - only `src/metrics/registry.rs` and `src/otel/preflight.rs` changed.

adele-tui never carried a pin of its own around the reqwest ceiling - the `reqwest` requirement in this `Cargo.toml` is the unconstrained `version = "0.12"` line for the 0.12 line `oauth2` pulls in, and the 0.13.x line comes in transitively at whatever `adelie-telemetry` (and `desktop-assistant-client-common`) allow. There was nothing to unwind.

**Verification method for the last two bumps: diff the full `Cargo.lock` against `origin/main`, not just against the previous commit.** A targeted `cargo update -p adelie-telemetry` is not guaranteed to leave every other package resolution untouched, and comparing only to the last commit would not catch a regression that was already present in an earlier commit of this same branch. Categorized every changed line in the delta against `origin/main`: the only in-place version changes anywhere are four already-explained upgrades (`reqwest` 0.13.1->0.13.4, `thiserror`/`thiserror-impl` 2.0.18->2.0.19, `tokio` 1.52.1->1.53.1), no package is removed, and nothing goes down in version - with one exception this check caught: the `36dcd57` bump's `cargo update -p adelie-telemetry` invocation had also silently re-resolved `prost-derive`'s `itertools` dependency from 0.14.0 down to 0.13.0. Both versions satisfy `prost-derive`'s own `>=0.10.1, <=0.14` range and both already exist in the tree for unrelated reasons (`bindgen` needs `<0.14`, `ratatui`'s chain needs `0.14.x`); a scratch full `cargo generate-lockfile` confirmed 0.14.0 is the canonical choice, and CVE-scanning 0.13.0 came back clean regardless, so this was resolver noise, not a real regression - but it was corrected back to 0.14.0 (an existing, already-checksummed block, so no package or checksum was added) and reverified against `origin/main` a second time.

CVE scan (cve-mcp) on every version-changed crate across all three bumps - `reqwest` 0.13.4, `rustls-native-certs` 0.8.3, `windows-sys` 0.61.2, `itertools` 0.13.0 and 0.14.0 - came back clean, same as the original 19-package scan when the dependency was first added.

## Review fixes

**First pass.** `run_headless`'s reply-streaming loop returned `Err` directly from the `SignalEvent::Error` arm, skipping the `record_reply_bytes`/`record_turn_duration` calls after the loop - a turn that streamed several chunks and then failed mid-stream lost its byte count, and no duration was recorded for a failed turn. Fixed: the loop breaks into a captured error instead of returning early, so both metrics record on every exit path before the error is raised.

**Second pass, MEDIUM - the D10 acceptance test could not fail.** It called the telemetry helpers directly with `secret.len()` instead of `secret`, so the content never reached any tested code - those helpers take only `&str` ids and `usize` counts, so the assertion was redundant with the compiler. Proven by mutation: injecting `tracing::info!(%chunk, "MUTATION: leaking reply content")` into the real `Chunk` arm still passed the whole suite. Fixed by extraction, not a bigger assertion: the reply loop is now `stream_reply`, a standalone function taking a `submit_tool_result` closure in place of `&Connector` so it is unit-testable without a live daemon connection. Two new tests drive it with a real secret through a real channel under a real capturing subscriber - `stream_reply_never_logs_chunk_or_reply_content` (the streamed path) and `stream_reply_never_logs_full_response_when_not_streamed` (the `!streamed` fallback branch, a materially different code path with the same risk). Verified both catch a leak: re-applied the reviewer's exact mutation plus the equivalent for `full_response`, watched each test fail with the secret in the panic message, reverted. The old test (`telemetry.rs`) is renamed to `span_helpers_record_ids_and_structure`, no longer claims to test D10, and its doc comment points at the two real tests. Also mutation-tested `no_subscriber_when_quiet` and `verbose_flag_installs_a_stderr_subscriber` the same way; each caught its own mutation.

**Second pass, LOW - asymmetric duration recording.** `send_prompt_with_system_refinement` failing meant no `turn_duration` was recorded, asymmetric with the stream-error fix above. Deliberate choice, not incidental: record it there too. A turn rejected at submit still took time, and that is the number an operator wants when the daemon is refusing or slow to accept work.

## Left undone (and why)

The interactive TUI's send -> stream-reply path is driven by `handle_signal`, invoked once per `SignalEvent` from the shared `select!` loop, not by one straight-line async function the way `run_headless` is. Giving it its own per-turn root span would mean threading span state through the event loop and into `client-ui-common`'s reducer - a materially larger change than "adopt the telemetry crate," and not required by any named acceptance criterion here. `desktop-assistant#1152` (which carries the span to the daemon as a `traceparent`) is the ticket that needs this shape decided; this PR intentionally stops at `run_headless` plus the session-level connect/registration spans, placed so `#1152` does not have to move them.

(Noted separately, no action needed here: `adele-gtk` reached the same deferral independently, and the underlying gap - `client-ui-common` has no per-request span/duration hook to thread through - is now filed as `client-ui-common#51`, recorded as a hard prerequisite on `desktop-assistant#1152`.)

## Test plan

- [x] `just check` (default features): fmt, clippy `-D warnings`, build, test - all green, at the current pin.
- [x] `just check-otel` (`--features otel`): same, all green, at the current pin.
- [x] `cargo tree --edges normal` with default features resolves no `opentelemetry*` crate; with `--features otel` it does.
- [x] `no_subscriber_when_quiet`, `verbose_flag_installs_a_stderr_subscriber`, `prompt_mode_stdout_carries_only_the_reply` run the real binary logic as a subprocess (`examples/logging_probe.rs`) and assert on real file descriptors.
- [x] `stream_reply_never_logs_chunk_or_reply_content` / `stream_reply_never_logs_full_response_when_not_streamed` (D10) drive the real reply-handling function with real secret content under a real capturing subscriber; both confirmed to fail against the mutations that motivated them.
- [x] Every acceptance test that has a plausible vacuous-test failure mode was mutation-tested: the code was deliberately broken and the test was watched failing for the right reason, then reverted. Not repeated for `default_build_pulls_no_opentelemetry` (a real `cargo tree` parse over a real subprocess output - no helper indirection to be vacuous about) or `prompt_mode_stdout_carries_only_the_reply` (independently confirmed sound by the second review pass already).
- [x] Verified against a real collector (`docker.io/otel/opentelemetry-collector-contrib:0.144.0` via podman) over **both** OTLP transports:
  - `http/protobuf`: the probe's `turn`/`connect` spans, the `adele_tui.reconnects` counter, the `adele_tui.turn_duration` histogram, and its log records all arrived.
  - `grpc`: re-ran against the same collector with `OTEL_EXPORTER_OTLP_PROTOCOL=grpc`, using the real `adele` binary (not the example probe - the probe's `fn main` is not `#[tokio::main]`, and gRPC needs a Tokio runtime; run against the probe it correctly hit the documented "needs a Tokio runtime" pipeline error and fell back to console-only rather than panicking, which is a second, incidental confirmation that a bad OTLP config never takes the process down). The `turn`/`connect` spans arrived over gRPC too. Metrics were not separately re-verified over gRPC in this repo - the pipeline construction is identical across all three signals in the upstream crate (its own gRPC-TLS fix touches traces, metrics, and logs uniformly), and that crate's own gate already verifies all three signals against a real collector on both transports.
- [ ] Not run: a real daemon round trip (`run_headless` reaching `Complete` with actual streamed content). No daemon instance available in this environment. The content-handling code is now covered directly by the two `stream_reply` tests above; the connect/register/send plumbing around it was verified by direct reading and by the collector checks, not by an end-to-end daemon turn.

Closes #152

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0163QjtWKHyEQq3Dd7daTY3c
