### PR TITLE
chore(telemetry): bump adelie-telemetry to 5c762eca (bidi-control sanitiser fix)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ dependencies = [
  "adele-voice-module",
  "adele-voice-stt-whisper",
  "adele-voice-vad-silero",
- "adelie-telemetry",
+ "adelie-telemetry 0.1.0 (git+https://github.com/adelie-ai/adelie-telemetry?rev=5c762eca14e43295dd27c5d5adaa658924f5f133)",
  "anyhow",
  "async-trait",
  "clap",
@@ -155,7 +155,18 @@ dependencies = [
 [[package]]
 name = "adelie-telemetry"
 version = "0.1.0"
-source = "git+https://github.com/adelie-ai/adelie-telemetry?rev=36dcd571c1b2d35a6afc9376e1600766480c4fdc#36dcd571c1b2d35a6afc9376e1600766480c4fdc"
+source = "git+https://github.com/adelie-ai/adelie-telemetry?rev=1b8166ab483174e76aa23079858b8a31aaa52ae1#1b8166ab483174e76aa23079858b8a31aaa52ae1"
+dependencies = [
+ "opentelemetry-otlp",
+ "thiserror 2.0.19",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "adelie-telemetry"
+version = "0.1.0"
+source = "git+https://github.com/adelie-ai/adelie-telemetry?rev=5c762eca14e43295dd27c5d5adaa658924f5f133#5c762eca14e43295dd27c5d5adaa658924f5f133"
 dependencies = [
  "opentelemetry",
  "opentelemetry-appender-tracing",
@@ -3053,12 +3064,14 @@ dependencies = [
 name = "mcp-core"
 version = "0.1.0"
 dependencies = [
+ "adelie-telemetry 0.1.0 (git+https://github.com/adelie-ai/adelie-telemetry?rev=1b8166ab483174e76aa23079858b8a31aaa52ae1)",
  "async-trait",
  "clap",
  "serde",
  "serde_json",
  "thiserror 2.0.19",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -3997,7 +4010,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # the metrics facade + in-process registry, the shutdown guard, and the
 # trace-context helpers. Depends on no other Adelie crate. The `otel` feature
 # below is off by default and adds no opentelemetry crate to a default build.
-adelie-telemetry = { git = "https://github.com/adelie-ai/adelie-telemetry", rev = "36dcd571c1b2d35a6afc9376e1600766480c4fdc" }
+adelie-telemetry = { git = "https://github.com/adelie-ai/adelie-telemetry", rev = "5c762eca14e43295dd27c5d5adaa658924f5f133" }
 # Direct zbus client for the standalone voice daemon (`org.desktopAssistant.Voice`),
 # a separate D-Bus service from the orchestrator transport. Used by
 # `voice_client::VoiceController` to route narration through the daemon's warm


### PR DESCRIPTION
Bumps the `adelie-telemetry` git pin to `5c762eca14e43295dd27c5d5adaa658924f5f133` (main),
which carries the bidi-control sanitiser fix: the previous predicate stripped control
characters but not bidirectional format characters, so a metric label containing U+202E
rendered in a terminal with everything after it visually reversed.

Verified against a fresh-clone control per the mcp-core#40 procedure: the control clone's
`Cargo.lock` (fresh clone, `origin/main` lockfile, this branch's `Cargo.toml`, then
`cargo update -p adelie-telemetry`) is byte-identical (matching sha256) to this branch's
`Cargo.lock`.

`rustls-platform-verifier`: `0.6.2` -> `0.6.2`, unchanged.

**Anomaly found and confirmed pre-existing, not caused by this change:** the lockfile
delta versus `origin/main` is not confined to this crate's own entry. It also gains a
second, independent `adelie-telemetry` package entry at rev `1b8166ab483174e76aa23079858b8a31aaa52ae1`,
pulled in transitively through the `mcp-core` path dependency, which adopted
`adelie-telemetry` on its own `main` in `adelie-ai/mcp-core#45` (merged today, before this
repo's own telemetry-adoption PR #161). `mcp-core`'s dependency list gains `adelie-telemetry`
and `tracing`; and `prost-derive`'s `itertools` edge redirects from the existing `0.14.0`
lock entry to the existing `0.13.0` entry (both versions already coexisted in the lockfile
before and after this change; no `itertools` version was added or removed).

I confirmed this is unrelated to this rev bump: running `cargo update -p adelie-telemetry`
against an *unmodified* `Cargo.toml` (still pinned at the old `36dcd571` rev) in a throwaway
worktree produces the exact same collateral lockfile changes. `adele-tui`'s own checked-in
`Cargo.lock` on `main` was already stale relative to `mcp-core`'s current, already-merged
state; this is simply the first `cargo update` to touch `adelie-telemetry` since that
drift appeared. No `mcp-core` files were touched by this PR. The build is unaffected:
`just check-all` is green in both configurations with the two independent
`adelie-telemetry` copies present.

Gate green in both configurations (`just check-all`: `just check` + `just check-otel`,
including the pre-push hook's own `just check` run).

Refs adelie-ai/mcp-core#47